### PR TITLE
Change the default timeout in KIFTestStep. Not everybody has four cores; 

### DIFF
--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -232,7 +232,7 @@
         return nil;
     }
     
-    self.timeout = 10.0f;
+    self.timeout = 30.0f;
     
     return self;
 }


### PR DESCRIPTION
Change the default timeout in KIFTestStep. Not everybody has four cores; somebody please think of the CI systems!
