### PR TITLE
Removes the need to use -all_load in projects using KIF

### DIFF
--- a/Additions/LoadableCategory.h
+++ b/Additions/LoadableCategory.h
@@ -1,0 +1,34 @@
+//
+//  LoadableCategory.h
+//  Objective-Gems
+//
+// Copyright 2011 Karl Stenerud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Note: You are NOT required to make the license available from within your
+// iOS application. Including it in your project is sufficient.
+//
+// Attribution is not required, but appreciated :)
+//
+
+
+/** Make all categories in the current file loadable without using -load-all.
+ *
+ * Normally, compilers will skip linking files that contain only categories.
+ * Adding a call to this macro adds a dummy class, which causes the linker
+ * to add the file.
+ *
+ * @param UNIQUE_NAME A globally unique name.
+ */
+#define MAKE_CATEGORIES_LOADABLE(UNIQUE_NAME) @interface FORCELOAD_##UNIQUE_NAME @end @implementation FORCELOAD_##UNIQUE_NAME @end

--- a/Additions/NSFileManager-KIFAdditions.m
+++ b/Additions/NSFileManager-KIFAdditions.m
@@ -7,6 +7,10 @@
 //
 
 #import "NSFileManager-KIFAdditions.h"
+#import "LoadableCategory.h"
+
+
+MAKE_CATEGORIES_LOADABLE(NSFileManager_KIFAdditions)
 
 
 @implementation NSFileManager (CCAdditions)

--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -7,6 +7,10 @@
 //
 
 #import "UIAccessibilityElement-KIFAdditions.h"
+#import "LoadableCategory.h"
+
+
+MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 
 
 @implementation UIAccessibilityElement (KIFAdditions)

--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -7,7 +7,11 @@
 //
 
 #import "UIApplication-KIFAdditions.h"
+#import "LoadableCategory.h"
 #import "UIView-KIFAdditions.h"
+
+
+MAKE_CATEGORIES_LOADABLE(UIApplication_KIFAdditions)
 
 
 @implementation UIApplication (KIFAdditions)

--- a/Additions/UIScrollView-KIFAdditions.m
+++ b/Additions/UIScrollView-KIFAdditions.m
@@ -7,8 +7,12 @@
 //
 
 #import "UIScrollView-KIFAdditions.h"
+#import "LoadableCategory.h"
 #import "UIApplication-KIFAdditions.h"
 #import "UIView-KIFAdditions.h"
+
+
+MAKE_CATEGORIES_LOADABLE(UIScrollView_KIFAdditions)
 
 
 @implementation UIScrollView (KIFAdditions)

--- a/Additions/UITouch-KIFAdditions.m
+++ b/Additions/UITouch-KIFAdditions.m
@@ -7,6 +7,10 @@
 //
 
 #import "UITouch-KIFAdditions.h"
+#import "LoadableCategory.h"
+
+
+MAKE_CATEGORIES_LOADABLE(UITouch_KIFAdditions)
 
 
 @implementation UITouch (KIFAdditions)

--- a/Documentation/Examples/Testable/Testable.xcodeproj/project.pbxproj
+++ b/Documentation/Examples/Testable/Testable.xcodeproj/project.pbxproj
@@ -370,7 +370,6 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
-					"-all_load",
 				);
 				PRODUCT_NAME = "Testable (Integration Tests)";
 				WRAPPER_EXTENSION = app;
@@ -400,7 +399,6 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
-					"-all_load",
 				);
 				PRODUCT_NAME = "Testable (Integration Tests)";
 				VALIDATE_PRODUCT = YES;

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		39160B1113D1E6BB00311E38 /* LoadableCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 39160B1013D1E6BB00311E38 /* LoadableCategory.h */; };
 		AAB0726C139719AC008AF393 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB0726B139719AC008AF393 /* Foundation.framework */; };
 		AAB0728213971A63008AF393 /* KIF-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = AAB0728113971A63008AF393 /* KIF-Prefix.pch */; };
 		AAB0728D13971A98008AF393 /* KIFTestController.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB0728613971A98008AF393 /* KIFTestController.h */; };
@@ -35,6 +36,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		39160B1013D1E6BB00311E38 /* LoadableCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadableCategory.h; sourceTree = "<group>"; };
 		AAB07268139719AC008AF393 /* libKIF.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libKIF.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAB0726B139719AC008AF393 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		AAB0728113971A63008AF393 /* KIF-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "KIF-Prefix.pch"; path = "Classes/KIF-Prefix.pch"; sourceTree = SOURCE_ROOT; };
@@ -131,6 +133,7 @@
 		AAB0729313971AB2008AF393 /* Additions */ = {
 			isa = PBXGroup;
 			children = (
+				39160B1013D1E6BB00311E38 /* LoadableCategory.h */,
 				AAB0729413971AB2008AF393 /* CGGeometry-KIFAdditions.h */,
 				AAB0729513971AB2008AF393 /* CGGeometry-KIFAdditions.m */,
 				CDFD8E84139728B4008D299F /* NSFileManager-KIFAdditions.h */,
@@ -170,6 +173,7 @@
 				AAB072B013971AB2008AF393 /* UIView-KIFAdditions.h in Headers */,
 				AAB072B213971AB2008AF393 /* UIWindow-KIFAdditions.h in Headers */,
 				CDFD8E86139728B4008D299F /* NSFileManager-KIFAdditions.h in Headers */,
+				39160B1113D1E6BB00311E38 /* LoadableCategory.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
By adding a dummy class in a module containing only categories, you can force the linker to include those categories during the linker phase. This removes the need to add -all_load to OTHER_LINKER_FLAGS in your end project.
