### PR TITLE
Add step to tap at a given screen point

### DIFF
--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -241,6 +241,16 @@ typedef KIFTestStepResult (^KIFTestStepExecutionBlock)(KIFTestStep *step, NSErro
 + (id)stepToTapViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits;
 
 /*!
+ @method stepToTapScreenAtPoint:
+ @abstract A step that taps the screen at a particular point.
+ @discussion Taps the screen at a specific point. In general you should use the factory steps that tap a view based on its accessibility label, but there are situations where it's not possible to access a view using accessibility mechanisms. This step is more lenient than the steps that use the accessibility label, and does not wait for any particular view to appear, or validate that the tapped view is enabled or has interaction enabled. Because this step doesn't doesn't validate that a view is present before tapping it, it's good practice to precede this step where possible with a -stepToWaitForViewWithAccessibilityLabel: with the label for another view that should appear on the same screen.
+ 
+ @param screenPoint The point in screen coordinates to tap. Screen points originate from the top left of the screen.
+ @result A configured test step.
+ */
++ (id)stepToTapScreenAtPoint:(CGPoint)screenPoint;
+
+/*!
  @method stepToEnterText:intoViewWithAccessibilityLabel:
  @abstract A step that enters text into a particular view in the view hierarchy.
  @discussion The view or accessibility element with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, a tap event is simulated in the center of the view or element, then text is entered into the view by simulating taps on the appropriate keyboard keys.

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -183,6 +183,34 @@
     }];
 }
 
++ (id)stepToTapScreenAtPoint:(CGPoint)screenPoint;
+{
+    NSString *description = [NSString stringWithFormat:@"Tap screen at point \"%@\"", NSStringFromCGPoint(screenPoint)];
+    
+    return [self stepWithDescription:description executionBlock:^(KIFTestStep *step, NSError **error) {
+        
+        // Try all the windows until we get one back that actually has something in it at the given point
+        UIView *view = nil;
+        for (UIWindow *window in [[[UIApplication sharedApplication] windows] reverseObjectEnumerator]) {
+            CGPoint windowPoint = [window convertPoint:screenPoint fromView:nil];
+            view = [window hitTest:windowPoint withEvent:nil];
+            
+            // If we hit the window itself, then skip it.
+            if (view == window || view == nil) {
+                continue;
+            }
+        }
+        
+        KIFTestWaitCondition(view, error, @"No view was found at the point %@", NSStringFromCGPoint(screenPoint));
+        
+        // This is mostly redundant of the test in _accessibilityElementWithLabel:
+        CGPoint viewPoint = [view convertPoint:screenPoint fromView:nil];
+        [view tapAtPoint:viewPoint];
+        
+        return KIFTestStepResultSuccess;
+    }];
+}
+
 + (id)stepToEnterText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label;
 {
     return [self stepToEnterText:text intoViewWithAccessibilityLabel:label traits:UIAccessibilityTraitNone expectedResult:nil];


### PR DESCRIPTION
In certain situations the accessibility labels don't cut it for being able to find and tap a view, so this adds a "tap at a certain screen point" step to handle more interesting cases. We hit a situation with the built in media picker where Apple's code isn't quite accessible, so this becomes necessary.
