### PR TITLE
Fix return button

### DIFF
--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -485,7 +485,7 @@
 }
 
 + (NSString *)_representedKeyboardStringForCharacter:(NSString *)characterString;
-{    
+{
     // Interpret control characters appropriately
     if ([characterString isEqual:@"\b"]) {
         characterString = @"Delete";


### PR DESCRIPTION
In my usage, the return button has not worked to complete input on a single-line field, I've found that instead of looking for "Return" on the keyboard, it is actually looking for the newline characters "\n" or "\r", so the conversion to "Return" actually breaks intended functionality.

This patch makes all UIReturnKeyTypes work on my machine, and makes sure that both expected and actual strings are stripped of newline characters when it checks the final string.

This should work for both single line fields as well as multiline views.

I'm assuming that the conversion of all newline characters to "Return" must have worked for a significant number of users, so I'm curious to know what makes my system different, and I welcome any input regarding this.
