### PR TITLE
Remove incorrect button tap

### DIFF
--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -454,7 +454,6 @@
     
     // Dismiss the resize UI
     [steps addObject:[KIFTestStep stepToTapViewWithAccessibilityLabel:@"Choose"]];
-    [steps addObject:[KIFTestStep stepToTapViewWithAccessibilityLabel:@"Done"]];
     
     return steps;
 }


### PR DESCRIPTION
There was an extra tap for a button named "Done" in the photo chooser steps. This was actually part of the app code and not specific to the chooser.
