### PR TITLE
Remove tapping Done from the picker view step

### DIFF
--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -353,13 +353,6 @@
                     // Tap in the middle of the picker view to select the item
                     [pickerView tap];
                     
-                    // Tap the done button
-                    UIButton *doneButton = (UIButton *)[[[UIApplication sharedApplication] pickerViewWindow] accessibilityElementWithLabel:@"Done"];
-                    KIFTestCondition(doneButton, error, @"Failed to find the \"Done\" button after selecting the picker value \"%@\"", title);
-                    
-                    [doneButton tap];
-                    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.5, false);                    
-                    
                     return KIFTestStepResultSuccess;
                 }
             }


### PR DESCRIPTION
The picker view step attempted to hit the Done button when it was finished selecting the picker view item, but not all picker views have a Done button. This should be added explicitly as another step after selecting the picker item.
