### PR TITLE
Better handle an edge case transition

### DIFF
--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -233,7 +233,7 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
         CGPoint tappablePointInElement = [view tappablePointInRect:elementFrame];
         
         // This is mostly redundant of the test in _accessibilityElementWithLabel:
-        KIFTestCondition(!isnan(tappablePointInElement.x), error, @"The element with accessibility label %@ is not tappable", label);
+        KIFTestWaitCondition(!isnan(tappablePointInElement.x), error, @"The element with accessibility label %@ is not tappable", label);
         [view tapAtPoint:tappablePointInElement];
 
         // Verify that we successfully selected the view


### PR DESCRIPTION
There is a rare race condition where we can try to tap while a view is in transition due to an animation. In this case we can't get a tappable point and fail. This fix makes it so that we simply wait until the view is in a stable state instead.
