### PR TITLE
Explicitly call pickerView:didSelectRow:inComponent: in stepToSelectPickViewRowWithTitle:

### DIFF
--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -366,6 +366,12 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
                     // Tap in the middle of the picker view to select the item
                     [pickerView tap];
                     
+                    // The combination of selectRow:inComponent:animated: and tap does not consistently result in
+                    // pickerView:didSelectRow:inComponent: being called on the delegate. We need to do it explicitly.
+                    if ([pickerView.delegate respondsToSelector:@selector(pickerView:didSelectRow:inComponent:)]) {
+                        [pickerView.delegate pickerView:pickerView didSelectRow:rowIndex inComponent:componentIndex];
+                    }
+                    
                     return KIFTestStepResultSuccess;
                 }
             }


### PR DESCRIPTION
@firestone

The combination of selectRow:inComponent:animated: and tap does not consistently result in pickerView:didSelectRow:inComponent: being called on the delegate. This pull request modifies stepToSelectPickViewRowWithTitle: to call it explicitly.
