### PR TITLE
Better compatibility with UIActionSheets

### DIFF
--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -29,8 +29,8 @@ MAKE_CATEGORIES_LOADABLE(UIApplication_KIFAdditions)
 
 - (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label accessibilityValue:(NSString *)value traits:(UIAccessibilityTraits)traits;
 {
-    // go through the array of windows in reverse orde to process the frontmost window first.
-    // when several elements with the same accessibilitylabel are present the one in front will be picked
+    // Go through the array of windows in reverse order to process the frontmost window first.
+    // When several elements with the same accessibilitylabel are present the one in front will be picked.
     for (UIWindow *window in [[self windows] reverseObjectEnumerator]) {
         UIAccessibilityElement *element = [window accessibilityElementWithLabel:label accessibilityValue:value traits:traits];
         if (element) {

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -620,8 +620,9 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
             isUserInteractionEnabled = YES;
         }
     }
+    
     // UIActionsheet Buttons have UIButtonLabels with userInteractionEnabled=NO inside,
-    // grab the superview UINavigationButton instead
+    // grab the superview UINavigationButton instead.
     if (!isUserInteractionEnabled && [view isKindOfClass:NSClassFromString(@"UIButtonLabel")]) {
         UIView *button = [view superview];
         while (button && ![button isKindOfClass:NSClassFromString(@"UINavigationButton")]) {


### PR DESCRIPTION
When implementing KIF Integration Tests into our app I had some problems with UIActionsheets:
- the actionsheet buttons contain a subclass of UILabel that has userInteractionEnabled=NO. To avoid this I added a special handling of this subclass in _isUserInteractionEnabledForView (KIFTestStep.m)
- when several elements with the same accessibilityLabel are present, the one at the 'bottom' of the view is picked. I consider this wrong, the one at the top should be picked. I therefore reversed the enumeration of windows in accessibilityElementWithLabel:accessibilityValue:traits: (UIApplication-KIFAdditions.m)
