### PR TITLE
Traverse subviews from front to back rather than the reverse

### DIFF
--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -31,7 +31,7 @@ MAKE_CATEGORIES_LOADABLE(UIApplication_KIFAdditions)
 {
     // Go through the array of windows in reverse order to process the frontmost window first.
     // When several elements with the same accessibilitylabel are present the one in front will be picked.
-    for (UIWindow *window in [[self windows] reverseObjectEnumerator]) {
+    for (UIWindow *window in [self.windows reverseObjectEnumerator]) {
         UIAccessibilityElement *element = [window accessibilityElementWithLabel:label accessibilityValue:value traits:traits];
         if (element) {
             return element;
@@ -43,7 +43,7 @@ MAKE_CATEGORIES_LOADABLE(UIApplication_KIFAdditions)
 
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock;
 {
-    for (UIWindow *window in [self windows]) {
+    for (UIWindow *window in [self.windows reverseObjectEnumerator]) {
         UIAccessibilityElement *element = [window accessibilityElementMatchingBlock:matchBlock];
         if (element) {
             return element;
@@ -55,7 +55,7 @@ MAKE_CATEGORIES_LOADABLE(UIApplication_KIFAdditions)
 
 - (UIWindow *)keyboardWindow;
 {
-    for (UIWindow *window in [self windows]) {
+    for (UIWindow *window in self.windows) {
         if ([NSStringFromClass([window class]) isEqual:@"UITextEffectsWindow"]) {
             return window;
         }

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -111,7 +111,7 @@
     // the returned objects are UIAccessibilityElementMockViews (which aren't actually views)
     // rather than the real subviews it contains. We want the real views if possible.
     // UITableViewCell is such an offender.
-    for (UIView *view in self.subviews) {
+    for (UIView *view in [self.subviews reverseObjectEnumerator]) {
         UIAccessibilityElement *element = [view accessibilityElementMatchingBlock:matchBlock];
         if (!element) {
             continue;


### PR DESCRIPTION
Inspired by https://github.com/square/KIF/pull/67. We should be traversing views from front to back as well.
