### PR TITLE
allow steps to be controlled by an asynchronous process

### DIFF
--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -57,7 +57,7 @@ if (!(condition)) { \
 if (!(condition)) { \
 if (error) { \
 *error = [[[NSError alloc] initWithDomain:@"KIFTest" code:KIFTestStepResultWait userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:__VA_ARGS__], NSLocalizedDescriptionKey, nil]] autorelease]; \
-[step waitWithError:*error]; \
+[step asyncWaitWithError:*error]; \
 } \
 return KIFTestStepResultWait; \
 } \
@@ -159,27 +159,27 @@ typedef KIFTestStepResult (^KIFTestStepExecutionBlock)(KIFTestStep *step, NSErro
 - (void)cleanUp;
 
 /*!
- @method succeed:
+ @method asyncSucceed:
  @abstract Override a currently waiting step to return a successful result on next execution attempt.
  @discussion This method allows asynchronous processes started by a step to signal success.
  */
-- (void)succeed;
+- (void)asyncSucceed;
 
 /*!
- @method failWithError:
+ @method asyncFailWithError:
  @abstract Override a currently waiting step to return a failing result on next execution attempt.
  @discussion This method allows asynchronous processes started by a step to signal failure.
  @param error The error corresponding to the failure.
  */
-- (void)failWithError:(NSError *)error;
+- (void)asyncFailWithError:(NSError *)error;
 
 /*!
- @method waitWithError:
+ @method asyncWaitWithError:
  @abstract Override a currently waiting step to wait until another async signal is sent.
  @discussion This method allows an asynchronous processes to make a step wait until it can finish.
  @param error The error identifying the reason for waiting.
  */
-- (void)waitWithError:(NSError *)error;
+- (void)asyncWaitWithError:(NSError *)error;
 
 #pragma mark Factory Steps
 

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -17,10 +17,10 @@
 #import "UIWindow-KIFAdditions.h"
 
 enum {
-	KIFTestStepAsyncSignalFailure = KIFTestStepResultFailure,
-	KIFTestStepAsyncSignalSuccess,
-	KIFtestStepAsyncSignalWait,
-	KIFTestStepAsyncSignalNone,
+    KIFTestStepAsyncSignalFailure = KIFTestStepResultFailure,
+    KIFTestStepAsyncSignalSuccess,
+    KIFtestStepAsyncSignalWait,
+    KIFTestStepAsyncSignalNone,
 };
 typedef NSInteger KIFTestStepAsyncSignal;
 
@@ -579,7 +579,7 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
     }
 
     self.timeout = [[self class] defaultTimeout];
-	self.asyncSignal = KIFTestStepAsyncSignalNone;
+    self.asyncSignal = KIFTestStepAsyncSignalNone;
 
     return self;
 }
@@ -594,8 +594,8 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
     notificationName = nil;
     [notificationObject release];
     notificationObject = nil;
-	[asyncError release];
-	asyncError = nil;
+    [asyncError release];
+    asyncError = nil;
 
     [super dealloc];
 }
@@ -607,20 +607,20 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
     KIFTestStepResult result = KIFTestStepResultFailure;
     
     if (self.executionBlock) {
-		if (self.asyncSignal == KIFTestStepAsyncSignalNone) {
-			@try {
-				result = self.executionBlock(self, error);
-			}
-			@catch (id exception) {
-				// We need to catch exceptions and things like NSInternalInconsistencyException, which is actually an NSString
-				KIFTestCondition(NO, error, @"Step threw exception: %@", exception);
-			}
-		} else {
-			result = self.asyncSignal;
-			if (self.asyncError) {
-				*error = [[self.asyncError copy] autorelease];
-			}
-		}
+        if (self.asyncSignal == KIFTestStepAsyncSignalNone) {
+            @try {
+                result = self.executionBlock(self, error);
+            }
+            @catch (id exception) {
+                // We need to catch exceptions and things like NSInternalInconsistencyException, which is actually an NSString
+                KIFTestCondition(NO, error, @"Step threw exception: %@", exception);
+            }
+        } else {
+            result = self.asyncSignal;
+            if (self.asyncError) {
+                *error = [[self.asyncError copy] autorelease];
+            }
+        }
     }
 
     return result;
@@ -633,21 +633,21 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
     }
 }
 
-- (void)succeed;
+- (void)asyncSucceed;
 {
-	self.asyncSignal = KIFTestStepAsyncSignalSuccess;
+    self.asyncSignal = KIFTestStepAsyncSignalSuccess;
 }
 
-- (void)failWithError:(NSError *)error
+- (void)asyncFailWithError:(NSError *)error
 {
-	self.asyncSignal = KIFTestStepAsyncSignalFailure;
-	self.asyncError = error;
+    self.asyncSignal = KIFTestStepAsyncSignalFailure;
+    self.asyncError = error;
 }
 
-- (void)waitWithError:(NSError *)error
+- (void)asyncWaitWithError:(NSError *)error
 {
-	self.asyncSignal = KIFtestStepAsyncSignalWait;
-	self.asyncError = error;
+    self.asyncSignal = KIFtestStepAsyncSignalWait;
+    self.asyncError = error;
 }
 
 #pragma mark Private Methods


### PR DESCRIPTION
This was in a previous pull request, but I mangled the branches and github lost track of it.

It is unclear what use it would have for UI interactions, but this was incredibly useful for reset steps that do asynchronous stuff with blocks, i.e. things of the form

```
if (foo) {
    [bar doSomethingWithFinishBlock:^{
        if (bar.isCorrect) {
            [step succeed];
        } else {
            [step failWithError:*error];
        }
    }
}
KIFTestAsyncWaitCondition(foo, error, "Waiting for async process to finish");
```
