### PR TITLE
Deprecate -[UIView subviewWithClassNamePrefix:]

### DIFF
--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -67,8 +67,8 @@ MAKE_CATEGORIES_LOADABLE(UIApplication_KIFAdditions)
 - (UIWindow *)pickerViewWindow;
 {
     for (UIWindow *window in [self windows]) {
-        UIView *pickerView = [window subviewWithClassNameOrSuperClassNamePrefix:@"UIPickerView"];
-        if (pickerView) {
+        NSArray *pickerViews = [window subviewsWithClassNameOrSuperClassNamePrefix:@"UIPickerView"];
+        if (pickerViews.count > 0) {
             return window;
         }
     }

--- a/Additions/UIView-KIFAdditions.h
+++ b/Additions/UIView-KIFAdditions.h
@@ -27,9 +27,9 @@
  */
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock;
 
-- (UIView *)subviewWithClassNamePrefix:(NSString *)prefix;
+- (UIView *)subviewWithClassNamePrefix:(NSString *)prefix __deprecated;
 - (NSArray *)subviewsWithClassNamePrefix:(NSString *)prefix;
-- (UIView *)subviewWithClassNameOrSuperClassNamePrefix:(NSString *)prefix;
+- (UIView *)subviewWithClassNameOrSuperClassNamePrefix:(NSString *)prefix __deprecated;
 - (NSArray *)subviewsWithClassNameOrSuperClassNamePrefix:(NSString *)prefix;
 
 - (void)flash;

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -383,7 +383,7 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
     return [self stepWithDescription:description executionBlock:^(KIFTestStep *step, NSError **error) {
         
         // Find the picker view
-        UIPickerView *pickerView = (UIPickerView *)[[[UIApplication sharedApplication] pickerViewWindow] subviewWithClassNameOrSuperClassNamePrefix:@"UIPickerView"];
+        UIPickerView *pickerView = [[[[UIApplication sharedApplication] pickerViewWindow] subviewsWithClassNameOrSuperClassNamePrefix:@"UIPickerView"] lastObject];
         KIFTestCondition(pickerView, error, @"No picker view is present");
         
         NSInteger componentCount = [pickerView.dataSource numberOfComponentsInPickerView:pickerView];
@@ -398,7 +398,8 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
                 } else if ([pickerView.delegate respondsToSelector:@selector(pickerView:viewForRow:forComponent:reusingView:)]) {
                     // This delegate inserts views directly, so try to figure out what the title is by looking for a label
                     UIView *rowView = [pickerView.delegate pickerView:pickerView viewForRow:rowIndex forComponent:componentIndex reusingView:nil];
-                    UILabel *label = (UILabel *)[rowView subviewWithClassNameOrSuperClassNamePrefix:@"UILabel"];
+                    NSArray *labels = [rowView subviewsWithClassNameOrSuperClassNamePrefix:@"UILabel"];
+                    UILabel *label = (labels.count > 0 ? [labels objectAtIndex:0] : nil);
                     rowTitle = label.text;
                 }
                 
@@ -474,7 +475,8 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
         const NSTimeInterval tapDelay = 0.05;
         NSArray *windows = [[UIApplication sharedApplication] windows];
         KIFTestCondition(windows.count, error, @"Failed to find any windows in the application");
-        [[[windows objectAtIndex:0] subviewWithClassNamePrefix:@"UIDimmingView"] tapAtPoint:CGPointMake(50.0f, 50.0f)];
+        UIView *dimmingView = [[[windows objectAtIndex:0] subviewsWithClassNamePrefix:@"UIDimmingView"] lastObject];
+        [dimmingView tapAtPoint:CGPointMake(50.0f, 50.0f)];
         CFRunLoopRunInMode(kCFRunLoopDefaultMode, tapDelay, false);
         return KIFTestStepResultSuccess;
     }];
@@ -680,7 +682,7 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
     }
     
     UIWindow *keyboardWindow = [[UIApplication sharedApplication] keyboardWindow];
-    UIView *keyboardView = [keyboardWindow subviewWithClassNamePrefix:@"UIKBKeyplaneView"];
+    UIView *keyboardView = [[keyboardWindow subviewsWithClassNamePrefix:@"UIKBKeyplaneView"] lastObject];
     
     // If we didn't find the standard keyboard view, then we may have a custom keyboard
     if (!keyboardView) {


### PR DESCRIPTION
Deprecating these methods since they don't really make sense given that the view hierarchy may contain multiple instances of a view type. Use the plural version that returns all instances instead.
