### PR TITLE
Automatically enable accessibility on the device also

### DIFF
--- a/Classes/KIFTestController.m
+++ b/Classes/KIFTestController.m
@@ -30,7 +30,7 @@ extern id objc_msgSend(id theReceiver, SEL theSelector, ...);
 @property (nonatomic, retain) NSDate *currentStepStartDate;
 @property (nonatomic, copy) KIFTestControllerCompletionBlock completionBlock;
 
-+ (void)_enableAccessibilityInSimulator;
++ (void)_enableAccessibility;
 
 - (void)_initializeScenariosIfNeeded;
 - (BOOL)_isAccessibilityInspectorEnabled;
@@ -68,10 +68,10 @@ extern id objc_msgSend(id theReceiver, SEL theSelector, ...);
 
 + (void)load
 {
-    [KIFTestController _enableAccessibilityInSimulator];
+    [KIFTestController _enableAccessibility];
 }
 
-+ (void)_enableAccessibilityInSimulator;
++ (void)_enableAccessibility;
 {
     NSAutoreleasePool *autoreleasePool = [[NSAutoreleasePool alloc] init];
     NSString *appSupportLocation = @"/System/Library/PrivateFrameworks/AppSupport.framework/AppSupport";


### PR DESCRIPTION
My previous pull request for enabling accessibility on the device. After some comments on my [blog post about it](http://sgleadow.github.com/blog/2011/10/14/enabling-accessibility-for-ios-applications/), I modified the code to also run on the device. I wrote up my findings on [another blog post](http://sgleadow.github.com/blog/2011/11/16/enabling-accessibility-programatically-on-ios-devices/)

Without this code, when I run KIF on a device _without VoiceOver on_, the accessibility values are not available to KIF and the test fails. With this code, the values become available automatically and the tests can run on the device.
