### PR TITLE
Missing fix in macro to work with ARC

### DIFF
--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -39,7 +39,7 @@ if (!(condition)) { \
 #define KIFTestWaitCondition(condition, error, ...) ({ \
 if (!(condition)) { \
     if (error) { \
-    *error = [[[NSError alloc] initWithDomain:@"KIFTest" code:KIFTestStepResultWait userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:__VA_ARGS__], NSLocalizedDescriptionKey, nil]] autorelease]; \
+    *error = [[NSError alloc] initWithDomain:@"KIFTest" code:KIFTestStepResultWait userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:__VA_ARGS__], NSLocalizedDescriptionKey, nil]]; \
     } \
     return KIFTestStepResultWait; \
 } \


### PR DESCRIPTION
efirestone forgot the second macro with "autorelease" in it. I just removed the autorelease in that line - that's all.
