### PR TITLE
Add Step for Observing Notifications Emited During Child Step Execution

### DIFF
--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -275,6 +275,17 @@ typedef KIFTestStepResult (^KIFTestStepExecutionBlock)(KIFTestStep *step, NSErro
 + (id)stepToWaitForNotificationName:(NSString*)name object:(id)object;
 
 /*!
+ @method stepToWaitForNotificationName:object:whileExecutingStep:
+ @abstract A step that waits for an NSNotification emitted during execution of a child step
+ @discussion Useful when step execution causes a notification to be emitted, but executes too quickly for stepToWaitForNotificationName: to observe it.
+    An observer will be registered for the notification before the observedStep is executed.
+ @param name The name of the NSNotification
+ @param object The object to which the step should listen. Nil value will listen to all objects.
+ @result A configured test step.
+ */
++ (id)stepToWaitForNotificationName:(NSString *)name object:(id)object whileExecutingStep:(KIFTestStep *)childStep;
+
+/*!
  @method stepToTapViewWithAccessibilityLabel:
  @abstract A step that taps a particular view in the view hierarchy.
  @discussion The view or accessibility element with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, a tap event is simulated in the center of the view or element.

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -26,6 +26,7 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
 @property (nonatomic, retain) id notificationObject;
 @property BOOL notificationOccurred;
 @property BOOL observingForNotification;
+@property (nonatomic, retain) KIFTestStep *childStep;
 
 + (BOOL)_isUserInteractionEnabledForView:(UIView *)view;
 
@@ -47,6 +48,7 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
 @synthesize notificationOccurred;
 @synthesize observingForNotification;
 @synthesize timeout;
+@synthesize childStep;
 
 #pragma mark Class Methods
 
@@ -224,9 +226,33 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
             [[NSNotificationCenter defaultCenter] addObserver:step selector:@selector(_onObservedNotification:) name:name object:object];
         }
         
-        KIFTestWaitCondition(step.notificationOccurred, error, @"Waiting for notification \"%@\"", name);        
+        KIFTestWaitCondition(step.notificationOccurred, error, @"Waiting for notification \"%@\"", name);
         return KIFTestStepResultSuccess;
     }];   
+    return step;
+}
+
++ (id)stepToWaitForNotificationName:(NSString *)name object:(id)object whileExecutingStep:(KIFTestStep *)childStep;
+{
+    NSString *description = [NSString stringWithFormat:@"Wait for notification \"%@\" while executing child step \"%@\"", name, childStep];
+    
+    KIFTestStep *step = [self stepWithDescription:description executionBlock:^(KIFTestStep *step, NSError **error) {  
+        if (!step.observingForNotification) {            
+            step.notificationName = name;
+            step.notificationObject = object; 
+            step.observingForNotification = YES;
+            [[NSNotificationCenter defaultCenter] addObserver:step selector:@selector(_onObservedNotification:) name:name object:object];
+        }
+        
+        // Execute the step we are observing for changes
+        KIFTestStepResult result = [step.childStep executeAndReturnError:error];
+        KIFTestWaitCondition(result != KIFTestStepResultWait, error, @"Waiting for completion of child step \"%@\"", step.childStep);
+        
+        // Wait for the actual notification
+        KIFTestWaitCondition(step.notificationOccurred, error, @"Waiting for notification \"%@\"", name);
+        return KIFTestStepResultSuccess;
+    }];    
+    step.childStep = childStep;    
     return step;
 }
 
@@ -588,6 +614,8 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
     notificationName = nil;
     [notificationObject release];
     notificationObject = nil;
+    [childStep release];
+    childStep = nil;
     
     [super dealloc];
 }


### PR DESCRIPTION
When building KIF integration tests for the GateGuru application, I have been making extensive use of notifications to observe for state changes as the result of some UI interactions rather than accessibility labeled elements. We use Three20's URL dispatching within the app, which allows us to directly open view controllers from our KIF steps and then execute interaction steps. This lets us quickly build focused tests for particular screens (especially modal view controllers) that drop out after a button has been pressed (i.e. save, login, logout, etc). Since we don't necessarily know what is going to be behind the controller when it is dismissed, I have been using `stepToWaitForNotificationName:object:` to watch for notifications posted from the data model to determine success.

The issue I have been running into is the observer step will sometimes fail because the observer is not registered until the step executes and the previous step in the scenario is taking the action that results in the notification being posted.

To remedy this, I have implemented `stepToWaitForNotificationName:object:whileExecutingStep:`. This step registers an observer, then executes the child step to completion, and then waits for the notification. This has made the brittle tests totally reliable.
