### PR TITLE
new junit logger and stepToClearField added

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -322,7 +322,6 @@
         return;
     }
     UITouch *touchDown = [[UITouch alloc] initAtPoint:points[0] inView:self];
-    [NSThread sleepForTimeInterval:0.1];
     [touchDown setPhase:UITouchPhaseBegan];
     
     UIEvent *eventDown = [self _eventWithTouch:touchDown];
@@ -330,7 +329,6 @@
     
     for (NSInteger pointIndex = 1; pointIndex < count - 1; pointIndex++) {
         UITouch *touchDrag = [[UITouch alloc] initAtPoint:points[pointIndex] inView:self];
-        [NSThread sleepForTimeInterval:0.1];
         [touchDrag setPhase:UITouchPhaseMoved];
         
         UIEvent *eventDrag = [self _eventWithTouch:touchDrag];
@@ -340,7 +338,6 @@
     }
     
     UITouch *touchUp = [[UITouch alloc] initAtPoint:points[count - 1] inView:self];
-    [NSThread sleepForTimeInterval:0.1];
     [touchUp setPhase:UITouchPhaseMoved];
     
     UIEvent *eventDrag2 = [self _eventWithTouch:touchUp];

--- a/Classes/KIFJunitTestLogger.h
+++ b/Classes/KIFJunitTestLogger.h
@@ -1,0 +1,13 @@
+//
+//  KIFJunitTestLogger.h
+//  KIF
+//
+//  Created by Rodney Gomes on 1/12/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import "KIFTestLogger.h"
+
+@interface KIFJunitTestLogger : KIFTestLogger
+
+@end

--- a/Classes/KIFJunitTestLogger.h
+++ b/Classes/KIFJunitTestLogger.h
@@ -7,7 +7,28 @@
 //
 
 #import "KIFTestLogger.h"
+#import "NSFileManager-KIFAdditions.h"
 
-@interface KIFJunitTestLogger : KIFTestLogger
+@interface KIFJunitTestLogger : KIFTestLogger {
+    NSFileHandle* fileHandle;
+}
+
+@property (nonatomic, retain) NSFileHandle *fileHandle;
+
+- (void)logTestingDidStart;
+
+- (void)logTestingDidFinish;
+
+- (void)logDidStartScenario:(KIFTestScenario *)scenario;
+
+- (void)logDidSkipScenario:(KIFTestScenario *)scenario;
+
+- (void)logDidSkipAddingScenarioGenerator:(NSString *)selectorString;
+
+- (void)logDidFinishScenario:(KIFTestScenario *)scenario duration:(NSTimeInterval)duration;
+
+- (void)logDidFailStep:(KIFTestStep *)step duration:(NSTimeInterval)duration error:(NSError *)error;
+
+- (void)logDidPassStep:(KIFTestStep *)step duration:(NSTimeInterval)duration;
 
 @end

--- a/Classes/KIFJunitTestLogger.m
+++ b/Classes/KIFJunitTestLogger.m
@@ -10,4 +10,134 @@
 
 @implementation KIFJunitTestLogger
 
+@synthesize fileHandle;
+
+static NSMutableDictionary* durations = nil;
+static NSMutableDictionary* errors = nil;
+static KIFTestScenario* currentScenario = nil;
+
+- (void) initFileHandle;
+{
+    if ( !fileHandle ) {
+        NSString *logsDirectory = [[NSFileManager defaultManager] createUserDirectory:NSLibraryDirectory];
+        
+        if (logsDirectory) {
+            logsDirectory = [logsDirectory stringByAppendingPathComponent:@"Logs"];
+        }
+        if (![[NSFileManager defaultManager] recursivelyCreateDirectory:logsDirectory]) {
+            logsDirectory = nil;
+        }
+        
+        NSString *dateString = [NSDateFormatter localizedStringFromDate:[NSDate date] dateStyle:NSDateFormatterMediumStyle timeStyle:NSDateFormatterLongStyle];
+        dateString = [dateString stringByReplacingOccurrencesOfString:@"/" withString:@"."];
+        dateString = [dateString stringByReplacingOccurrencesOfString:@":" withString:@"."];
+        NSString *fileName = [NSString stringWithFormat:@"KIF Tests %@.junit.xml", dateString];
+        
+        NSString *logFilePath = [logsDirectory stringByAppendingPathComponent:fileName];
+        
+        if (![[NSFileManager defaultManager] fileExistsAtPath:logFilePath]) {
+            [[NSFileManager defaultManager] createFileAtPath:logFilePath contents:[NSData data] attributes:nil];
+        }
+        
+        fileHandle = [[NSFileHandle fileHandleForWritingAtPath:logFilePath] retain];
+        
+        if (fileHandle) {
+            NSLog(@"JUNIT XML RESULTS AT %@", logFilePath);
+        }
+    }
+    
+    return fileHandle;
+}
+
+- (void) appendToLog:(NSString*) data
+{
+    [self initFileHandle];
+    [self.fileHandle writeData:[data dataUsingEncoding:NSUTF8StringEncoding]];
+}
+
+- (void)dealloc {
+    [fileHandle closeFile];
+    [fileHandle release];
+    [errors release];
+    [durations release];
+    [super dealloc];
+}
+
+
+- (void) _init
+{
+    if ( durations == nil ) {
+        durations = [[NSMutableDictionary alloc] init];
+    }
+    
+    if ( errors == nil ) { 
+        errors = [[NSMutableDictionary alloc] init];
+    }
+}
+
+- (void)logTestingDidStart;
+{
+    [self _init]; 
+}
+
+- (void)logTestingDidFinish;
+{
+    NSTimeInterval totalDuration = -[self.controller.testSuiteStartDate timeIntervalSinceNow];
+    NSString* data = [NSString stringWithFormat: @"<testsuite name=\"%@\" tests=\"%d\" failures=\"%d\" time=\"%0.4f\">\n",
+                      @"KIF Tests", [self.controller.scenarios count], self.controller.failureCount, totalDuration];
+    
+    [self appendToLog:data];
+    
+    for(KIFTestScenario* scenario in self.controller.scenarios) { 
+        NSNumber* duration = [durations objectForKey: [scenario description]];
+        NSError* error = [errors objectForKey: [scenario description]];
+        
+        
+        NSString* scenarioSteps = [[scenario.steps valueForKeyPath:@"description"] componentsJoinedByString:@"\n"];
+        NSString* errorMsg =  (error ? [NSString stringWithFormat:@"<failure message=\"%@\">%@</failure>", 
+                                        [error localizedDescription], scenarioSteps] :
+                               @"");
+        
+        NSString* description = [scenario description];
+        NSString* classString = [scenario class];
+        
+        data = [NSString stringWithFormat:@"<testcase name=\"%@\" class=\"%@\" time=\"%0.4f\">%@</testcase>\n",
+                                          description, classString, [duration doubleValue], errorMsg];
+        [self appendToLog:data];
+    }
+        
+    [self appendToLog:@"</testsuite>\n"];
+}
+
+- (void)logDidStartScenario:(KIFTestScenario *)scenario;
+{
+    currentScenario = scenario;
+}
+
+- (void)logDidSkipScenario:(KIFTestScenario *)scenario;
+{
+
+}
+
+- (void)logDidSkipAddingScenarioGenerator:(NSString *)selectorString;
+{
+    
+}
+
+- (void)logDidFinishScenario:(KIFTestScenario *)scenario duration:(NSTimeInterval)duration;
+{
+    NSNumber* number = [[NSNumber alloc] initWithDouble: duration];
+    [durations setValue: number forKey: [scenario description]];
+}
+
+- (void)logDidFailStep:(KIFTestStep *)step duration:(NSTimeInterval)duration error:(NSError *)error;
+{
+    [errors setValue:error forKey:[currentScenario description]];
+}
+
+- (void)logDidPassStep:(KIFTestStep *)step duration:(NSTimeInterval)duration;
+{
+    
+}
+
 @end

--- a/Classes/KIFJunitTestLogger.m
+++ b/Classes/KIFJunitTestLogger.m
@@ -1,0 +1,13 @@
+//
+//  KIFJunitTestLogger.m
+//  KIF
+//
+//  Created by Rodney Gomes on 1/12/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import "KIFJunitTestLogger.h"
+
+@implementation KIFJunitTestLogger
+
+@end

--- a/Classes/KIFJunitTestLogger.m
+++ b/Classes/KIFJunitTestLogger.m
@@ -16,9 +16,9 @@ static NSMutableDictionary* durations = nil;
 static NSMutableDictionary* errors = nil;
 static KIFTestScenario* currentScenario = nil;
 
-- (void) initFileHandle;
+- (void)initFileHandle;
 {
-    if ( !fileHandle ) {
+    if (!fileHandle) {
         NSString *logsDirectory = [[NSFileManager defaultManager] createUserDirectory:NSLibraryDirectory];
         
         if (logsDirectory) {
@@ -49,13 +49,14 @@ static KIFTestScenario* currentScenario = nil;
     return fileHandle;
 }
 
-- (void) appendToLog:(NSString*) data
+- (void)appendToLog:(NSString*) data;
 {
     [self initFileHandle];
     [self.fileHandle writeData:[data dataUsingEncoding:NSUTF8StringEncoding]];
 }
 
-- (void)dealloc {
+- (void)dealloc;
+{
     [fileHandle closeFile];
     [fileHandle release];
     [errors release];
@@ -64,13 +65,13 @@ static KIFTestScenario* currentScenario = nil;
 }
 
 
-- (void) _init
+- (void)_init;
 {
-    if ( durations == nil ) {
+    if (durations == nil) {
         durations = [[NSMutableDictionary alloc] init];
     }
     
-    if ( errors == nil ) { 
+    if (errors == nil) { 
         errors = [[NSMutableDictionary alloc] init];
     }
 }
@@ -88,7 +89,7 @@ static KIFTestScenario* currentScenario = nil;
     
     [self appendToLog:data];
     
-    for(KIFTestScenario* scenario in self.controller.scenarios) { 
+    for (KIFTestScenario* scenario in self.controller.scenarios) { 
         NSNumber* duration = [durations objectForKey: [scenario description]];
         NSError* error = [errors objectForKey: [scenario description]];
         

--- a/Classes/KIFTestController.h
+++ b/Classes/KIFTestController.h
@@ -40,6 +40,7 @@ typedef void (^KIFTestControllerCompletionBlock)();
     
     KIFTestScenario *currentScenario;
     KIFTestStep *currentStep;
+    NSMutableArray *loggers;
     
     NSDate *testSuiteStartDate;
     NSDate *currentStepStartDate;
@@ -81,6 +82,9 @@ typedef void (^KIFTestControllerCompletionBlock)();
  @abstract The number of failed scenarios so far.
  */
 @property (nonatomic, readonly) NSInteger failureCount;
+
+@property (nonatomic, readonly) NSDate *testSuiteStartDate;
+
 
 /*!
  @method sharedInstance
@@ -129,5 +133,9 @@ typedef void (^KIFTestControllerCompletionBlock)();
  @param completionBlock An optional execution block that will be invoked when testing is complete.
  */
 - (void)startTestingWithCompletionBlock:(KIFTestControllerCompletionBlock)completionBlock;
+
+- (NSInteger) failureCount;
+
+- (void) registerLogger:(id) logger;
 
 @end

--- a/Classes/KIFTestController.h
+++ b/Classes/KIFTestController.h
@@ -11,6 +11,8 @@
 #import "KIFTestScenario.h"
 #import "KIFTestStep.h"
 
+@class KIFTestLogger;
+@protocol KIFTestLogger;
 
 typedef void (^KIFTestControllerCompletionBlock)();
 
@@ -134,8 +136,17 @@ typedef void (^KIFTestControllerCompletionBlock)();
  */
 - (void)startTestingWithCompletionBlock:(KIFTestControllerCompletionBlock)completionBlock;
 
-- (NSInteger) failureCount;
+/*!
+ @method failureCount:
+ @abstract returns the failure count as of right now.
+*/
+- (NSInteger)failureCount;
 
-- (void) registerLogger:(id) logger;
+/*!
+ @method registerLogger:logger:
+ @abstract Register another KIFTestLogger which will be used during test execution to report results.
+ @param logger A KIFTestLogger implementation.
+ */
+- (void)registerLogger:(KIFTestLogger*) logger;
 
 @end

--- a/Classes/KIFTestController.m
+++ b/Classes/KIFTestController.m
@@ -10,6 +10,8 @@
 #import "KIFTestController.h"
 #import "KIFTestScenario.h"
 #import "KIFTestStep.h"
+#import "KIFTestLogger.h"
+
 #import "NSFileManager-KIFAdditions.h"
 #import <QuartzCore/QuartzCore.h>
 #import <dlfcn.h>
@@ -137,7 +139,10 @@ static void releaseInstance()
         failedScenarioIndexes = [[NSMutableIndexSet alloc] init];
     }
     
-    return self;
+    loggers = [[NSMutableArray alloc] init];
+    [self registerLogger: [[KIFTestLogger alloc] init]];
+    
+    return self;    
 }
 
 - (void)dealloc;
@@ -155,6 +160,9 @@ static void releaseInstance()
 
     [failedScenarioIndexes release];
     failedScenarioIndexes = nil;
+    
+    [loggers release];
+    loggers = nil;
     
     [super dealloc];
 }
@@ -459,106 +467,73 @@ static void releaseInstance()
     [UIImagePNGRepresentation(image) writeToFile:outputPath atomically:YES];
 }
 
-#pragma mark Logging
-
-#define KIFLog(...) [[self _logFileHandleForWriting] writeData:[[NSString stringWithFormat:@"%@\n", [NSString stringWithFormat:__VA_ARGS__]] dataUsingEncoding:NSUTF8StringEncoding]]; NSLog(__VA_ARGS__);
-#define KIFLogBlankLine() KIFLog(@" ");
-#define KIFLogSeparator() KIFLog(@"---------------------------------------------------");
-
-- (NSFileHandle *)_logFileHandleForWriting;
+- (NSInteger) failureCount;
 {
-    static NSFileHandle *fileHandle = nil;
-    if (!fileHandle) {
-        NSString *logsDirectory = [[NSFileManager defaultManager] createUserDirectory:NSLibraryDirectory];
-        
-        if (logsDirectory) {
-            logsDirectory = [logsDirectory stringByAppendingPathComponent:@"Logs"];
-        }
-        if (![[NSFileManager defaultManager] recursivelyCreateDirectory:logsDirectory]) {
-            logsDirectory = nil;
-        }
-        
-        NSString *dateString = [NSDateFormatter localizedStringFromDate:[NSDate date] dateStyle:NSDateFormatterMediumStyle timeStyle:NSDateFormatterLongStyle];
-        dateString = [dateString stringByReplacingOccurrencesOfString:@"/" withString:@"."];
-        dateString = [dateString stringByReplacingOccurrencesOfString:@":" withString:@"."];
-        NSString *fileName = [NSString stringWithFormat:@"KIF Tests %@.log", dateString];
-        
-        NSString *logFilePath = [logsDirectory stringByAppendingPathComponent:fileName];
-        
-        if (![[NSFileManager defaultManager] fileExistsAtPath:logFilePath]) {
-            [[NSFileManager defaultManager] createFileAtPath:logFilePath contents:[NSData data] attributes:nil];
-        }
-        
-        fileHandle = [[NSFileHandle fileHandleForWritingAtPath:logFilePath] retain];
-        
-        if (fileHandle) {
-            NSLog(@"Logging KIF test activity to %@", logFilePath);
-        }
-    }
-    
-    return fileHandle;
+    return failureCount;
 }
+
+- (void) registerLogger:(id) logger
+{
+    [logger initWithController: self];
+    [loggers addObject:logger];
+}
+
+#pragma mark Logging
 
 - (void)_logTestingDidStart;
 {
-    if (failedScenarioIndexes.count != self.scenarios.count) {
-        KIFLog(@"BEGIN KIF TEST RUN: re-running %d of %d scenarios that failed last time", failedScenarioIndexes.count, self.scenarios.count);
-    } else {
-        KIFLog(@"BEGIN KIF TEST RUN: %d scenarios", self.scenarios.count);
+    for(KIFTestLogger* logger in loggers) { 
+        [logger logTestingDidStart];
     }
 }
 
 - (void)_logTestingDidFinish;
 {
-    KIFLogBlankLine();
-    KIFLogSeparator();
-    KIFLog(@"KIF TEST RUN FINISHED: %d failures (duration %.2fs)", failureCount, -[self.testSuiteStartDate timeIntervalSinceNow]);
-    KIFLogSeparator();
-    
-    // Also log the failure count to stdout, for easier integration with CI tools.
-    NSLog(@"*** KIF TESTING FINISHED: %d failures", failureCount);
+    for(KIFTestLogger* logger in loggers) { 
+        [logger logTestingDidFinish];
+    }
 }
 
 - (void)_logDidStartScenario:(KIFTestScenario *)scenario;
 {
-    KIFLogBlankLine();
-    KIFLogSeparator();
-    KIFLog(@"BEGIN SCENARIO %d/%d (%d steps)", [self.scenarios indexOfObjectIdenticalTo:scenario] + 1, self.scenarios.count, scenario.steps.count);
-    KIFLog(@"%@", scenario.description);
-    KIFLogSeparator();
+    for(KIFTestLogger* logger in loggers) { 
+        [logger logDidStartScenario:scenario];
+    }
 }
 
 - (void)_logDidSkipScenario:(KIFTestScenario *)scenario;
 {
-    KIFLogBlankLine();
-    KIFLogSeparator();
-    NSString *reason = (scenario.skippedByFilter ? @"filter doesn't match description" : @"only running previously-failed scenarios");
-    KIFLog(@"SKIPPING SCENARIO %d/%d (%@)", [self.scenarios indexOfObjectIdenticalTo:scenario] + 1, self.scenarios.count, reason);
-    KIFLog(@"%@", scenario.description);
-    KIFLogSeparator();
+    for(KIFTestLogger* logger in loggers) { 
+        [logger logDidSkipScenario:scenario];
+    }
 }
 
 - (void)_logDidSkipAddingScenarioGenerator:(NSString *)selectorString;
 {
-    KIFLog(@"Skipping scenario generator %@ because it takes arguments", selectorString);
+    for(KIFTestLogger* logger in loggers) { 
+        [logger logDidSkipAddingScenarioGenerator:selectorString];
+    }
 }
 
 - (void)_logDidFinishScenario:(KIFTestScenario *)scenario duration:(NSTimeInterval)duration
 {
-    KIFLogSeparator();
-    KIFLog(@"END OF SCENARIO (duration %.2fs)", duration);
-    KIFLogSeparator();
+    for(KIFTestLogger* logger in loggers) { 
+        [logger logDidFinishScenario:scenario duration:duration];
+    }
 }
 
 - (void)_logDidFailStep:(KIFTestStep *)step duration:(NSTimeInterval)duration error:(NSError *)error;
 {
-    KIFLog(@"FAIL (%.2fs): %@", duration, step);
-    KIFLog(@"FAILING ERROR: %@", error);
+    for(KIFTestLogger* logger in loggers) { 
+        [logger logDidFailStep:step duration:duration error:error];
+    }
 }
 
 - (void)_logDidPassStep:(KIFTestStep *)step duration:(NSTimeInterval)duration;
 {
-    KIFLog(@"PASS (%.2fs): %@", duration, step);
+    for(KIFTestLogger* logger in loggers) { 
+        [logger logDidPassStep:step duration:duration];
+    }
 }
 
 @end

--- a/Classes/KIFTestController.m
+++ b/Classes/KIFTestController.m
@@ -140,7 +140,7 @@ static void releaseInstance()
     }
     
     loggers = [[NSMutableArray alloc] init];
-    [self registerLogger: [[KIFTestLogger alloc] init]];
+    [self registerLogger:[[[KIFTestLogger alloc] init] autorelease]];
     
     return self;    
 }
@@ -474,7 +474,7 @@ static void releaseInstance()
 
 - (void) registerLogger:(id) logger
 {
-    [logger initWithController: self];
+    [logger setupController: self];
     [loggers addObject:logger];
 }
 

--- a/Classes/KIFTestController.m
+++ b/Classes/KIFTestController.m
@@ -10,7 +10,6 @@
 #import "KIFTestController.h"
 #import "KIFTestScenario.h"
 #import "KIFTestStep.h"
-#import "KIFTestLogger.h"
 
 #import "NSFileManager-KIFAdditions.h"
 #import <QuartzCore/QuartzCore.h>
@@ -467,12 +466,12 @@ static void releaseInstance()
     [UIImagePNGRepresentation(image) writeToFile:outputPath atomically:YES];
 }
 
-- (NSInteger) failureCount;
+- (NSInteger)failureCount;
 {
     return failureCount;
 }
 
-- (void) registerLogger:(id) logger
+- (void)registerLogger:(KIFTestLogger*) logger
 {
     [logger setupController: self];
     [loggers addObject:logger];

--- a/Classes/KIFTestLogger.h
+++ b/Classes/KIFTestLogger.h
@@ -1,0 +1,13 @@
+//
+//  KIFTestLogger.h
+//  KIF
+//
+//  Created by Rodney Gomes on 1/12/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface KIFTestLogger : NSObject
+
+@end

--- a/Classes/KIFTestLogger.h
+++ b/Classes/KIFTestLogger.h
@@ -18,7 +18,7 @@
 
 @property (nonatomic,retain) KIFTestController *controller;
 
-- (KIFTestLogger*) initWithController: (KIFTestController*) controller;
+- (void) setupController: (KIFTestController*) controller;
 
 - (void)logTestingDidStart;
 

--- a/Classes/KIFTestLogger.h
+++ b/Classes/KIFTestLogger.h
@@ -7,7 +7,33 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "KIFTestController.h"
+#import "KIFTestScenario.h"
+#import "KIFTestStep.h"
+#import "KIFTestLogger.h"
 
-@interface KIFTestLogger : NSObject
+@interface KIFTestLogger : NSObject {
+    KIFTestController* controller;
+}
+
+@property (nonatomic,retain) KIFTestController *controller;
+
+- (KIFTestLogger*) initWithController: (KIFTestController*) controller;
+
+- (void)logTestingDidStart;
+
+- (void)logTestingDidFinish;
+
+- (void)logDidStartScenario:(KIFTestScenario *)scenario;
+
+- (void)logDidSkipScenario:(KIFTestScenario *)scenario;
+
+- (void)logDidSkipAddingScenarioGenerator:(NSString *)selectorString;
+
+- (void)logDidFinishScenario:(KIFTestScenario *)scenario duration:(NSTimeInterval)duration;
+
+- (void)logDidFailStep:(KIFTestStep *)step duration:(NSTimeInterval)duration error:(NSError *)error;
+
+- (void)logDidPassStep:(KIFTestStep *)step duration:(NSTimeInterval)duration;
 
 @end

--- a/Classes/KIFTestLogger.m
+++ b/Classes/KIFTestLogger.m
@@ -10,4 +10,113 @@
 
 @implementation KIFTestLogger
 
+@synthesize controller;
+
+- (KIFTestLogger*) initWithController: (KIFTestController*) controller;
+{
+    self = [super init];
+    self.controller = controller;
+    return self;
+}
+
+#define KIFLog(...) [[self logFileHandleForWriting] writeData:[[NSString stringWithFormat:@"%@\n", [NSString stringWithFormat:__VA_ARGS__]] dataUsingEncoding:NSUTF8StringEncoding]]; NSLog(__VA_ARGS__);
+#define KIFLogBlankLine() KIFLog(@" ");
+#define KIFLogSeparator() KIFLog(@"---------------------------------------------------");
+
+- (NSFileHandle *)logFileHandleForWriting;
+{
+    static NSFileHandle *fileHandle = nil;
+    if (!fileHandle) {
+        NSString *logsDirectory = [[NSFileManager defaultManager] createUserDirectory:NSLibraryDirectory];
+        
+        if (logsDirectory) {
+            logsDirectory = [logsDirectory stringByAppendingPathComponent:@"Logs"];
+        }
+        if (![[NSFileManager defaultManager] recursivelyCreateDirectory:logsDirectory]) {
+            logsDirectory = nil;
+        }
+        
+        NSString *dateString = [NSDateFormatter localizedStringFromDate:[NSDate date] dateStyle:NSDateFormatterMediumStyle timeStyle:NSDateFormatterLongStyle];
+        dateString = [dateString stringByReplacingOccurrencesOfString:@"/" withString:@"."];
+        dateString = [dateString stringByReplacingOccurrencesOfString:@":" withString:@"."];
+        NSString *fileName = [NSString stringWithFormat:@"KIF Tests %@.log", dateString];
+        
+        NSString *logFilePath = [logsDirectory stringByAppendingPathComponent:fileName];
+        
+        if (![[NSFileManager defaultManager] fileExistsAtPath:logFilePath]) {
+            [[NSFileManager defaultManager] createFileAtPath:logFilePath contents:[NSData data] attributes:nil];
+        }
+        
+        fileHandle = [[NSFileHandle fileHandleForWritingAtPath:logFilePath] retain];
+        
+        if (fileHandle) {
+            NSLog(@"Logging KIF test activity to %@", logFilePath);
+        }
+    }
+    
+    return fileHandle;
+}
+
+- (void)logTestingDidStart;
+{
+    if (self.controller.failureCount != self.controller.scenarios.count) {
+        KIFLog(@"BEGIN KIF TEST RUN: re-running %d of %d scenarios that failed last time", self.controller.failureCount,self.controller.scenarios.count);
+    } else {
+        KIFLog(@"BEGIN KIF TEST RUN: %d scenarios", self.controller.scenarios.count);
+    }
+}
+
+- (void)logTestingDidFinish;
+{
+    KIFLogBlankLine();
+    KIFLogSeparator();
+    KIFLog(@"KIF TEST RUN FINISHED: %d failures (duration %.2fs)", self.controller.failureCount, -[self.controller.testSuiteStartDate timeIntervalSinceNow]);
+    KIFLogSeparator();
+    
+    // Also log the failure count to stdout, for easier integration with CI tools.
+    NSLog(@"*** KIF TESTING FINISHED: %d failures", self.controller.failureCount);
+}
+
+- (void)logDidStartScenario:(KIFTestScenario *)scenario;
+{
+    KIFLogBlankLine();
+    KIFLogSeparator();
+    KIFLog(@"BEGIN SCENARIO %d/%d (%d steps)", [self.controller.scenarios indexOfObjectIdenticalTo:scenario] + 1, self.controller.scenarios.count, scenario.steps.count);
+    KIFLog(@"%@", scenario.description);
+    KIFLogSeparator();
+}
+
+- (void)logDidSkipScenario:(KIFTestScenario *)scenario;
+{
+    KIFLogBlankLine();
+    KIFLogSeparator();
+    NSString *reason = (scenario.skippedByFilter ? @"filter doesn't match description" : @"only running previously-failed scenarios");
+    KIFLog(@"SKIPPING SCENARIO %d/%d (%@)", [self.controller.scenarios indexOfObjectIdenticalTo:scenario] + 1, self.controller.scenarios.count, reason);
+    KIFLog(@"%@", scenario.description);
+    KIFLogSeparator();
+}
+
+- (void)logDidSkipAddingScenarioGenerator:(NSString *)selectorString;
+{
+    KIFLog(@"Skipping scenario generator %@ because it takes arguments", selectorString);
+}
+
+- (void)logDidFinishScenario:(KIFTestScenario *)scenario duration:(NSTimeInterval)duration
+{
+    KIFLogSeparator();
+    KIFLog(@"END OF SCENARIO (duration %.2fs)", duration);
+    KIFLogSeparator();
+}
+
+- (void)logDidFailStep:(KIFTestStep *)step duration:(NSTimeInterval)duration error:(NSError *)error;
+{
+    KIFLog(@"FAIL (%.2fs): %@", duration, step);
+    KIFLog(@"FAILING ERROR: %@", error);
+}
+
+- (void)logDidPassStep:(KIFTestStep *)step duration:(NSTimeInterval)duration;
+{
+    KIFLog(@"PASS (%.2fs): %@", duration, step);
+}
+
 @end

--- a/Classes/KIFTestLogger.m
+++ b/Classes/KIFTestLogger.m
@@ -1,0 +1,13 @@
+//
+//  KIFTestLogger.m
+//  KIF
+//
+//  Created by Rodney Gomes on 1/12/12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import "KIFTestLogger.h"
+
+@implementation KIFTestLogger
+
+@end

--- a/Classes/KIFTestLogger.m
+++ b/Classes/KIFTestLogger.m
@@ -12,11 +12,9 @@
 
 @synthesize controller;
 
-- (KIFTestLogger*) initWithController: (KIFTestController*) controller;
+- (void) setupController: (KIFTestController*) controller;
 {
-    self = [super init];
     self.controller = controller;
-    return self;
 }
 
 #define KIFLog(...) [[self logFileHandleForWriting] writeData:[[NSString stringWithFormat:@"%@\n", [NSString stringWithFormat:__VA_ARGS__]] dataUsingEncoding:NSUTF8StringEncoding]]; NSLog(__VA_ARGS__);

--- a/Classes/KIFTestLogger.m
+++ b/Classes/KIFTestLogger.m
@@ -12,7 +12,7 @@
 
 @synthesize controller;
 
-- (void) setupController: (KIFTestController*) controller;
+- (void)setupController: (KIFTestController*) controller;
 {
     self.controller = controller;
 }

--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -395,4 +395,9 @@ typedef KIFTestStepResult (^KIFTestStepExecutionBlock)(KIFTestStep *step, NSErro
  */
 + (id)stepToTapRowInTableViewWithAccessibilityLabel:(NSString*)tableViewLabel atIndexPath:(NSIndexPath *)indexPath;
 
+
++ (id)stepToClearField: (NSString *)label traits:(UIAccessibilityTraits)traits expectedResult:(NSString *)expectedResult;
+
++ (id)stepToClearField: (NSString *)label; 
+
 @end

--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -398,6 +398,7 @@ typedef KIFTestStepResult (^KIFTestStepExecutionBlock)(KIFTestStep *step, NSErro
 
 + (id)stepToClearField: (NSString *)label traits:(UIAccessibilityTraits)traits expectedResult:(NSString *)expectedResult;
 
+
 + (id)stepToClearField: (NSString *)label; 
 
 @end

--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -404,15 +404,6 @@ typedef KIFTestStepResult (^KIFTestStepExecutionBlock)(KIFTestStep *step, NSErro
 + (id)stepToTapRowInTableViewWithAccessibilityLabel:(NSString*)tableViewLabel atIndexPath:(NSIndexPath *)indexPath;
 
 /*!
- @method stepToSleepForInterval:interval:
- @abstract A step that sleeps for a specified interval of time.
- @discussion This step will sleep for the amount of time specified in the interval argument.
- @param interval the amount of time to sleep.
- @result A pause in the application for the time specified
- */
-+ (id)stepToSleepForInterval:(NSTimeInterval) interval;
-
-/*!
  @method stepToClearFieldWithAccessibilityLabel:label:traits:expectedResult
  @abstract A step that deletes the contents of an input field (ie TextField or TextView).
  @discussion This step will get the view with the specified accessibility label and clear its contents using the Delete key.

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -877,4 +877,43 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
     return element;
 }
 
++ (id)stepToClearField: (NSString *)label 
+                traits:(UIAccessibilityTraits)traits 
+        expectedResult:(NSString *)expectedResult;
+{
+    NSString *description = [NSString stringWithFormat:@"Clear the text in the view with accessibility label \"%@\"", label];
+    
+    return [self stepWithDescription:description executionBlock:^(KIFTestStep *step, NSError **error) {
+        
+        UIAccessibilityElement *element = [self _accessibilityElementWithLabel:label accessibilityValue:nil tappable:YES traits:traits error:error];
+        if (!element) {
+            return KIFTestStepResultWait;
+        }
+        
+        UIView *view = [UIAccessibilityElement viewContainingAccessibilityElement:element];
+        KIFTestWaitCondition(view, error, @"Cannot find view with accessibility label \"%@\"", label);
+        
+        //XXX: need to change this to use the keyboard and press the Delete key till everything is wiped
+        //     from the textfield
+        
+        // This is probably a UITextField- or UITextView-ish view, so make sure it worked
+        if ([view respondsToSelector:@selector(text)]) {
+            ((UITextField*)view).text = @"";
+            
+            // We trim \n and \r because they trigger the return key, so they won't show up in the final product on single-line inputs
+            //            NSString *expected = [expectedResult ? expectedResult : text stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+            //            NSString *actual = [[view performSelector:@selector(text)] stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+            //            KIFTestCondition([actual isEqualToString:expected], error, @"Failed to actually enter text \"%@\" in field; instead, it was \"%@\"", text, actual);
+        }
+        
+        return KIFTestStepResultSuccess;
+    }];
+}
+
++ (id)stepToClearField: (NSString *)label;
+{
+    return [self stepToClearField:label traits:UIAccessibilityTraitNone expectedResult:nil];
+}
+
+
 @end

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -944,13 +944,4 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
     }];
 }
 
-+ (id)stepToSleepForInterval:(NSTimeInterval) interval;
-{
-    return [KIFTestStep stepWithDescription:[NSString stringWithFormat:@"Sleeping for %d",interval]
-                             executionBlock:^(KIFTestStep *step, NSError **error) {
-                                 [NSThread sleepForTimeInterval:interval];
-                                 return KIFTestStepResultSuccess;
-                             }];
-}
-
 @end

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		230EF1D114BF68E800A47D00 /* KIFTestLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 230EF1CF14BF68E800A47D00 /* KIFTestLogger.h */; };
+		230EF1D214BF68E800A47D00 /* KIFTestLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 230EF1D014BF68E800A47D00 /* KIFTestLogger.m */; };
+		230EF1DA14BF732C00A47D00 /* KIFJunitTestLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 230EF1D814BF732C00A47D00 /* KIFJunitTestLogger.h */; };
+		230EF1DB14BF732C00A47D00 /* KIFJunitTestLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 230EF1D914BF732C00A47D00 /* KIFJunitTestLogger.m */; };
+		230EF1DC14BF8F2F00A47D00 /* KIFJunitTestLogger.h in Sources */ = {isa = PBXBuildFile; fileRef = 230EF1D814BF732C00A47D00 /* KIFJunitTestLogger.h */; };
+		230EF1DD14BF8F2F00A47D00 /* KIFTestLogger.h in Sources */ = {isa = PBXBuildFile; fileRef = 230EF1CF14BF68E800A47D00 /* KIFTestLogger.h */; };
 		39160B1113D1E6BB00311E38 /* LoadableCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 39160B1013D1E6BB00311E38 /* LoadableCategory.h */; };
 		AAB0726C139719AC008AF393 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB0726B139719AC008AF393 /* Foundation.framework */; };
 		AAB0728213971A63008AF393 /* KIF-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = AAB0728113971A63008AF393 /* KIF-Prefix.pch */; };
@@ -36,6 +42,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		230EF1CF14BF68E800A47D00 /* KIFTestLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFTestLogger.h; sourceTree = "<group>"; };
+		230EF1D014BF68E800A47D00 /* KIFTestLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFTestLogger.m; sourceTree = "<group>"; };
+		230EF1D814BF732C00A47D00 /* KIFJunitTestLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFJunitTestLogger.h; sourceTree = "<group>"; };
+		230EF1D914BF732C00A47D00 /* KIFJunitTestLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFJunitTestLogger.m; sourceTree = "<group>"; };
 		39160B1013D1E6BB00311E38 /* LoadableCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadableCategory.h; sourceTree = "<group>"; };
 		AAB07268139719AC008AF393 /* libKIF.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libKIF.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAB0726B139719AC008AF393 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -123,6 +133,10 @@
 				AAB0728613971A98008AF393 /* KIFTestController.h */,
 				AAB0728713971A98008AF393 /* KIFTestController.m */,
 				AAB0728813971A98008AF393 /* KIFTestScenario.h */,
+				230EF1D814BF732C00A47D00 /* KIFJunitTestLogger.h */,
+				230EF1D914BF732C00A47D00 /* KIFJunitTestLogger.m */,
+				230EF1CF14BF68E800A47D00 /* KIFTestLogger.h */,
+				230EF1D014BF68E800A47D00 /* KIFTestLogger.m */,
 				AAB0728913971A98008AF393 /* KIFTestScenario.m */,
 				AAB0728A13971A98008AF393 /* KIFTestStep.h */,
 				AAB0728B13971A98008AF393 /* KIFTestStep.m */,
@@ -174,6 +188,8 @@
 				AAB072B213971AB2008AF393 /* UIWindow-KIFAdditions.h in Headers */,
 				CDFD8E86139728B4008D299F /* NSFileManager-KIFAdditions.h in Headers */,
 				39160B1113D1E6BB00311E38 /* LoadableCategory.h in Headers */,
+				230EF1D114BF68E800A47D00 /* KIFTestLogger.h in Headers */,
+				230EF1DA14BF732C00A47D00 /* KIFJunitTestLogger.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -227,8 +243,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AAB0728E13971A98008AF393 /* KIFTestController.m in Sources */,
+				230EF1D214BF68E800A47D00 /* KIFTestLogger.m in Sources */,
 				AAB0729013971A98008AF393 /* KIFTestScenario.m in Sources */,
+				230EF1DB14BF732C00A47D00 /* KIFJunitTestLogger.m in Sources */,
+				230EF1DC14BF8F2F00A47D00 /* KIFJunitTestLogger.h in Sources */,
+				230EF1DD14BF8F2F00A47D00 /* KIFTestLogger.h in Sources */,
+				AAB0728E13971A98008AF393 /* KIFTestController.m in Sources */,
 				AAB0729213971A98008AF393 /* KIFTestStep.m in Sources */,
 				AAB072A513971AB2008AF393 /* CGGeometry-KIFAdditions.m in Sources */,
 				AAB072A713971AB2008AF393 /* UIAccessibilityElement-KIFAdditions.m in Sources */,


### PR DESCRIPTION

I've added a junit logger and even the ability to plug your own logger into the KIF reporting and I also added a new method called stepToClearField which makes it easy to delete the text in a textfield/textview as a user would (to clear previous state that some apps like to save). If you guys find it useful then feel free to pull the changes in and if you want the logger business to be written slightly different let me know as I'm not an experienced objective c developer and have done things in the easiest and quickest way.