### PR TITLE
Fix bug in coordinate systems mapping in [view tap]

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -256,14 +256,7 @@
 
 - (void)tap;
 {
-    CGRect frame;
-    if ([self isKindOfClass:[UIWindow class]]) {
-        frame = self.frame;
-    } else {
-        frame = [self.window convertRect:self.frame fromView:self.superview];
-    }
-    
-    CGPoint centerPoint = CGPointMake(frame.size.width * 0.5f, frame.size.height * 0.5f);
+    CGPoint centerPoint = CGPointMake(self.frame.size.width * 0.5f, self.frame.size.height * 0.5f);
     
     [self tapAtPoint:centerPoint];
 }


### PR DESCRIPTION
The old implementation doesn't always work in landscape mode because the window's coordinate system is always based on a portrait orientation. This means that the height and width of the view are flipped, which means the tapped point isn't in the center of the view (and is sometimes totally outside the view, and thus the tap doesn't happen).
