### PR TITLE
Use scrollRectToVisible: instead of setContentOffset: on UIScrollView

### DIFF
--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -923,8 +923,8 @@ typedef CGPoint KIFDisplacement;
         if ((UIAccessibilityElement *)view == element) {
             [scrollView scrollViewToVisible:view animated:YES];
         } else {
-            CGRect elementFrame = [view.window convertRect:element.accessibilityFrame toView:scrollView];            
-            [scrollView setContentOffset:CGPointMake(0,  elementFrame.origin.y) animated:YES];
+            CGRect elementFrame = [view.window convertRect:element.accessibilityFrame toView:scrollView];
+            [scrollView scrollRectToVisible:elementFrame animated:YES];
         }
         
         // Give the scroll view a small amount of time to perform the scroll.


### PR DESCRIPTION
The current implementation of `+ (UIAccessibilityElement *)_accessibilityElementWithLabel:(NSString *)label accessibilityValue:(NSString *)value tappable:(BOOL)mustBeTappable traits:(UIAccessibilityTraits)traits error:(out NSError **)error;` uses setContentOffset: to scroll resolved accessibility elements into the visible frame of the scroll view by the y origin point as the offset. This causes table views to be very jerky when cells are found directly by accessibility label and scrolls all other cells above the found cell out of the visible frame.

On iOS 5, this is an annoyance. On iOS 6, the offscreen cells fail to be found and return nil, breaking scenarios.
