### PR TITLE
Introduce step to verify the first responder is equal to a view with a given accessibility label

### DIFF
--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -431,4 +431,15 @@ typedef enum {
  */
 + (id)stepToSwipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction;
 
+/*!
+ @method stepToWaitForFirstResponderWithAccessibilityLabel:
+ @abstract A step that waits until a view or accessibility element is the first responder.
+ @discussion The first responder is found by searching the view hierarchy of the application's
+    main window and its accessibility label is compared to the given value. If they match, the
+    step returns success else it will attempt to wait until they do.
+ @param label The accessibility label of the element to wait for.
+ @result A configured test step.
+ */
++ (id)stepToWaitForFirstResponderWithAccessibilityLabel:(NSString *)label;
+
 @end

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -595,6 +595,17 @@ typedef CGPoint KIFDisplacement;
     }];
 }
 
++ (id)stepToWaitForFirstResponderWithAccessibilityLabel:(NSString *)label;
+{
+    NSString *description = [NSString stringWithFormat:@"Verify that the first responder is the view with accessibility label '%@'", label];
+    return [KIFTestStep stepWithDescription:description executionBlock:^KIFTestStepResult(KIFTestStep *step, NSError *__autoreleasing *error) {
+        UIResponder *firstResponder = [[[UIApplication sharedApplication] keyWindow] firstResponder];
+        KIFTestWaitCondition([[firstResponder accessibilityLabel] isEqualToString:label], error, @"Expected accessibility label for first responder to be '%@', got '%@'", label, [firstResponder accessibilityLabel]);
+
+        return KIFTestStepResultSuccess;
+    }];
+}
+
 #pragma mark Step Collections
 
 + (NSArray *)stepsToChoosePhotoInAlbum:(NSString *)albumName atRow:(NSInteger)row column:(NSInteger)column;


### PR DESCRIPTION
Adds a simple step for verifying the first responder. Useful if you are doing things like advancing between two UITextField's via the Keyboard 'Next' button or otherwise programmatically manipulating the responder chain.
