### PR TITLE
Allow user-specified swipe distances

### DIFF
--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -432,6 +432,17 @@ typedef enum {
 + (id)stepToSwipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction;
 
 /*!
+ @method stepToSwipeViewWithAccessibilityLabel:inDirection:
+ @abstract A step that swipes a particular view in the view hierarchy in the given direction for the given distance.
+ @discussion The view will get the view with the specified accessibility label and swipe the screen in the given direction from the view's center for the given distance in pixels.
+ @param label The accessibility label of the view to swipe.
+ @param direction The direction in which to swipe.
+ @param distance The distance for which to swipe.
+ @result A configured test step.
+ */
++ (id)stepToSwipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction withDistance:(CGFloat)distance;
+
+/*!
  @method stepToWaitForFirstResponderWithAccessibilityLabel:
  @abstract A step that waits until a view or accessibility element is the first responder.
  @discussion The first responder is found by searching the view hierarchy of the application's

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -552,9 +552,22 @@ typedef CGPoint KIFDisplacement;
 
 + (id)stepToSwipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction
 {
-    // The original version of this came from http://groups.google.com/group/kif-framework/browse_thread/thread/df3f47eff9f5ac8c
-    NSString *directionDescription = nil;
+    KIFDisplacement swipeDisplacement = [self _displacementForSwipingInDirection:direction];
+    return [self _stepToSwipeViewWithAccessibilityLabel:label inDirection:direction withDisplacement:swipeDisplacement];
+}
 
++ (id)stepToSwipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction withDistance:(CGFloat)distance
+{
+  
+    KIFDisplacement swipeDisplacement = [self _displacementForSwipingInDirection:direction andDistance:distance];
+    return [self _stepToSwipeViewWithAccessibilityLabel:label inDirection:direction withDisplacement:swipeDisplacement];
+}
+
++(id)_stepToSwipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction withDisplacement:(KIFDisplacement)swipeDisplacement
+{
+    // The original version of this came from http://groups.google.com/group/kif-framework/browse_thread/thread/df3f47eff9f5ac8c  
+    NSString *directionDescription = nil;
+    
     switch(direction)
     {
         case KIFSwipeDirectionRight:
@@ -586,8 +599,6 @@ typedef CGPoint KIFDisplacement;
 
         CGRect elementFrame = [viewToSwipe.window convertRect:element.accessibilityFrame toView:viewToSwipe];
         CGPoint swipeStart = CGPointCenteredInRect(elementFrame);
-
-        KIFDisplacement swipeDisplacement = [self _displacementForSwipingInDirection:direction];
 
         CGPoint swipePath[NUM_POINTS_IN_SWIPE_PATH];
 
@@ -1005,6 +1016,30 @@ typedef CGPoint KIFDisplacement;
             break;
         case KIFSwipeDirectionDown:
             return CGPointMake(MINOR_SWIPE_DISPLACEMENT, MAJOR_SWIPE_DISPLACEMENT);
+            break;
+        default:
+            return CGPointZero;
+    }
+}
+
++ (KIFDisplacement)_displacementForSwipingInDirection:(KIFSwipeDirection)direction andDistance:(CGFloat)distance
+{
+    switch (direction)
+    {
+            // As discovered on the Frank mailing lists, it won't register as a
+            // swipe if you move purely horizontally or vertically, so need a
+            // slight orthogonal offset too.
+        case KIFSwipeDirectionRight:
+            return CGPointMake(distance, MINOR_SWIPE_DISPLACEMENT);
+            break;
+        case KIFSwipeDirectionLeft:
+            return CGPointMake(-distance, MINOR_SWIPE_DISPLACEMENT);
+            break;
+        case KIFSwipeDirectionUp:
+            return CGPointMake(MINOR_SWIPE_DISPLACEMENT, -distance);
+            break;
+        case KIFSwipeDirectionDown:
+            return CGPointMake(MINOR_SWIPE_DISPLACEMENT, distance);
             break;
         default:
             return CGPointZero;


### PR DESCRIPTION
This patch allows KIF users to specify the distance to swipe when calling stepToSwipeViewWithAccessibilityLabel:inDirection: by introduction an overload with a distance variable.
