### PR TITLE
stepToWaitForSwitchWithAccessibilityLabel:value: for easier verification of UISwitch value

### DIFF
--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -461,10 +461,12 @@ typedef enum {
  @param label The accessibility label of the view to swipe.
  @param direction The direction in which to swipe.
  @PARAM displacement The amount of displacement in the path of the swipe.
+ @param offset An offset from center inside the view
  @result A configured test step.
  */
 + (id)stepToSwipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction withDisplacement:(CGFloat)displacement;
 
++ (id)stepToSwipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction withDisplacement:(CGFloat)displacement atOffset:(UIOffset)offset;
 /*!
  @method stepToWaitForFirstResponderWithAccessibilityLabel:
  @abstract A step that waits until a view or accessibility element is the first responder.

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -644,6 +644,11 @@ typedef CGPoint KIFDisplacement;
 
 + (id)stepToSwipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction withDisplacement:(CGFloat)displacement
 {
+    return [KIFTestStep stepToSwipeViewWithAccessibilityLabel:label inDirection:direction withDisplacement:displacement atOffset:UIOffsetZero];
+}
+
++ (id)stepToSwipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction withDisplacement:(CGFloat)displacement atOffset:(UIOffset)offset
+{
     // The original version of this came from http://groups.google.com/group/kif-framework/browse_thread/thread/df3f47eff9f5ac8c
     NSString *directionDescription = nil;
 
@@ -678,6 +683,8 @@ typedef CGPoint KIFDisplacement;
 
         CGRect elementFrame = [viewToSwipe.window convertRect:element.accessibilityFrame toView:viewToSwipe];
         CGPoint swipeStart = CGPointCenteredInRect(elementFrame);
+        // Offset by the desired amount
+        swipeStart = CGPointMake(swipeStart.x + offset.horizontal, swipeStart.y + offset.vertical);
 
         KIFDisplacement swipeDisplacement = [self _displacementForSwipingInDirection:direction withDisplacement:displacement];
 


### PR DESCRIPTION
stepToWaitForViewWithAccessibilityLabel:value:traits: works for checking the value of a UISwitch, but I suspect that people need to do some extra typing (switchIsOn ? @"1" : @"0") to provide the value as a string. The implementation is mostly copied from stepToSetOn:forSwitchWithAccessibilityLabel:.
