### PR TITLE
When the accessibility frame is not set, use the view frame

### DIFF
--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -309,8 +309,8 @@ typedef CGPoint KIFDisplacement;
 
         // If the accessibilityFrame is not set, fallback to the view frame.
         CGRect elementFrame;
-        if (element.accessibilityFrame.origin.x == 0 && element.accessibilityFrame.origin.y == 0 && element.accessibilityFrame.size.width == 0 && element.accessibilityFrame.size.height == 0) {
-            elementFrame.origin.x = elementFrame.origin.y = 0;
+        if (CGRectEqualToRect(CGRectZero, element.accessibilityFrame)) {
+            elementFrame.origin = CGPointZero;
             elementFrame.size = view.frame.size;
         } else {
             elementFrame = [view.window convertRect:element.accessibilityFrame toView:view];


### PR DESCRIPTION
On the iOS Simulator 5.0, there are times when the Accessibility Inspector will
determine the accessibility frame correctly but the accessibilityFrame property
on the element will be {0, 0, 0, 0}. This happens in some cases when the UI is
created programmatically.

As a work-around when running on 5.0 and prior, this change attempts to
duplicate the OS's behavior of guessing the accessibility frame. It assumes
{0, 0, WIDTH, HEIGHT} where WIDTH and HEIGHT are equal to view.frame.width and
view.frame.height.
