### PR TITLE
Add KIF_SILENT_FILTERING environment variable to suppress logging output

### DIFF
--- a/Classes/KIFTestController.m
+++ b/Classes/KIFTestController.m
@@ -530,6 +530,7 @@ static void releaseInstance()
 
 - (void)_logDidSkipScenario:(KIFTestScenario *)scenario;
 {
+    if ([[[[NSProcessInfo processInfo] environment] objectForKey:@"KIF_SILENT_FILTERING"] boolValue]) return; // Don't want filter skipping noise
     KIFLogBlankLine();
     KIFLogSeparator();
     NSString *reason = (scenario.skippedByFilter ? @"filter doesn't match description" : @"only running previously-failed scenarios");


### PR DESCRIPTION
This micro-patch introduces a new environment variable to suppress the logging output when executing a scenarios with a filter applied. In development, I often use the filters to focus on the scenarios I am currently working on and the flood of logging can cover up valuable information within the logs. This adds a new environment variable to switch it off.
