### PR TITLE
allow subclasses of KIFTestStep to take action when step fails

### DIFF
--- a/Classes/KIFTestController.m
+++ b/Classes/KIFTestController.m
@@ -326,6 +326,7 @@ static void releaseInstance()
         case KIFTestStepResultFailure: {
             [self _logDidFailStep:self.currentStep duration:currentStepDuration error:error];
             [self _writeScreenshotForStep:self.currentStep];
+            [[self.currentStep class] stepFailed];
             [self.currentStep cleanUp];
             
             self.currentScenario = [self _nextScenarioAfterResult:result];

--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -23,7 +23,7 @@ if (!(condition)) { \
     if (error) { \
         *error = [NSError errorWithDomain:@"KIFTest" code:KIFTestStepResultFailure userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:__VA_ARGS__], NSLocalizedDescriptionKey, nil]]; \
     } \
-    [KIFTestStep stepFailed]; \
+    [self stepFailed]; \
     return KIFTestStepResultFailure; \
 } \
 })

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -399,7 +399,7 @@ typedef CGPoint KIFDisplacement;
             // We trim \n and \r because they trigger the return key, so they won't show up in the final product on single-line inputs
             NSString *expected = [expectedResult ? expectedResult : text stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]];
             NSString *actual = [[view performSelector:@selector(text)] stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-            KIFTestCondition([actual isEqualToString:expected], error, @"Failed to actually enter text \"%@\" in field; instead, it was \"%@\"", text, actual);
+            KIFTestCondition([actual isEqualToString:expected], error, @"Failed to get text \"%@\" in field; instead, it was \"%@\"", expected, actual);
         }
         
         return KIFTestStepResultSuccess;
@@ -726,6 +726,12 @@ typedef CGPoint KIFDisplacement;
 }
 
 #pragma mark Private Methods
+
+- (void)stepFailed;
+{
+    [[self class] stepFailed];
+}
+
 
 - (void)_onObservedNotification:(NSNotification *)notification;
 {


### PR DESCRIPTION
fix test condition macro to use current step class to report failed step instead of base class
add test step instance method to respond to test failures
