### PR TITLE
Only use the |window| property on the app delegate if it is implemented

### DIFF
--- a/Classes/KIFTestController.m
+++ b/Classes/KIFTestController.m
@@ -272,9 +272,15 @@ static void releaseInstance()
 
 - (BOOL)_isAccessibilityInspectorEnabled;
 {
-    // This method for testing if the inspector is enabled was taken from the Frank framework.
+    // This method for testing if the inspector is enabled is based on that used by the Frank framework.
     // https://github.com/moredip/Frank
-    UIWindow *keyWindow = [[[UIApplication sharedApplication] delegate] window];
+    id<UIApplicationDelegate> appDelegate = [[UIApplication sharedApplication] delegate];
+    UIWindow *keyWindow;
+    if ([appDelegate respondsToSelector:@selector(window)]) {
+        keyWindow = [appDelegate window];
+    } else {
+        keyWindow = [[UIApplication sharedApplication] keyWindow];
+    }
     NSString *originalAccessibilityLabel = [keyWindow accessibilityLabel];
     
     [keyWindow setAccessibilityLabel:@"KIF Test Label"];


### PR DESCRIPTION
|window| is an optional property, so if it is not defined, we use the previous
method of using |keyWindow| instead.
