### PR TITLE
Remove call to |stepFailed| in the KIFTestCondition macro

### DIFF
--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -23,7 +23,6 @@ if (!(condition)) { \
     if (error) { \
         *error = [NSError errorWithDomain:@"KIFTest" code:KIFTestStepResultFailure userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[NSString stringWithFormat:__VA_ARGS__], NSLocalizedDescriptionKey, nil]]; \
     } \
-    [self stepFailed]; \
     return KIFTestStepResultFailure; \
 } \
 })


### PR DESCRIPTION
This call is not strictly necessary because it is also being made in
|KIFTestController _advanceWithResult:error:|. It is also inconsistent
because:
- the KIFTestWaitCondition macro does not call |stepFailed| itself.
- the macro originally didn't make any assumptions about local
  variables when it is being called, as the error parameter must be
  passed explicitly. This allowed you to use the macro in more
  contexts (see below).

Without this change, you cannot define a step execution block inline
in a scenario method. This worked before but was broken by:
http://goo.gl/0AKuT

Example:

```
@implementation KIFTestScenario (MyScenarios)

+ (id)scenarioToDefineExecutionBlock {
  ...
  [scenario addStep:[KIFTestStep stepWithDescription:@"..."
      executionBlock:^(KIFTestStep *step, NSError **error) {
        KIFTestCondition([foo bar], error, @"[foo bar] should be YES");
      }]];
  ...
}

@end
```
