### PR TITLE
Crash fix: Don't add steps to scenarios with skippedByFilter.

### DIFF
--- a/Classes/KIFTestScenario.m
+++ b/Classes/KIFTestScenario.m
@@ -117,6 +117,9 @@ static NSArray *defaultStepsToTearDown = nil;
 
 - (void)addStep:(KIFTestStep *)step;
 {
+    if (self.skippedByFilter) {
+        return;
+    }
     NSAssert(![steps containsObject:step], @"The step %@ is already added", step);
     
     [self _initializeStepsIfNeeded];
@@ -125,6 +128,9 @@ static NSArray *defaultStepsToTearDown = nil;
 
 - (void)addStepsFromArray:(NSArray *)inSteps;
 {
+    if (self.skippedByFilter) {
+        return;
+    }
     for (KIFTestStep *step in inSteps) {
         NSAssert(![steps containsObject:step], @"The step %@ is already added", step);
     }


### PR DESCRIPTION
Adding a step to a scenario that is
"skippedByFilter" can cause a crash if that
scenario has default tearDown steps because
insertion uses NSMakeRange(...) to decide, where
to insert into self.steps. When, skippedByFilter
the steps array is never initialized, so on first
inspection it may seem like the checks aren't
necessary, since we'd be messaging nil, but the
arguments of the message are still evaluated
causing a crash like so:

**\* Terminating app due to uncaught exception \
'NSRangeException', reason: '**\* -[NSIndexSet \
initWithIndexesInRange:]: Range {4294967294, 1} \
exceeds maximum index value of NSNotFound - 1'
