### PR TITLE
Fix UITouch timestamp to match Apple's implementation.

### DIFF
--- a/Additions/UITouch-KIFAdditions.m
+++ b/Additions/UITouch-KIFAdditions.m
@@ -74,7 +74,7 @@ MAKE_CATEGORIES_LOADABLE(UITouch_KIFAdditions)
     _phase = UITouchPhaseBegan;
     _touchFlags._firstTouchForView = 1;
     _touchFlags._isTap = 1;
-    _timestamp = [NSDate timeIntervalSinceReferenceDate];
+    _timestamp = [[NSProcessInfo processInfo] systemUptime];
 
 	return self;
 }
@@ -87,7 +87,7 @@ MAKE_CATEGORIES_LOADABLE(UITouch_KIFAdditions)
 - (void)setPhase:(UITouchPhase)phase;
 {
 	_phase = phase;
-	_timestamp = [NSDate timeIntervalSinceReferenceDate];
+	_timestamp = [[NSProcessInfo processInfo] systemUptime];
 }
 
 //
@@ -99,7 +99,7 @@ MAKE_CATEGORIES_LOADABLE(UITouch_KIFAdditions)
 {
 	_previousLocationInWindow = _locationInWindow;
 	_locationInWindow = location;
-	_timestamp = [NSDate timeIntervalSinceReferenceDate];
+	_timestamp = [[NSProcessInfo processInfo] systemUptime];
 }
 
 @end


### PR DESCRIPTION
The Apple docs explicitly say that their timestamp is based off of
-[NSProccessInfo systemUptime].

Please see:
http://developer.apple.com/library/ios/documentation/uikit/reference/UITouch_Class/Reference/Reference.html#//apple_ref/occ/instp/UITouch/timestamp

Using the timeIntervalSinceReferenceDate can cause interaction
with views that use the timestamp, to behave incorrectly while under test.
