### PR TITLE
Stop search for views in stepToTapScreenAtPoint: when first one is found

### DIFF
--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -338,9 +338,8 @@ typedef CGPoint KIFDisplacement;
             CGPoint windowPoint = [window convertPoint:screenPoint fromView:nil];
             view = [window hitTest:windowPoint withEvent:nil];
             
-            // If we hit the window itself, then skip it.
-            if (view == window || view == nil) {
-                continue;
+            if (view != nil) {
+                break;
             }
         }
         


### PR DESCRIPTION
The existing if-statement was pretty nonsensical as the loop continues in any case.

Now the search for views actually gets stopped when one is found as the comment suggests. The previous version was searching through all the windows regardless.
