### PR TITLE
Fixed broken scrolling to off screen items

### DIFF
--- a/Additions/UIScrollView-KIFAdditions.m
+++ b/Additions/UIScrollView-KIFAdditions.m
@@ -20,39 +20,16 @@ MAKE_CATEGORIES_LOADABLE(UIScrollView_KIFAdditions)
 
 - (void)scrollViewToVisible:(UIView *)view animated:(BOOL)animated;
 {
-    BOOL needsUpdate = NO;
-    CGRect frame = [self.window convertRect:self.frame fromView:self.superview];
+    CGRect viewFrame = [self convertRect:view.frame fromView:view.superview];
+    CGRect visibleFrame = self.frame;
+    visibleFrame.origin = self.contentOffset;
     
-    CGRect viewFrame = [self.window convertRect:view.frame fromView:view.superview];
-    CGFloat viewMaxX = viewFrame.origin.x + viewFrame.size.width;
-    CGFloat viewMaxY = viewFrame.origin.y + viewFrame.size.height;
-    CGFloat scrollViewMaxX = frame.origin.x + frame.size.width;
-    CGFloat scrollViewMaxY = frame.origin.y + frame.size.height;
-    
-    CGPoint offsetPoint = self.contentOffset;
-    if (viewMaxX > scrollViewMaxX) {
-        // The view is to the right of the view port, so scroll it just into view
-        offsetPoint.x = frame.origin.x + viewFrame.size.width;
-        needsUpdate = YES;
-    } else if (viewMaxX < 0.0) {
-        offsetPoint.x = viewFrame.origin.x;
-        needsUpdate = YES;
+    if (CGRectContainsRect(visibleFrame, viewFrame)) {
+        return;
     }
     
-    if (viewMaxY > scrollViewMaxY) {
-        // The view is below the view port, so scroll it just into view
-        offsetPoint.y = frame.origin.y + viewFrame.size.height;
-        needsUpdate = YES;
-    } else if (viewMaxY < 0.0) {
-        offsetPoint.y = viewFrame.origin.y;
-        needsUpdate = YES;
-    }
-    
-    if (needsUpdate) {
-        offsetPoint = [self.window convertPoint:offsetPoint toView:self.superview];
-        [self setContentOffset:offsetPoint animated:animated];
-        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.2, false);
-    }
+    [self scrollRectToVisible:viewFrame animated:YES];
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.3, false);
 }
 
 @end


### PR DESCRIPTION
The code in `scrollViewToVisible:animate:` that this replaces was so unnecessarily verbose, I'm still not entirely confident that I wasn't missing something.

The intent of the method seems clear, if the provided view is not currently visible in the receiving scroll view, make it so. This can be achieved with only one coordinate space conversion and rect containment check for efficiency's sake.
