### PR TITLE
One line fix for nil reference bug

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -158,8 +158,9 @@ typedef struct __GSEvent * GSEventRef;
         for (NSInteger accessibilityElementIndex = 0; accessibilityElementIndex < accessibilityElementCount; accessibilityElementIndex++) {
             UIAccessibilityElement *subelement = [element accessibilityElementAtIndex:accessibilityElementIndex];
             
-            if (subelement)
+            if (subelement) {
                 [elementStack addObject:subelement];
+            }
         }
     }
         


### PR DESCRIPTION
This is a one line fix for a bug causing crashes for me.
The present code is adding an object to an array, without
first checking if the object reference is not nil.
