### PR TITLE
stepToWaitForSwitchWithAccessibilityLabel:value: for easier verification of UISwitch value

### DIFF
--- a/Classes/KIFTestStep.h
+++ b/Classes/KIFTestStep.h
@@ -423,7 +423,7 @@ typedef KIFTestStepResult (^KIFTestStepExecutionBlock)(KIFTestStep *step, NSErro
  @param label The accessibility label of the UISwitch element.
  @result A configured test step.
  */
-+ (id)stepToWaitForSwitchWithAccessibilityLabel:(NSString *)label withValue:(BOOL)switchIsOn;
++ (id)stepToWaitForSwitchWithAccessibilityLabel:(NSString *)label value:(BOOL)switchIsOn;
 
 /*!
  @method stepToDismissPopover

--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -581,7 +581,7 @@ typedef CGPoint KIFDisplacement;
     }];
 }
 
-+ (id)stepToWaitForSwitchWithAccessibilityLabel:(NSString *)label withValue:(BOOL)switchIsOn
++ (id)stepToWaitForSwitchWithAccessibilityLabel:(NSString *)label value:(BOOL)switchIsOn
 {
     NSString *description = [NSString stringWithFormat:@"Verify that the switch with accessibility label \"%@\" is %@", label, switchIsOn ? @"ON" : @"OFF"];
     return [self stepWithDescription:description executionBlock:^(KIFTestStep *step, NSError **error) {


### PR DESCRIPTION
stepToWaitForViewWithAccessibilityLabel:value:traits: works for checking the value of a UISwitch, but I suspect that people need to do some extra typing (switchIsOn ? @"1" : @"0") to provide the value as a string. The implementation is mostly copied from stepToSetOn:forSwitchWithAccessibilityLabel:.
