### PR TITLE
Fixed off-by-one bug in dragAlongPathWithPoints

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -360,7 +360,7 @@ typedef struct __GSEvent * GSEventRef;
 
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, DRAG_TOUCH_DELAY, false);
     
-    for (NSInteger pointIndex = 1; pointIndex < count - 1; pointIndex++) {
+    for (NSInteger pointIndex = 1; pointIndex < count; pointIndex++) {
         [touch setLocationInWindow:[self.window convertPoint:points[pointIndex] fromView:self]];
         [touch setPhase:UITouchPhaseMoved];
         


### PR DESCRIPTION
Fixed off-by-one bug in dragAlongPathWithPoints method which was omitting the last point when simulating a drag along an array of points.
