### PR TITLE
View with zero alpha should also count as invisible

### DIFF
--- a/Classes/KIFTestStep.m
+++ b/Classes/KIFTestStep.m
@@ -163,7 +163,7 @@ typedef CGPoint KIFDisplacement;
         KIFTestWaitCondition(view, error, @"Cannot find view containing accessibility element with the label \"%@\"", label);
 
         // Hidden views count as absent
-        KIFTestWaitCondition([view isHidden], error, @"Accessibility element with label \"%@\" is visible and not hidden.", label);
+        KIFTestWaitCondition([view isHidden] || [view alpha] == 0.0, error, @"Accessibility element with label \"%@\" is visible and not hidden.", label);
 
         return KIFTestStepResultSuccess;
     }];


### PR DESCRIPTION
Setting view.alpha = 0 instead of view.hidden = YES is useful if the view is hidden with animation.
