### PR TITLE
Fix crash in accessibilityElementMatchingBlock

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -131,7 +131,7 @@ typedef struct __GSEvent * GSEventRef;
     NSMutableArray *elementStack = [NSMutableArray arrayWithObject:self];
     
     while (elementStack.count) {
-        UIAccessibilityElement *element = [elementStack lastObject];
+        UIAccessibilityElement *element = [[[elementStack lastObject] retain] autorelease];
         [elementStack removeLastObject];
 
         BOOL elementMatches = matchBlock(element);


### PR DESCRIPTION
In some circumstances, instances of `_UIAccessibilityElementMockView` were present in the element stack and nowhere else.  When they were popped from the stack, they were then dealloced before use.  This adds retain and autorelease when they are popped to prevent this.
