### PR TITLE
Make sure that the main window(s) are first in the windowsWithKeyWindow array

### DIFF
--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -79,10 +79,19 @@ MAKE_CATEGORIES_LOADABLE(UIApplication_KIFAdditions)
 - (NSArray *)windowsWithKeyWindow
 {
     NSMutableArray *windows = self.windows.mutableCopy;
+    
     UIWindow *keyWindow = self.keyWindow;
-    if (![windows containsObject:keyWindow]) {
-        [windows addObject:keyWindow];
+    if ([windows containsObject:keyWindow]) {
+        [windows removeObject:keyWindow];
     }
+    [windows insertObject:keyWindow atIndex:0];
+    
+    UIWindow *mainWindow = [self.delegate window];
+    if ([windows containsObject:mainWindow]) {
+        [windows removeObject:mainWindow];
+    }
+    [windows insertObject:mainWindow atIndex:0];
+    
     return [windows autorelease];
 }
 


### PR DESCRIPTION
`stepToDismissPopover` looks at the first window in the array returned by `windowsWithKeyWindow`; this is not always the main window.  This commit (a) makes sure that the main window is first, if present, and (b) makes sure that the app delegate's window is used if it's different to the app's key window (this was happening on my system causing the step to fail).
