### PR TITLE
failWithException should respect stop parameter

### DIFF
--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -167,7 +167,7 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
 
 - (void)failWithException:(NSException *)exception stopTest:(BOOL)stop
 {
-    [self failWithExceptions:@[exception] stopTest:YES];
+    [self failWithExceptions:@[exception] stopTest:stop];
 }
 
 - (void)failWithExceptions:(NSArray *)exceptions stopTest:(BOOL)stop


### PR DESCRIPTION
It seems as if there was a bug in `KIFTestActor(Delegate) failWithException:stopTest` that caused all exceptions to be hard-coded to stop tests, rather than respecting the passed "should stop test" attribute.

One word fix.
