### PR TITLE
Treat parent `UISearchBar` as first responder when `UISearchBarTextField` instance is the first responder

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -545,6 +545,9 @@
 {
     [self runBlock:^KIFTestStepResult(NSError **error) {
         UIResponder *firstResponder = [[[UIApplication sharedApplication] keyWindow] firstResponder];
+        if ([firstResponder isKindOfClass:NSClassFromString(@"UISearchBarTextField")]) {
+            firstResponder = [(UIView *)firstResponder superview];
+        }
         KIFTestWaitCondition([[firstResponder accessibilityLabel] isEqualToString:label], error, @"Expected accessibility label for first responder to be '%@', got '%@'", label, [firstResponder accessibilityLabel]);
         
         return KIFTestStepResultSuccess;


### PR DESCRIPTION
This enables you to write natural test expectations against the `UISearchBar` accessibility label since the `UISearchBarTextField` instance is private and you cannot configure an accessibility label.
