### PR TITLE
Rework `UISearchBarTextField` first responder detection to support iOS 7

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -571,7 +571,9 @@
     [self runBlock:^KIFTestStepResult(NSError **error) {
         UIResponder *firstResponder = [[[UIApplication sharedApplication] keyWindow] firstResponder];
         if ([firstResponder isKindOfClass:NSClassFromString(@"UISearchBarTextField")]) {
-            firstResponder = [(UIView *)firstResponder superview];
+            do {
+                firstResponder = [(UIView *)firstResponder superview];
+            } while (firstResponder && ![firstResponder isKindOfClass:[UISearchBar class]]);
         }
         KIFTestWaitCondition([[firstResponder accessibilityLabel] isEqualToString:label], error, @"Expected accessibility label for first responder to be '%@', got '%@'", label, [firstResponder accessibilityLabel]);
         


### PR DESCRIPTION
The view hierarchy for `UISearchBar` instances has changed under iOS 7 such that the direct superview of the `UISearchBarTextField` is no longer the `UISearchBar` instance, breaking the first responder detection. This change does an upward search through the view hierarchy to find the parent `UISearchBar`. It is backwards compatible to iOS 5 & 6 while also supporting iOS 7.
