### PR TITLE
Made scroll view and table view methods use accessibilityIdentifier

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -291,10 +291,21 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
  @discussion This step will get the view with the specified accessibility label and tap the row at indexPath.
  
  For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+ 
  @param tableViewLabel Accessibility label of the table view.
  @param indexPath Index path of the row to tap.
  */
-- (void)tapRowInTableViewWithAccessibilityLabel:(NSString*)tableViewLabel atIndexPath:(NSIndexPath *)indexPath;
+- (void)tapRowInTableViewWithAccessibilityLabel:(NSString*)tableViewLabel atIndexPath:(NSIndexPath *)indexPath DEPRECATED_MSG_ATTRIBUTE("Use tapRowAtIndexPath:inTableViewWithAccessibilityIdentifier:");
+
+/*!
+ @abstract Taps the row at IndexPath in a view with the given identifier.
+ @discussion This step will get the view with the specified accessibility identifier and tap the row at indexPath.
+ 
+ For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+ @param indexPath Index path of the row to tap.
+ @param identifier Accessibility identifier of the table view.
+ */
+- (void)tapRowAtIndexPath:(NSIndexPath *)indexPath inTableViewWithAccessibilityIdentifier:(NSString *)identifier NS_AVAILABLE_IOS(5_0);
 
 /*!
  @abstract Swipes a particular view in the view hierarchy in the given direction.
@@ -311,7 +322,16 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
  @param horizontalFraction The horizontal displacement of the scroll action, as a fraction of the width of the view.
  @param verticalFraction The vertical displacement of the scroll action, as a fraction of the height of the view.
  */
-- (void)scrollViewWithAccessibilityLabel:(NSString *)label byFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction;
+- (void)scrollViewWithAccessibilityLabel:(NSString *)label byFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction DEPRECATED_MSG_ATTRIBUTE("Use scrollViewWithAccessibilityIdentifier:byFractionOfSizeHorizontal:vertical:");
+
+/*!
+ @abstract Scrolls a particular view in the view hierarchy by an amount indicated as a fraction of its size.
+ @discussion The view will get the view with the specified accessibility identifier and scroll it by the indicated fraction of its size, with the scroll centered on the center of the view.
+ @param identifier The accessibility identifier of the view to scroll.
+ @param horizontalFraction The horizontal displacement of the scroll action, as a fraction of the width of the view.
+ @param verticalFraction The vertical displacement of the scroll action, as a fraction of the height of the view.
+ */
+- (void)scrollViewWithAccessibilityIdentifier:(NSString *)identifier byFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction NS_AVAILABLE_IOS(5_0);
 
 /*!
  @abstract Waits until a view or accessibility element is the first responder.

--- a/KIF Tests/GestureTests.m
+++ b/KIF Tests/GestureTests.m
@@ -55,15 +55,15 @@
 
 - (void)testScrolling
 {
-    [tester scrollViewWithAccessibilityLabel:@"Scroll View" byFractionOfSizeHorizontal:-0.9 vertical:-0.9];
+    [tester scrollViewWithAccessibilityIdentifier:@"Scroll View" byFractionOfSizeHorizontal:-0.9 vertical:-0.9];
     [tester waitForTappableViewWithAccessibilityLabel:@"Bottom Right"];
-    [tester scrollViewWithAccessibilityLabel:@"Scroll View" byFractionOfSizeHorizontal:0.9 vertical:0.9];
+    [tester scrollViewWithAccessibilityIdentifier:@"Scroll View" byFractionOfSizeHorizontal:0.9 vertical:0.9];
     [tester waitForTappableViewWithAccessibilityLabel:@"Top Left"];
 }
 
 - (void)testMissingScrollableElement
 {
-    KIFExpectFailure([[tester usingTimeout:0.25] scrollViewWithAccessibilityLabel:@"Unknown" byFractionOfSizeHorizontal:0.5 vertical:0.5]);
+    KIFExpectFailure([[tester usingTimeout:0.25] scrollViewWithAccessibilityIdentifier:@"Unknown" byFractionOfSizeHorizontal:0.5 vertical:0.5]);
 }
 
 @end

--- a/KIF Tests/LandscapeTests.m
+++ b/KIF Tests/LandscapeTests.m
@@ -16,7 +16,7 @@
 - (void)beforeAll
 {
     [system simulateDeviceRotationToOrientation:UIDeviceOrientationLandscapeLeft];
-    [tester scrollViewWithAccessibilityLabel:@"Test Suite TableView" byFractionOfSizeHorizontal:0 vertical:-0.2];
+    [tester scrollViewWithAccessibilityIdentifier:@"Test Suite TableView" byFractionOfSizeHorizontal:0 vertical:-0.2];
 }
 
 - (void)afterAll

--- a/KIF Tests/TableViewTests.m
+++ b/KIF Tests/TableViewTests.m
@@ -26,26 +26,26 @@
 
 - (void)testTappingRows
 {
-    [tester tapRowInTableViewWithAccessibilityLabel:@"TableView Tests Table" atIndexPath:[NSIndexPath indexPathForRow:0 inSection:2]];
+    [tester tapRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:2] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"];
     [tester waitForViewWithAccessibilityLabel:@"Last Cell" traits:UIAccessibilityTraitSelected];
-    [tester tapRowInTableViewWithAccessibilityLabel:@"TableView Tests Table" atIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+    [tester tapRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"];
     [tester waitForViewWithAccessibilityLabel:@"First Cell" traits:UIAccessibilityTraitSelected];
 }
 
 - (void)testTappingLastRowAndSection
 {
-    [tester tapRowInTableViewWithAccessibilityLabel:@"TableView Tests Table" atIndexPath:[NSIndexPath indexPathForRow:-1 inSection:-1]];
+    [tester tapRowAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:-1] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"];
     [tester waitForViewWithAccessibilityLabel:@"Last Cell" traits:UIAccessibilityTraitSelected];
 }
 
 - (void)testOutOfBounds
 {
-    KIFExpectFailure([tester tapRowInTableViewWithAccessibilityLabel:@"TableView Tests Table" atIndexPath:[NSIndexPath indexPathForRow:0 inSection:99]]);
+    KIFExpectFailure([tester tapRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:99] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"]);
 }
 
 - (void)testUnknownTable
 {
-    KIFExpectFailure([[tester usingTimeout:1] tapRowInTableViewWithAccessibilityLabel:@"Unknown Table" atIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]]);
+    KIFExpectFailure([[tester usingTimeout:1] tapRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inTableViewWithAccessibilityIdentifier:@"Unknown Table"]);
 }
 
 @end

--- a/Test Host/en.lproj/MainStoryboard.storyboard
+++ b/Test Host/en.lproj/MainStoryboard.storyboard
@@ -185,7 +185,7 @@
                             </tableViewSection>
                         </sections>
                         <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Test Suite TableView"/>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Test Suite TableView"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="dataSource" destination="12" id="16"/>
@@ -949,7 +949,7 @@
                             </tableViewSection>
                         </sections>
                         <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="TableView Tests Table"/>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="TableView Tests Table"/>
                         </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="dataSource" destination="gLb-0u-HV7" id="bw7-CM-2IE"/>
@@ -1014,7 +1014,7 @@
                                         </subviews>
                                         <color key="backgroundColor" red="0.0" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Scroll View"/>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Scroll View"/>
                                         </userDefinedRuntimeAttributes>
                                     </scrollView>
                                 </subviews>


### PR DESCRIPTION
These views shouldn't really receive accessibility labels.  With iOS 5.0, they should be using accessibility identifiers.

I also adjusted the signature for table views to be more consistent with other methods.
