### PR TITLE
Mention correct environment variable.

### DIFF
--- a/Additions/UIApplication-KIFAdditions.h
+++ b/Additions/UIApplication-KIFAdditions.h
@@ -61,7 +61,7 @@ UIKIT_EXTERN NSString *const UIApplicationOpenedURLKey;
 
 /*!
  @abstract Writes a screenshot to disk.
- @discussion This method only works if the @c KIF_SCREENSHOT environment variable is set.
+ @discussion This method only works if the @c KIF_SCREENSHOTS environment variable is set.
  @param lineNumber The line number in the code at which the screenshot was taken.
  @param filename The name of the file in which the screenshot was taken.
  @param description An optional description of the scene being captured.

--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -114,7 +114,7 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
     NSString *outputPath = [[[NSProcessInfo processInfo] environment] objectForKey:@"KIF_SCREENSHOTS"];
     if (!outputPath) {
         if (error) {
-            *error = [NSError KIFErrorWithFormat:@"Screenshot path not defined.  Please set KIF_SCREENSHOT environment variable."];
+            *error = [NSError KIFErrorWithFormat:@"Screenshot path not defined. Please set KIF_SCREENSHOTS environment variable."];
         }
         return NO;
     }

--- a/Classes/KIFSystemTestActor.h
+++ b/Classes/KIFSystemTestActor.h
@@ -63,7 +63,7 @@
 
 /*!
  @abstract Captured a screenshot of the current screen and writes it to disk with an optional description.
- @discussion This step will fail if the @c KIF_SCREENSHOT environment variable is not set or if the screenshot cannot be written to disk.
+ @discussion This step will fail if the @c KIF_SCREENSHOTS environment variable is not set or if the screenshot cannot be written to disk.
  @param description A description to use when writing the file to disk.
  */
 - (void)captureScreenshotWithDescription:(NSString *)description;


### PR DESCRIPTION
In some comment and error messages, the environment variable was missing a character. 
