### PR TITLE
Replace newlines with spaces on iOS 7+

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -48,6 +48,10 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 
 + (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits error:(out NSError **)error;
 {
+    if ([[[UIDevice currentDevice] systemVersion] integerValue] >= 7) {
+        label = [label stringByReplacingOccurrencesOfString:@"\n" withString:@" "];
+    }
+    
     UIAccessibilityElement *element = [[UIApplication sharedApplication] accessibilityElementWithLabel:label accessibilityValue:value traits:traits];
     if (element || !error) {
         return element;

--- a/KIF Tests/WaitForViewTests.m
+++ b/KIF Tests/WaitForViewTests.m
@@ -18,6 +18,11 @@
     [tester waitForViewWithAccessibilityLabel:@"Test Suite"];
 }
 
+- (void)testWaitingForViewWithAccessibilityLabelWithNewlines
+{
+    [tester waitForViewWithAccessibilityLabel:@"Two\nLines"];
+}
+
 - (void)testWaitingForViewWithTraits
 {
     [tester waitForViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitStaticText];

--- a/Test Host/en.lproj/MainStoryboard.storyboard
+++ b/Test Host/en.lproj/MainStoryboard.storyboard
@@ -193,6 +193,10 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="Test Suite" id="36">
+                        <barButtonItem key="leftBarButtonItem" style="plain" id="da0-Z7-2SH">
+                            <string key="title">Two
+Lines</string>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" id="1dx-4R-qUX">
                             <switch key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="YCM-aH-b0t">
                                 <rect key="frame" x="238" y="8" width="79" height="27"/>


### PR DESCRIPTION
On iOS7, the system seems to replace newlines in accessibility labels with spaces.  This does the same in `accessibilityElementWithLabel:value:traits:error:` in order that users can test for the value that they set, and so their tests don't break when switching between 6 and 7.  Fixes #265.
