### PR TITLE
Suppress Xcode 5 compiler warning: undeclared selector '_touchesEvent'

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -517,7 +517,10 @@ typedef struct __GSEvent * GSEventRef;
 
 - (UIEvent *)_eventWithTouch:(UITouch *)touch;
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
     UIEvent *event = [[UIApplication sharedApplication] performSelector:@selector(_touchesEvent)];
+#pragma clang diagnostic pop
     
     CGPoint location = [touch locationInView:touch.window];
     KIFEventProxy *eventProxy = [[KIFEventProxy alloc] init];


### PR DESCRIPTION
Based on the same pull request for KIF v1 from paulz.
