### PR TITLE
Fix undeclared selector warning (shows up when installed via CocoaPods)

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -517,7 +517,7 @@ typedef struct __GSEvent * GSEventRef;
 
 - (UIEvent *)_eventWithTouch:(UITouch *)touch;
 {
-    UIEvent *event = [[UIApplication sharedApplication] performSelector:@selector(_touchesEvent)];
+    UIEvent *event = [[UIApplication sharedApplication] performSelector:NSSelectorFromString(@"_touchesEvent")];
     
     CGPoint location = [touch locationInView:touch.window];
     KIFEventProxy *eventProxy = [[KIFEventProxy alloc] init];

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -865,6 +865,7 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				DSTROOT = /tmp/KIF.dst;
 				FRAMEWORK_SEARCH_PATHS = "\"$(SDKROOT)/Developer/Library/Frameworks\"";
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = KIF;
 			};
@@ -876,6 +877,7 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				DSTROOT = /tmp/KIF.dst;
 				FRAMEWORK_SEARCH_PATHS = "\"$(SDKROOT)/Developer/Library/Frameworks\"";
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = KIF;
 			};
@@ -910,6 +912,7 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				DSTROOT = /tmp/KIF.dst;
 				FRAMEWORK_SEARCH_PATHS = "\"$(SDKROOT)/Developer/Library/Frameworks\"";
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = KIF;
 			};


### PR DESCRIPTION
This change avoids an undeclared selector warning for `_touchesEvent`. I also enabled the undeclared selectors warning in the project so that any future instances of this bubble up.

It was showing up in my project with KIF integrated via CocoaPods.

By the way, I think we are due for a 2.0.1 tag.
