### PR TITLE
Introduced a property on the test actor that can change the speed of animations

### DIFF
--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -130,8 +130,9 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
  @abstract Changes the speed of all the animations in the current set of Windows.
  @example A value of 2.0f causes all animations to run twice as fast. (1.0 is default)
  @note This speed factor also shortens the timeInterval in waitForTimeInterval:.
+ @note Controls that are presented in their own windows after this property is set is not affected by the animation speed (for example UIAlertView).
  */
-@property (nonatomic, assign) float animationSpeedFactor;
+@property (nonatomic, assign) float animationSpeed;
 
 @end
 

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -63,7 +63,7 @@
         _line = line;
         _delegate = delegate;
         _executionBlockTimeout = [[self class] defaultTimeout];
-        _animationSpeedFactor = 1.0f;
+        _animationSpeed = 1.0f;
     }
     return self;
 }
@@ -155,7 +155,9 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
 - (void)waitForTimeInterval:(NSTimeInterval)timeInterval
 {
     NSTimeInterval startTime = [NSDate timeIntervalSinceReferenceDate];
-    timeInterval /= self.animationSpeedFactor;
+    if (fabsf(self.animationSpeed - 1.0f) > FLT_EPSILON) {
+        timeInterval /= self.animationSpeed;
+    }
     
     [self runBlock:^KIFTestStepResult(NSError **error) {
         KIFTestWaitCondition((([NSDate timeIntervalSinceReferenceDate] - startTime) >= timeInterval), error, @"Waiting for time interval to expire.");
@@ -163,12 +165,12 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
     } timeout:timeInterval + 1];
 }
 
-- (void)setAnimationSpeedFactor:(float)speedFactor
+- (void)setAnimationSpeed:(float)animationSpeed
 {
-    _animationSpeedFactor = speedFactor;
+    _animationSpeed = animationSpeed;
     NSArray *allWindows = [UIApplication sharedApplication].windows;
     for (UIWindow *window in allWindows) {
-        window.layer.speed = speedFactor;
+        window.layer.speed = animationSpeed;
     }
 }
 

--- a/KIF Tests/FastAnimationTests.m
+++ b/KIF Tests/FastAnimationTests.m
@@ -1,0 +1,246 @@
+//
+//  FastAnimationTests.m
+//  KIF
+//
+//  Created by David Rönnqvist on 12/07/14.
+//
+//
+
+#import <KIF/KIF.h>
+#import <KIF/UIApplication-KIFAdditions.h>
+
+#import <KIF/KIFTestStepValidation.h> // for gesture tests
+
+/*!
+ Runs a mixture of table view tests at 5x animation speed
+ */
+
+@interface FastTableViewTests : KIFTestCase
+@end
+
+@implementation FastTableViewTests
+
+- (void)beforeEach
+{
+    [tester setAnimationSpeed:5.0]; // 5x the animation speed
+    [tester tapViewWithAccessibilityLabel:@"TableViews"];
+}
+
+- (void)afterEach
+{
+    [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
+    [tester setAnimationSpeed:1.0]; // restore to default
+}
+
+- (void)testSpeedUpSearchField
+{
+    [tester tapViewWithAccessibilityLabel:nil traits:UIAccessibilityTraitSearchField];
+    [tester waitForFirstResponderWithAccessibilityLabel:nil traits:UIAccessibilityTraitSearchField];
+    [tester enterTextIntoCurrentFirstResponder:@"text"];
+    [tester waitForViewWithAccessibilityLabel:nil value:@"text" traits:UIAccessibilityTraitSearchField];
+}
+
+
+- (void)testSpeedUpScrollingToTop
+{
+    [tester tapRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:2] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"];
+    [tester tapStatusBar];
+    
+    UITableView *tableView;
+    [tester waitForAccessibilityElement:NULL view:&tableView withIdentifier:@"TableView Tests Table" tappable:NO];
+    [tester runBlock:^KIFTestStepResult(NSError *__autoreleasing *error) {
+        KIFTestWaitCondition(tableView.contentOffset.y == - tableView.contentInset.top, error, @"Waited for scroll view to scroll to top, but it ended at %@", NSStringFromCGPoint(tableView.contentOffset));
+        return KIFTestStepResultSuccess;
+    }];
+}
+
+@end
+
+
+
+/*!
+ Runs the typing tests at 2x the animation speed
+ */
+
+@interface FastTypingTests : KIFTestCase
+@end
+
+@implementation FastTypingTests
+
+- (void)beforeEach
+{
+    [tester setAnimationSpeed:2.0]; // 2x the animation speed
+    [tester tapViewWithAccessibilityLabel:@"Tapping"];
+}
+
+- (void)afterEach
+{
+    [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
+    [tester setAnimationSpeed:1.0]; // restore to default
+}
+
+
+- (void)testWaitingForFirstResponder
+{
+    [tester tapViewWithAccessibilityLabel:@"Greeting" value:@"Hello" traits:UIAccessibilityTraitNone];
+    [tester waitForFirstResponderWithAccessibilityLabel:@"Greeting"];
+}
+
+- (void)testEnteringTextIntoFirstResponder
+{
+    [tester longPressViewWithAccessibilityLabel:@"Greeting" value:@"Hello" duration:2];
+    [tester tapViewWithAccessibilityLabel:@"Select All"];
+    [tester enterTextIntoCurrentFirstResponder:@"Yo"];
+    [tester waitForViewWithAccessibilityLabel:@"Greeting" value:@"Yo" traits:UIAccessibilityTraitNone];
+}
+
+- (void)testEnteringTextIntoViewWithAccessibilityLabel
+{
+    [tester longPressViewWithAccessibilityLabel:@"Greeting" value:@"Hello" duration:2];
+    [tester tapViewWithAccessibilityLabel:@"Select All"];
+    [tester tapViewWithAccessibilityLabel:@"Delete"];
+    [tester enterText:@"Yo" intoViewWithAccessibilityLabel:@"Greeting"];
+    [tester waitForViewWithAccessibilityLabel:@"Greeting" value:@"Yo" traits:UIAccessibilityTraitNone];
+}
+
+- (void)testEnteringTextIntoViewWithAccessibilityLabelExpectingResults
+{
+    [tester enterText:@", world" intoViewWithAccessibilityLabel:@"Greeting" traits:UIAccessibilityTraitNone expectedResult:@"Hello, world"];
+    [tester waitForViewWithAccessibilityLabel:@"Greeting" value:@"Hello, world" traits:UIAccessibilityTraitNone];
+}
+
+- (void)testClearingAndEnteringTextIntoViewWithAccessibilityLabel
+{
+    [tester clearTextFromAndThenEnterText:@"Yo" intoViewWithAccessibilityLabel:@"Greeting"];
+}
+
+- (void)testEnteringReturnCharacterIntoViewWithAccessibilityLabel
+{
+    [tester enterText:@"Hello\n" intoViewWithAccessibilityLabel:@"Other Text"];
+    [tester waitForFirstResponderWithAccessibilityLabel:@"Greeting"];
+    [tester enterText:@", world\n" intoViewWithAccessibilityLabel:@"Greeting" traits:UIAccessibilityTraitNone expectedResult:@"Hello, world"];
+}
+
+@end
+
+
+
+/*!
+ Runs the Tapping tests at 10x the animation speed
+ */
+
+@interface FastTappingTests : KIFTestCase
+@end
+
+@implementation FastTappingTests
+
+- (void)beforeEach
+{
+    [tester setAnimationSpeed:10.0]; // 10x the animation speed
+    [tester tapViewWithAccessibilityLabel:@"Tapping"];
+}
+
+- (void)afterEach
+{
+    [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
+    [tester setAnimationSpeed:1.0]; // restore do default
+}
+
+- (void)testTappingViewWithAccessibilityLabel
+{
+    // Since the tap has occurred in setup, we just need to wait for the result.
+    [tester waitForViewWithAccessibilityLabel:@"TapViewController"];
+}
+
+- (void)testTappingViewWithTraits
+{
+    [tester tapViewWithAccessibilityLabel:@"X" traits:UIAccessibilityTraitButton];
+    [tester waitForViewWithAccessibilityLabel:@"X" traits:UIAccessibilityTraitButton | UIAccessibilityTraitSelected];
+}
+
+- (void)testTappingViewWithValue
+{
+    [tester tapViewWithAccessibilityLabel:@"Greeting" value:@"Hello" traits:UIAccessibilityTraitNone];
+    [tester waitForFirstResponderWithAccessibilityLabel:@"Greeting"];
+}
+
+- (void)testTappingViewWithScreenAtPoint
+{
+    [tester waitForTimeInterval:0.75];
+    [tester tapScreenAtPoint:CGPointMake(15, 200)];
+    [tester waitForViewWithAccessibilityLabel:@"X" traits:UIAccessibilityTraitSelected];
+}
+
+- (void)testTappingViewPartiallyOffscreenAndWithinScrollView
+{
+    [tester tapViewWithAccessibilityLabel:@"Slightly Offscreen Button"];
+}
+
+@end
+
+
+
+/*!
+ Runs the gesture tests at 3.5x the animation speed
+ */
+
+@interface FastGestureTests : KIFTestCase
+@end
+
+@implementation FastGestureTests
+
+- (void)beforeAll
+{
+    [tester setAnimationSpeed:3.5]; // 3.5x the animation speed
+    [tester tapViewWithAccessibilityLabel:@"Gestures"];
+}
+
+- (void)afterAll
+{
+    [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
+    [tester setAnimationSpeed:1.0]; // restore do default
+}
+
+- (void)testSwipingLeft
+{
+    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" inDirection:KIFSwipeDirectionLeft];
+    [tester waitForViewWithAccessibilityLabel:@"Left"];
+}
+
+- (void)testSwipingRight
+{
+    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" inDirection:KIFSwipeDirectionRight];
+    [tester waitForViewWithAccessibilityLabel:@"Right"];
+}
+
+- (void)testSwipingUp
+{
+    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" inDirection:KIFSwipeDirectionUp];
+    [tester waitForViewWithAccessibilityLabel:@"Up"];
+}
+
+- (void)testSwipingDown
+{
+    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" inDirection:KIFSwipeDirectionDown];
+    [tester waitForViewWithAccessibilityLabel:@"Down"];
+}
+
+- (void)testMissingSwipeableElement
+{
+    KIFExpectFailure([[tester usingTimeout:0.25] swipeViewWithAccessibilityLabel:@"Unknown" inDirection:KIFSwipeDirectionDown]);
+}
+
+- (void)testScrolling
+{
+    [tester scrollViewWithAccessibilityIdentifier:@"Scroll View" byFractionOfSizeHorizontal:-0.9 vertical:-0.9];
+    [tester waitForTappableViewWithAccessibilityLabel:@"Bottom Right"];
+    [tester scrollViewWithAccessibilityIdentifier:@"Scroll View" byFractionOfSizeHorizontal:0.9 vertical:0.9];
+    [tester waitForTappableViewWithAccessibilityLabel:@"Top Left"];
+}
+
+- (void)testMissingScrollableElement
+{
+    KIFExpectFailure([[tester usingTimeout:0.25] scrollViewWithAccessibilityIdentifier:@"Unknown" byFractionOfSizeHorizontal:0.5 vertical:0.5]);
+}
+
+@end

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6F2EFBBA19713F390072E097 /* FastAnimationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F2EFBB919713F390072E097 /* FastAnimationTests.m */; };
 		A88930121685098E00FC7C63 /* KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A88930111685098E00FC7C63 /* KIF.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB02523E17AA109400A7D13A /* CompositionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EB02523D17AA109400A7D13A /* CompositionTests.m */; };
 		EB09001017E3696A00AA15B1 /* SearchFieldTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EB09000F17E3696A00AA15B1 /* SearchFieldTests.m */; };
@@ -96,6 +97,7 @@
 
 /* Begin PBXFileReference section */
 		39160B1013D1E6BB00311E38 /* LoadableCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadableCategory.h; sourceTree = "<group>"; };
+		6F2EFBB919713F390072E097 /* FastAnimationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FastAnimationTests.m; sourceTree = "<group>"; };
 		A88930111685098E00FC7C63 /* KIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIF.h; sourceTree = "<group>"; };
 		AAB0726B139719AC008AF393 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		AAB0728113971A63008AF393 /* KIF-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "KIF-Prefix.pch"; path = "Classes/KIF-Prefix.pch"; sourceTree = SOURCE_ROOT; };
@@ -365,6 +367,7 @@
 				EB22B5AF17AF52640090B848 /* CascadingFailureTests.m */,
 				EB9FC00417E144B700138266 /* LandscapeTests.m */,
 				EB09000F17E3696A00AA15B1 /* SearchFieldTests.m */,
+				6F2EFBB919713F390072E097 /* FastAnimationTests.m */,
 				EB60ECF0177F8DB3005A041A /* Supporting Files */,
 			);
 			path = "KIF Tests";
@@ -568,6 +571,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F2EFBBA19713F390072E097 /* FastAnimationTests.m in Sources */,
 				EB09001017E3696A00AA15B1 /* SearchFieldTests.m in Sources */,
 				EB22B5B017AF52640090B848 /* CascadingFailureTests.m in Sources */,
 				EB02523E17AA109400A7D13A /* CompositionTests.m in Sources */,


### PR DESCRIPTION
This can be used in `beforeEach:` and `afterEach:` to decrease execution
time by making animations run faster and not having to wait as long for
these animations to complete. 

Two example cases where this can matter are:
- orientation changes
- keyboard appearing 

Note that the current behaviour and wait durations are the same if this property not altered.
