### PR TITLE
Fix issue where first key tap is ignored or handled incorrectly

### DIFF
--- a/Classes/KIFTypist.h
+++ b/Classes/KIFTypist.h
@@ -11,5 +11,6 @@
 @interface KIFTypist : NSObject
 
 + (BOOL)enterCharacter:(NSString *)characterString;
++ (void)prepareKeyboardForTyping;
 
 @end

--- a/Classes/KIFTypist.m
+++ b/Classes/KIFTypist.m
@@ -36,6 +36,21 @@
     return [self _enterCharacter:characterString history:[NSMutableDictionary dictionary]];
 }
 
++ (void)prepareKeyboardForTyping;
+{
+    // Keyboard does not always repond to first touch properly. So prime it with some throwaway touches.
+    UIView *keyboardView = [self _keyboardView];
+    CGPoint corner = CGPointMake(10, keyboardView.frame.size.height - 10);
+    [keyboardView tapAtPoint:corner];
+    [keyboardView tapAtPoint:corner];
+}
+
++ (UIView *)_keyboardView;
+{
+    UIWindow *keyboardWindow = [[UIApplication sharedApplication] keyboardWindow];
+    return [[keyboardWindow subviewsWithClassNamePrefix:@"UIKBKeyplaneView"] lastObject];
+}
+
 + (BOOL)_enterCharacter:(NSString *)characterString history:(NSMutableDictionary *)history;
 {
     const NSTimeInterval keystrokeDelay = 0.05f;
@@ -46,8 +61,7 @@
         return YES;
     }
     
-    UIWindow *keyboardWindow = [[UIApplication sharedApplication] keyboardWindow];
-    UIView *keyboardView = [[keyboardWindow subviewsWithClassNamePrefix:@"UIKBKeyplaneView"] lastObject];
+    UIView *keyboardView = [self _keyboardView];
     
     // If we didn't find the standard keyboard view, then we may have a custom keyboard
     if (!keyboardView) {

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -256,6 +256,8 @@
 
 - (void)enterTextIntoCurrentFirstResponder:(NSString *)text fallbackView:(UIView *)fallbackView;
 {
+    [KIFTypist prepareKeyboardForTyping];
+    
     for (NSUInteger characterIndex = 0; characterIndex < [text length]; characterIndex++) {
         NSString *characterString = [text substringWithRange:NSMakeRange(characterIndex, 1)];
         


### PR DESCRIPTION
Under some conditions the keyboard does not process its first touch event properly. This causes characters to be mistyped or not typed at all. This pull request fixes the issue by tapping the keyboard twice in the bottom left corner before actual typing begins.

I suppose a less invasive fix might be possible, but I failed to come up with one that worked, and this one is at least simple and harmless.

The typing test suite passes with this change.
