### PR TITLE
Skip KIFTestCase itself when running tests.

### DIFF
--- a/Classes/KIFTestCase.m
+++ b/Classes/KIFTestCase.m
@@ -16,6 +16,16 @@
 
 @implementation KIFTestCase
 
++ (id)defaultTestSuite
+{
+    if (self == [KIFTestCase class]) {
+        // Don't run KIFTestCase "tests"
+        return nil;
+    }
+    
+    return [super defaultTestSuite];
+}
+
 - (id)initWithInvocation:(NSInvocation *)anInvocation;
 {
     self = [super initWithInvocation:anInvocation];


### PR DESCRIPTION
When executing tests, KIFTestCase gets listed in the output, despite not containing any tests. This change removes that minor annoyance. Works with both OCUnit and XCUnit.
