### PR TITLE
Changes to keyboard input delay

### DIFF
--- a/Classes/KIFTypist.h
+++ b/Classes/KIFTypist.h
@@ -11,6 +11,6 @@
 @interface KIFTypist : NSObject
 
 + (BOOL)enterCharacter:(NSString *)characterString;
-+ (void)setKeyboardDelay:(NSTimeInterval)delay;
++ (void)setKeystrokeDelay:(NSTimeInterval)delay;
 
 @end

--- a/Classes/KIFTypist.m
+++ b/Classes/KIFTypist.m
@@ -164,7 +164,7 @@ static NSTimeInterval keystrokeDelay = 0.1f;
     return YES;
 }
 
-+ (void)setKeyboardDelay:(NSTimeInterval)delay
++ (void)setKeystrokeDelay:(NSTimeInterval)delay
 {
     keystrokeDelay = delay;
 }


### PR DESCRIPTION
Increase default keyboard input delay to 0.1 seconds.
Add method to set default keyboard input delay.
fixes #363 
