### PR TITLE
Set the text of a UISearchBar if a keyboard character can't be found.

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -269,7 +269,7 @@
                 }
             }
             
-            if ([fallbackView isKindOfClass:[UITextField class]] || [fallbackView isKindOfClass:[UITextView class]]) {
+            if ([fallbackView isKindOfClass:[UITextField class]] || [fallbackView isKindOfClass:[UITextView class]] || [fallbackView isKindOfClass:[UISearchBar class]]) {
                 NSLog(@"KIF: Unable to find keyboard key for %@. Inserting manually.", characterString);
                 [(UITextField *)fallbackView setText:[[(UITextField *)fallbackView text] stringByAppendingString:characterString]];
             } else {


### PR DESCRIPTION
This seems to be related to #263. KIFUITestActor already manually sets the text
in a UITextField and a UITextView when a character cannot be found, so
this change includes UISearchBar as a view whose text can be manually
set if needed.

This workaround serves my purposes, so I figured I would share.

Just for some background, I'm having the "Failed to find key for character" error occur when entering text into a UISearchBar with ~340 items in its corresponding UITableView. I think @plu is correct is his assumptions about the search/core data delay.

Also, as a note, with a fresh clone of KIF for me, the LongPressTests failed in afterEach and in testLongPressingViewViewWithValue. After this change, all the tests passed except those same 2.
