### PR TITLE
Add a stabilization wait to tapRowAtIndexPath: and tapItemAtIndexPath:

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -553,6 +553,9 @@
     UITableViewCell *cell = [self waitForCellAtIndexPath:indexPath inTableView:tableView];
     CGRect cellFrame = [cell.contentView convertRect:cell.contentView.frame toView:tableView];
     [tableView tapAtPoint:CGPointCenteredInRect(cellFrame)];
+    
+    // Wait for the view to stabilize.
+    [tester waitForTimeInterval:0.5];
 }
 
 - (void)tapItemAtIndexPath:(NSIndexPath *)indexPath inCollectionViewWithAccessibilityIdentifier:(NSString *)identifier
@@ -569,6 +572,9 @@
     
     CGRect cellFrame = [cell.contentView convertRect:cell.contentView.frame toView:collectionView];
     [collectionView tapAtPoint:CGPointCenteredInRect(cellFrame)];
+    
+    // Wait for the view to stabilize.
+    [tester waitForTimeInterval:0.5];
 }
 
 - (void)swipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction


### PR DESCRIPTION
This is similar to what happens in `tapViewWithAccessibilityLabel:`. In an app that I'm testing, I sometimes get timing glitches without this. I figure if it is appropriate for `tapViewWithAccessibilityLabel:`, then it's appropriate for `tapRowAtIndexPath:` and `tapItemAtIndexPath:`.
