### PR TITLE
Changed KIFTestStepResult enum into new style NS_ENUM.

### DIFF
--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -59,12 +59,11 @@ return KIFTestStepResultWait; \
  @constant KIFTestStepResultSuccess The step succeeded and the test controller should move to the next step in the current scenario.
  @constant KIFTestStepResultWait The test isn't ready yet and should be tried again after a short delay.
  */
-enum {
+typedef NS_ENUM(NSUInteger, KIFTestStepResult) {
     KIFTestStepResultFailure = 0,
     KIFTestStepResultSuccess,
     KIFTestStepResultWait,
 };
-typedef NSInteger KIFTestStepResult;
 
 /*!
  @typedef KIFTestExecutionBlock


### PR DESCRIPTION
This change fixes a compilation problem while using XCTool to run a build. Apparently the compiler is unable to determine the correct return type of a block using said enum and causes a "incompatible block pointer types".
