### PR TITLE
makeElementsVisible property

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.h
+++ b/Additions/UIAccessibilityElement-KIFAdditions.h
@@ -29,10 +29,26 @@
  @param label The accessibility label of the element to wait for.
  @param value The accessibility value of the element to tap.
  @param traits The accessibility traits of the element to wait for. Elements that do not include at least these traits are ignored.
+ @param tappable @c YES if the element must be tappable.
  @param error A reference to an error object to be populated when no matching element or view is found.  Can be @c NULL.
  @result @c YES if the element and view were found.  Otherwise @c NO.
  */
 + (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits tappable:(BOOL)mustBeTappable error:(out NSError **)error;
+
+/*!
+ @abstract Finds an accessibility element and view with a matching label, value, and traits, optionally passing a tappability test and making it visible.
+ @discussion This method combines @c +accessibilityElementWithLabel:value:traits:error: and @c +viewContainingAccessibilityElement:tappable:error: for convenience.
+ @param foundElement The found accessibility element or @c nil if the method returns @c NO.  Can be @c NULL.
+ @param foundView The first matching view for @c foundElement as determined by the accessibility API or @c nil if the view is hidden or fails the tappability test. Can be @c NULL.
+ @param label The accessibility label of the element to wait for.
+ @param value The accessibility value of the element to tap.
+ @param traits The accessibility traits of the element to wait for. Elements that do not include at least these traits are ignored.
+ @param tappable @c YES if the element must be tappable.
+ @param makeVisible If @c YES, attempt to make element visible by scrolling it into view.
+ @param error A reference to an error object to be populated when no matching element or view is found.  Can be @c NULL.
+ @result @c YES if the element and view were found.  Otherwise @c NO.
+ */
++ (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits tappable:(BOOL)mustBeTappable makeVisible:(BOOL)makeVisible error:(out NSError **)error;
 
 /*!
  @abstract Finds an accessibility element with a matching label, value, and traits.
@@ -55,5 +71,17 @@
  @return The first matching view as determined by the accessibility API or nil if the view is hidden or fails the tappability test.
  */
 + (UIView *)viewContainingAccessibilityElement:(UIAccessibilityElement *)element tappable:(BOOL)mustBeTappable error:(NSError **)error;
+
+/*!
+ @abstract Finds a view for a given accessibility element.
+ @discussion If the element is found, off screen, and is inside a scroll view, this method will attempt to programmatically scroll the view onto the screen before performing any logic as to if the view is tappable.
+ 
+ @param element The accessibility element.
+ @param mustBeTappable If @c YES, a tappability test will be performed.
+ @param makeVisible If @c YES, attempt to make element visible by scrolling it into view.
+ @param error A reference to an error object to be populated when no element is found.  Can be @c NULL.
+ @return The first matching view as determined by the accessibility API or nil if the view is hidden or fails the tappability test.
+ */
++ (UIView *)viewContainingAccessibilityElement:(UIAccessibilityElement *)element tappable:(BOOL)mustBeTappable makeVisible:(BOOL)makeVisible error:(NSError **)error;
 
 @end

--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -83,6 +83,7 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 
 @interface KIFTestActor : NSObject
 
+- (instancetype)initWithFile:(NSString *)file line:(NSInteger)line delegate:(id<KIFTestActorDelegate>)delegate;
 + (instancetype)actorInFile:(NSString *)file atLine:(NSInteger)line delegate:(id<KIFTestActorDelegate>)delegate;
 
 @property (strong, nonatomic, readonly) NSString *file;

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -62,6 +62,8 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 
 @interface KIFUITestActor : KIFTestActor
 
+@property (nonatomic) BOOL makeElementsVisible;
+
 /*!
  @abstract Waits until a view or accessibility element is present.
  @discussion The view or accessibility element with the given label is found in the view hierarchy. If the element isn't found, then the step will attempt to wait until it is. Note that the view does not necessarily have to be visible on the screen, and may be behind another view or offscreen. Views with their hidden property set to YES are ignored.

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -26,6 +26,15 @@
     }
 }
 
+- (instancetype)initWithFile:(NSString *)file line:(NSInteger)line delegate:(id<KIFTestActorDelegate>)delegate
+{
+    self = [super initWithFile:file line:line delegate:delegate];
+    if (self) {
+        _makeElementsVisible = YES;
+    }
+    return self;
+}
+
 - (UIView *)waitForViewWithAccessibilityLabel:(NSString *)label
 {
     return [self waitForViewWithAccessibilityLabel:label value:nil traits:UIAccessibilityTraitNone tappable:NO];
@@ -66,7 +75,7 @@
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits tappable:(BOOL)mustBeTappable
 {
     [self runBlock:^KIFTestStepResult(NSError **error) {
-        return [UIAccessibilityElement accessibilityElement:element view:view withLabel:label value:value traits:traits tappable:mustBeTappable error:error] ? KIFTestStepResultSuccess : KIFTestStepResultWait;
+        return [UIAccessibilityElement accessibilityElement:element view:view withLabel:label value:value traits:traits tappable:mustBeTappable makeVisible:_makeElementsVisible error:error] ? KIFTestStepResultSuccess : KIFTestStepResultWait;
     }];
 }
 
@@ -88,7 +97,7 @@
         
         KIFTestWaitCondition(foundElement, error, @"Could not find view matching: %@", predicate);
         
-        UIView *foundView = [UIAccessibilityElement viewContainingAccessibilityElement:foundElement tappable:mustBeTappable error:error];
+        UIView *foundView = [UIAccessibilityElement viewContainingAccessibilityElement:foundElement tappable:mustBeTappable makeVisible:_makeElementsVisible error:error];
         if (!foundView) {
             return KIFTestStepResultWait;
         }


### PR DESCRIPTION
KIF automatically scrolls elements into view. Sometimes this causes major issues because of numerous `UIScrollView` bugs. This pull request adds a `makeElementsVisible` property to `KIFUITestActor`. The default is `YES`. When set to `NO`, the automatic scrolling is disabled.

I considered creating a bunch of new `waitForElement` methods with a `makeVisible` argument, but this would really balloon `KIFUITestActor`. Since most users will not need to disable scrolling, using an unobtrusive property seemed like a better approach.

Let me know if this pull request is acceptable to everyone.
