### PR TITLE
fix analyzer warnings

### DIFF
--- a/Additions/UITableView-KIFAdditions.h
+++ b/Additions/UITableView-KIFAdditions.h
@@ -11,6 +11,6 @@
 
 @interface UITableView (KIFAdditions)
 
-- (void)dragCell:(UITableViewCell *)cell toIndexPath:(NSIndexPath *)indexPath error:(NSError **)error;
+- (BOOL)dragCell:(UITableViewCell *)cell toIndexPath:(NSIndexPath *)indexPath error:(NSError **)error;
 
 @end

--- a/Additions/UITableView-KIFAdditions.m
+++ b/Additions/UITableView-KIFAdditions.m
@@ -18,12 +18,14 @@
 
 #define DRAG_STEP_DISTANCE 5
 
-- (void)dragCell:(UITableViewCell *)cell toIndexPath:(NSIndexPath *)indexPath error:(NSError **)error;
+- (BOOL)dragCell:(UITableViewCell *)cell toIndexPath:(NSIndexPath *)indexPath error:(NSError **)error;
 {
     UIView *sourceReorderControl = [[cell subviewsWithClassNameOrSuperClassNamePrefix:@"UITableViewCellReorderControl"] lastObject];
     if (!sourceReorderControl) {
-        *error = [NSError KIFErrorWithFormat:@"Failed to find reorder control for cell"];
-        return;
+        if (error) {
+            *error = [NSError KIFErrorWithFormat:@"Failed to find reorder control for cell"];
+        }
+        return NO;
     }
     
     CGPoint sourcePoint = [self convertPoint:CGPointCenteredInRect(sourceReorderControl.bounds) fromView:sourceReorderControl];
@@ -79,6 +81,7 @@
     if (touch.view == self && [self canBecomeFirstResponder]) {
         [self becomeFirstResponder];
     }
+    return YES;
 }
 
 @end

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -836,8 +836,7 @@
     UITableViewCell *cell = [self waitForCellAtIndexPath:sourceIndexPath inTableView:tableView];
     
     NSError *error = nil;
-    [tableView dragCell:cell toIndexPath:destinationIndexPath error:&error];
-    if (error) {
+    if (![tableView dragCell:cell toIndexPath:destinationIndexPath error:&error]) {
         [self failWithError:error stopTest:YES];
     }
 }


### PR DESCRIPTION
Method accepting NSError*\* should have a non-void return value to indicate whether or not an error occurred
Potential null dereference.  According to coding standards in 'Creating and Returning NSError Objects' the parameter may be null
