### PR TITLE
Prevent KIF steps from unnecessarily waiting too long

### DIFF
--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -111,6 +111,19 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 + (void)setDefaultTimeout:(NSTimeInterval)newDefaultTimeout;
 
 /*!
+ @method stepDelay
+ @abstract The amount of time that execution blocks use before trying again to met desired conditions.
+ @discussion To change the default value of the step delay property, call +setStepDelay: with a different value.
+ */
++ (NSTimeInterval)stepDelay;
+
+/*!
+ @method setStepDelay:
+ @abstract Sets the amount of time that execution blocks use before trying again to met desired conditions.
+ */
++ (void)setStepDelay:(NSTimeInterval)newStepDelay;
+
+/*!
  @abstract Fails the test.
  @discussion Mostly useful for test debugging or as a placeholder when building new tests.
  */

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -99,7 +99,7 @@
         NSError *error = nil;
         
         while ((result = executionBlock(&error)) == KIFTestStepResultWait && -[startDate timeIntervalSinceNow] < timeout) {
-            CFRunLoopRunInMode([[UIApplication sharedApplication] currentRunLoopMode] ?: kCFRunLoopDefaultMode, 0.1, false);
+            CFRunLoopRunInMode([[UIApplication sharedApplication] currentRunLoopMode] ?: kCFRunLoopDefaultMode, KIFTestStepDelay, false);
         }
         
         if (result == KIFTestStepResultWait) {
@@ -136,6 +136,7 @@
 #pragma mark Class Methods
 
 static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
+static NSTimeInterval KIFTestStepDelay = 0.1;
 
 + (NSTimeInterval)defaultTimeout;
 {
@@ -145,6 +146,16 @@ static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
 + (void)setDefaultTimeout:(NSTimeInterval)newDefaultTimeout;
 {
     KIFTestStepDefaultTimeout = newDefaultTimeout;
+}
+
++ (NSTimeInterval)stepDelay;
+{
+    return KIFTestStepDelay;
+}
+
++ (void)setStepDelay:(NSTimeInterval)newStepDelay;
+{
+    KIFTestStepDelay = newStepDelay;
 }
 
 #pragma mark Generic tests


### PR DESCRIPTION
This was already discussed in https://github.com/kif-framework/KIF/pull/351
I though it was a nice to have, so I implemented it.
