### PR TITLE
Let 'waitForCellAtIndexPath' actually wait for a cell at a given index p...

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -732,37 +732,34 @@
     if (![tableView isKindOfClass:[UITableView class]]) {
         [self failWithError:[NSError KIFErrorWithFormat:@"View is not a table view"] stopTest:YES];
     }
-    
-    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-    
+
     // If section < 0, search from the end of the table.
     if (indexPath.section < 0) {
         indexPath = [NSIndexPath indexPathForRow:indexPath.row inSection:tableView.numberOfSections + indexPath.section];
     }
-    
+
     // If row < 0, search from the end of the section.
     if (indexPath.row < 0) {
         indexPath = [NSIndexPath indexPathForRow:[tableView numberOfRowsInSection:indexPath.section] + indexPath.row inSection:indexPath.section];
     }
-    
-    if (!cell) {
-        if (indexPath.section >= tableView.numberOfSections) {
-            [self failWithError:[NSError KIFErrorWithFormat:@"Section %d is not found in table view", (int)indexPath.section] stopTest:YES];
-        }
-        
-        if (indexPath.row >= [tableView numberOfRowsInSection:indexPath.section]) {
-            [self failWithError:[NSError KIFErrorWithFormat:@"Row %d is not found in section %d of table view", (int)indexPath.row, (int)indexPath.section] stopTest:YES];
-        }
-        
-        [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionMiddle animated:YES];
-        [self waitForTimeInterval:0.5];
-        cell = [tableView cellForRowAtIndexPath:indexPath];
-    }
-    
+
+    [self runBlock:^KIFTestStepResult(NSError **error) {
+
+        KIFTestWaitCondition(indexPath.section < tableView.numberOfSections, error, @"Section %ld is not found in table view", (long)indexPath.section);
+
+        KIFTestWaitCondition(indexPath.row < [tableView numberOfRowsInSection:indexPath.section], error, @"Row %ld is not found in section %ld of table view", (long)indexPath.row, (long)indexPath.section);
+
+        return KIFTestStepResultSuccess;
+    }];
+
+    [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionMiddle animated:YES];
+    [self waitForTimeInterval:0.5];
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+
     if (!cell) {
         [self failWithError:[NSError KIFErrorWithFormat: @"Table view cell at index path %@ not found", indexPath] stopTest:YES];
     }
-    
+
     return cell;
 }
 
@@ -791,23 +788,28 @@
     if (item < 0) {
         item += [collectionView numberOfItemsInSection:section];
     }
-    
-    if (section >= collectionView.numberOfSections) {
-        [self failWithError:[NSError KIFErrorWithFormat:@"Section %d is not found in collection view", (int)section] stopTest:YES];
-    }
-    
-    if (item >= [collectionView numberOfItemsInSection:section]) {
-        [self failWithError:[NSError KIFErrorWithFormat:@"Item %d is not found in section %d of collection view", (int)item, (int)section] stopTest:YES];
-    }
-    
+
     indexPath = [NSIndexPath indexPathForItem:item inSection:section];
-    [collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally | UICollectionViewScrollPositionCenteredVertically animated:YES];
+
+    [self runBlock:^KIFTestStepResult(NSError **error) {
+
+        KIFTestWaitCondition(indexPath.section < collectionView.numberOfSections, error, @"Section %ld is not found in collection view", (long)indexPath.section);
+
+        KIFTestWaitCondition(indexPath.row < [collectionView numberOfItemsInSection:indexPath.section], error, @"Item %ld is not found in section %ld of collection view", (long)indexPath.row, (long)indexPath.section);
+
+        return KIFTestStepResultSuccess;
+    }];
+
+    [collectionView scrollToItemAtIndexPath:indexPath
+                           atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally | UICollectionViewScrollPositionCenteredVertically
+                                   animated:YES];
     [self waitForTimeInterval:0.5];
     UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
-    
+
     if (!cell) {
         [self failWithError:[NSError KIFErrorWithFormat: @"Collection view cell at index path %@ not found", indexPath] stopTest:YES];
     }
+
     return cell;
 }
 


### PR DESCRIPTION
...ath

This pull request gives more flexibility when dealing with tableviews and collectionviews.
In our application we usually show an empty tableview, where the content is updated through a web request.
Currently on KIF the method waits only the tableview, assuming that if we have the table view, we should have also the cell, that's not always true, indeed in our application it always result on "cell not found" error.
I expanded the method to actually wait for an existent cell at a given index path.
