### PR TITLE
Fixed frame calculation for view to tap in a custom keyboard

### DIFF
--- a/Classes/KIFTypist.m
+++ b/Classes/KIFTypist.m
@@ -201,7 +201,7 @@ static NSTimeInterval keystrokeDelay = 0.1f;
     }
     
     UIView *view = [UIAccessibilityElement viewContainingAccessibilityElement:element];
-    CGRect keyFrame = [view.window convertRect:[element accessibilityFrame] toView:view];
+    CGRect keyFrame = [view.windowOrIdentityWindow convertRect:[element accessibilityFrame] toView:view];
     [view tapAtPoint:CGPointCenteredInRect(keyFrame)];
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, keystrokeDelay, false);
     


### PR DESCRIPTION
This prevents wrong frame calculation for elements to tap in a custom keyboard on landscape orientation.
