### PR TITLE
Added support for UISegmentedControl(s)

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -308,6 +308,14 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 - (void)setOn:(BOOL)switchIsOn forSwitchWithAccessibilityLabel:(NSString *)label;
 
 /*!
+ @abstract Change selected segment with a specified index
+ @discussion The UISegmentedControl with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present, the step will return if it's already in the desired position.
+ @param index The desired index of the UISegmentedControl.
+ @param label The accessibility label of the element to change.
+ */
+- (void)setIndex:(NSInteger)index forSegmentedControlWithAccessibilityLabel:(NSString *)label;
+
+/*!
  @abstract Slides a UISlider to a specified value.
  @discussion The UISlider with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present, the step will attempt to drag the slider to the new value.  The step will fail if it finds a view with the given accessibility label that is not a UISlider or if value is outside of the possible values.  Because this step simulates drag events, the value reached may not be the exact value requested and the app may ignore the touch events if the movement is less than the drag gesture recognizer's minimum distance.
  @param value The desired value of the UISlider.

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -509,6 +509,34 @@
     }
 }
 
+- (void)setIndex:(NSInteger)index forSegmentedControlWithAccessibilityLabel:(NSString *)label
+{
+    UISegmentedControl *segmentedControlView = nil;
+    UIAccessibilityElement *element = nil;
+
+
+    [self waitForAccessibilityElement:&element view:&segmentedControlView withLabel:label value:nil traits:UIAccessibilityTraitNone tappable:YES];
+
+    if (![segmentedControlView isKindOfClass:[UISegmentedControl class]]) {
+        [self failWithError:[NSError KIFErrorWithFormat:@"View with accessibility label \"%@\" is a %@, not a UISegmentedControl", label, NSStringFromClass([segmentedControlView class])] stopTest:YES];
+    }
+
+    // No need to switch it if it's already in the correct position
+    if (segmentedControlView.selectedSegmentIndex == index) {
+        return;
+    }
+
+    NSLog(@"Faking setting segmented control index %ld with accessibility label %@", (long)index, label);
+    [segmentedControlView setSelectedSegmentIndex:index];
+    [segmentedControlView sendActionsForControlEvents:UIControlEventValueChanged];
+    [self waitForTimeInterval:0.5];
+
+    // We gave it our best shot.  Fail the test.
+    if (segmentedControlView.selectedSegmentIndex != index) {
+        [self failWithError:[NSError KIFErrorWithFormat:@"Failed to change selected segment to \"%ld\"; instead, it was \"%ld\"", (long)index, (long)segmentedControlView.selectedSegmentIndex] stopTest:YES];
+    }
+}
+
 - (void)setValue:(float)value forSliderWithAccessibilityLabel:(NSString *)label
 {
     UISlider *slider = nil;


### PR DESCRIPTION
It adds support for segmented control.

An alternative would be to pass the accessibilityLabel of the UISegment to tap (UISegmentedControl contains  one or more more UISegment), but since there is not public API to set an accessibilityLabel to a particular UISegment, I preferred to just specify an index to tap.
