### PR TITLE
Prefer 'view' method over 'accessibilityContainer'

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -25,10 +25,9 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     while (element && ![element isKindOfClass:[UIView class]]) {
         // Sometimes accessibilityContainer will return a view that's too far up the view hierarchy
         // UIAccessibilityElement instances will sometimes respond to view, so try to use that and then fall back to accessibilityContainer
-        // This workaround is only used for UISwitch, other classes still use accessibilityContainer to get the containing view
         id view = [element respondsToSelector:@selector(view)] ? [(id)element view] : nil;
         
-        if (view && [view isKindOfClass:[UISwitch class]]) {
+        if (view) {
             element = view;
         } else {
             element = [element accessibilityContainer];

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -131,9 +131,9 @@
         
         // If we found an element, but it's not associated with a view, then something's wrong. Wait it out and try again.
         KIFTestWaitCondition(view, error, @"Cannot find view containing accessibility element with the label \"%@\"", label);
-        
+
         // Hidden views count as absent
-        KIFTestWaitCondition([view isHidden], error, @"Accessibility element with label \"%@\" is visible and not hidden.", label);
+        KIFTestWaitCondition([view isHidden] || [view superview] == nil, error, @"Accessibility element with label \"%@\" is visible and not hidden.", label);
         
         return KIFTestStepResultSuccess;
     }];

--- a/KIF Tests/TableViewTests.m
+++ b/KIF Tests/TableViewTests.m
@@ -8,6 +8,7 @@
 
 #import <KIF/KIF.h>
 #import "KIFTestStepValidation.h"
+#import "UIApplication-KIFAdditions.h"
 
 @interface TableViewTests : KIFTestCase
 @end
@@ -26,7 +27,7 @@
 
 - (void)testTappingRows
 {
-    [tester tapRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:2] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"];
+    [tester tapRowAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:2] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"];
     [tester waitForViewWithAccessibilityLabel:@"Last Cell" traits:UIAccessibilityTraitSelected];
     [tester tapRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"];
     [tester waitForViewWithAccessibilityLabel:@"First Cell" traits:UIAccessibilityTraitSelected];
@@ -122,6 +123,27 @@
 {
     [tester setOn:NO forSwitchWithAccessibilityLabel:@"Table View Switch"];
     [tester setOn:YES forSwitchWithAccessibilityLabel:@"Table View Switch"];
+}
+
+- (void)testButtonAbsentAfterRemoveFromSuperview
+{
+    [tester waitForViewWithAccessibilityLabel:@"Button"];
+    UIAccessibilityElement *element = [[UIApplication sharedApplication] accessibilityElementWithLabel:@"Button" accessibilityValue:nil traits:0];
+
+    [[(id)element view] removeFromSuperview];
+    [tester waitForAbsenceOfViewWithAccessibilityLabel:@"Button"];
+}
+
+- (void)testButtonAbsentAfterSetHidden
+{
+    [tester waitForViewWithAccessibilityLabel:@"Button"];
+    UIAccessibilityElement *element = [[UIApplication sharedApplication] accessibilityElementWithLabel:@"Button" accessibilityValue:nil traits:0];
+
+    [[(id)element view] setHidden:YES];
+    [tester waitForAbsenceOfViewWithAccessibilityLabel:@"Button"];
+
+    [[(id)element view] setHidden:NO];
+    [tester waitForViewWithAccessibilityLabel:@"Button"];
 }
 
 @end

--- a/Test Host/en.lproj/MainStoryboard.storyboard
+++ b/Test Host/en.lproj/MainStoryboard.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" variant="6xAndEarlier" propertyAccessControl="none" initialViewController="3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="5056" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" variant="6xAndEarlier" propertyAccessControl="none" initialViewController="3">
     <dependencies>
         <deployment defaultVersion="1552" identifier="iOS"/>
         <development version="4600" identifier="xcode"/>
@@ -1013,8 +1013,31 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Section-3" id="TFu-FW-SYg">
                                 <cells>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="bSs-19-a1f" style="IBUITableViewCellStyleDefault" id="qeS-3T-ucP">
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="36z-vc-3xL">
                                         <rect key="frame" x="0.0" y="1870" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="dd2-Fw-Lzg">
+                                                    <rect key="frame" x="11" y="8" width="72" height="29"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                                    <state key="normal" title="Button">
+                                                        <color key="titleColor" red="0.19607843137254902" green="0.30980392156862746" blue="0.52156862745098043" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <state key="highlighted">
+                                                        <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                </button>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="bSs-19-a1f" style="IBUITableViewCellStyleDefault" id="qeS-3T-ucP">
+                                        <rect key="frame" x="0.0" y="1914" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>


### PR DESCRIPTION
accessibilityContainer seems to return the superview even if there is no superview available
