### PR TITLE
Wrap all run loop spins in an autoreleasepool block

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -14,6 +14,7 @@
 #import "UIView-KIFAdditions.h"
 #import "LoadableCategory.h"
 #import "KIFTestActor.h"
+#import "KIFRunLoop.h"
 
 MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 
@@ -115,7 +116,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
             }
             
             // Give the scroll view a small amount of time to perform the scroll.
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.3, false);
+            KIFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.3, false);
         }
         
         superview = superview.superview;

--- a/Additions/UIScrollView-KIFAdditions.m
+++ b/Additions/UIScrollView-KIFAdditions.m
@@ -11,7 +11,7 @@
 #import "LoadableCategory.h"
 #import "UIApplication-KIFAdditions.h"
 #import "UIView-KIFAdditions.h"
-
+#import "KIFRunLoop.h"
 
 MAKE_CATEGORIES_LOADABLE(UIScrollView_KIFAdditions)
 
@@ -37,7 +37,7 @@ MAKE_CATEGORIES_LOADABLE(UIScrollView_KIFAdditions)
     
     if (!CGPointEqualToPoint(contentOffset, self.contentOffset)) {
         [self setContentOffset:contentOffset animated:animated];
-        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.2, false);
+        KIFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.2, false);
     }
 }
 

--- a/Additions/UITableView-KIFAdditions.m
+++ b/Additions/UITableView-KIFAdditions.m
@@ -13,6 +13,7 @@
 #import "UITouch-KIFAdditions.h"
 #import "CGGeometry-KIFAdditions.h"
 #import "NSError-KIFAdditions.h"
+#import "KIFRunLoop.h"
 
 @implementation UITableView (KIFAdditions)
 
@@ -50,7 +51,7 @@
     [[UIApplication sharedApplication] sendEvent:eventDown];
     
     // Hold long enough to enter reordering mode
-    CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.2, false);
+    KIFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.2, false);
     
     CGPoint currentLocation = sourcePoint;
     while (currentLocation.y < destinationPoint.y - DRAG_STEP_DISTANCE || currentLocation.y > destinationPoint.y + DRAG_STEP_DISTANCE) {
@@ -66,11 +67,11 @@
         UIEvent *eventDrag = [self eventWithTouch:touch];
         [[UIApplication sharedApplication] sendEvent:eventDrag];
         
-        CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.01, false);
+        KIFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.01, false);
     }
     
     // Hold long enough for the animations to catch up
-    CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.2, false);
+    KIFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.2, false);
     
     [touch setPhaseAndUpdateTimestamp:UITouchPhaseEnded];
     

--- a/Classes/KIFRunLoop.h
+++ b/Classes/KIFRunLoop.h
@@ -1,0 +1,3 @@
+#import <Foundation/Foundation.h>
+
+SInt32 KIFRunLoopRunInMode(CFStringRef mode, CFTimeInterval seconds, Boolean returnAfterSourceHandled);

--- a/Classes/KIFRunLoop.m
+++ b/Classes/KIFRunLoop.m
@@ -1,0 +1,9 @@
+#import "KIFRunLoop.h"
+
+SInt32 KIFRunLoopRunInMode(CFStringRef mode, CFTimeInterval seconds, Boolean returnAfterSourceHandled) {
+  SInt32 result;
+    @autoreleasepool {
+        result = CFRunLoopRunInMode(mode, seconds, returnAfterSourceHandled);
+    }
+    return result;
+}

--- a/Classes/KIFSystemTestActor.m
+++ b/Classes/KIFSystemTestActor.m
@@ -11,6 +11,7 @@
 #import <UIKit/UIKit.h>
 #import "UIApplication-KIFAdditions.h"
 #import "NSError-KIFAdditions.h"
+#import "KIFRunLoop.h"
 
 @implementation KIFSystemTestActor
 
@@ -62,7 +63,7 @@
             dispatch_semaphore_signal(semaphore);
         }];
         while (dispatch_semaphore_wait(semaphore, DISPATCH_TIME_NOW)) {
-            CFRunLoopRunInMode([[UIApplication sharedApplication] currentRunLoopMode] ?: kCFRunLoopDefaultMode, 0.1, false);
+            KIFRunLoopRunInMode([[UIApplication sharedApplication] currentRunLoopMode] ?: kCFRunLoopDefaultMode, 0.1, false);
         }
     } else {
         [[UIApplication sharedApplication] rotateIfNeeded:orientation];

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -15,6 +15,7 @@
 #endif
 
 #import "KIFTestActor.h"
+#import "KIFRunLoop.h"
 #import "NSError-KIFAdditions.h"
 #import <dlfcn.h>
 #import <objc/runtime.h>
@@ -99,7 +100,7 @@
         NSError *error = nil;
         
         while ((result = executionBlock(&error)) == KIFTestStepResultWait && -[startDate timeIntervalSinceNow] < timeout) {
-            CFRunLoopRunInMode([[UIApplication sharedApplication] currentRunLoopMode] ?: kCFRunLoopDefaultMode, KIFTestStepDelay, false);
+            KIFRunLoopRunInMode([[UIApplication sharedApplication] currentRunLoopMode] ?: kCFRunLoopDefaultMode, KIFTestStepDelay, false);
         }
         
         if (result == KIFTestStepResultWait) {

--- a/Classes/KIFTypist.m
+++ b/Classes/KIFTypist.m
@@ -8,6 +8,7 @@
 //  which Square, Inc. licenses this file to you.
 
 #import "KIFTypist.h"
+#import "KIFRunLoop.h"
 #import "UIApplication-KIFAdditions.h"
 #import "UIView-KIFAdditions.h"
 #import "CGGeometry-KIFAdditions.h"
@@ -154,15 +155,15 @@ static NSTimeInterval keystrokeDelay = 0.1f;
     
     if (keyToTap) {
         [keyboardView tapAtPoint:CGPointCenteredInRect([keyToTap frame])];
-        CFRunLoopRunInMode(kCFRunLoopDefaultMode, keystrokeDelay, false);
-        
+
+        KIFRunLoopRunInMode(kCFRunLoopDefaultMode, keystrokeDelay, false);
         return YES;
     }
     
     // We didn't find anything, so try the symbols pane
     if (modifierKey) {
         [keyboardView tapAtPoint:CGPointCenteredInRect([modifierKey frame])];
-        CFRunLoopRunInMode(kCFRunLoopDefaultMode, keystrokeDelay, false);
+        KIFRunLoopRunInMode(kCFRunLoopDefaultMode, keystrokeDelay, false);
         
         // If we're back at a place we've been before, and we still have things to explore in the previous
         id /*UIKBKeyplane*/ newKeyplane = [keyboardView valueForKey:@"keyplane"];
@@ -203,8 +204,7 @@ static NSTimeInterval keystrokeDelay = 0.1f;
     UIView *view = [UIAccessibilityElement viewContainingAccessibilityElement:element];
     CGRect keyFrame = [view.windowOrIdentityWindow convertRect:[element accessibilityFrame] toView:view];
     [view tapAtPoint:CGPointCenteredInRect(keyFrame)];
-    CFRunLoopRunInMode(kCFRunLoopDefaultMode, keystrokeDelay, false);
-    
+    KIFRunLoopRunInMode(kCFRunLoopDefaultMode, keystrokeDelay, false);
     return YES;
 }
 

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -15,6 +15,7 @@
 #import "UITableView-KIFAdditions.h"
 #import "CGGeometry-KIFAdditions.h"
 #import "NSError-KIFAdditions.h"
+#import "KIFRunLoop.h"
 #import "KIFTypist.h"
 
 @implementation KIFUITestActor
@@ -439,7 +440,7 @@
 
                 if ([rowTitle isEqual:pickerColumnValues[componentIndex]]) {
                     [pickerView selectRow:rowIndex inComponent:componentIndex animated:false];
-                    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
+                    KIFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
 
                     // Tap in the middle of the picker view to select the item
                     [pickerView tap];
@@ -543,7 +544,7 @@
     }
     UIView *dimmingView = [[window subviewsWithClassNamePrefix:@"UIDimmingView"] lastObject];
     [dimmingView tapAtPoint:CGPointMake(50.0f, 50.0f)];
-    CFRunLoopRunInMode(kCFRunLoopDefaultMode, tapDelay, false);
+    KIFRunLoopRunInMode(kCFRunLoopDefaultMode, tapDelay, false);
 }
 
 - (void)choosePhotoInAlbum:(NSString *)albumName atRow:(NSInteger)row column:(NSInteger)column


### PR DESCRIPTION
This increases the realism of KIF tests. 

Normally, it appears `CFRunLoop` wraps each run loop iteration in an autorelease pool (via a symbol named `_wrapRunLoopWithAutoreleasePoolHandler`). However, since KIF explicitly spins the run loop from within `XCTestCase`'s internals, it looks like `CFRunLoop` notices that there's already a pushed autorelease pool and does not push an additional one. As a result, objects that would normally be added to the run loop's autorelease pool and released at the end of the loop end up added to the `XCTestCase`'s pool instead, and then aren't deallocated until the end of the test.

Keeping these objects alive until the end of the test changes the behavior of the application significantly, particularly if the `dealloc` methods tear down notifications or similar callback chains. This longer life can lead to test failures that don't match up with real-world behavior.

In our case, a call to `swipeViewWithAccessibilityLabel:inDirection:` was calling `[UITouchesEvent -_addTouch:forDelayedDelivery:]`, which eventually retains and autoreleases the presented `UINavigationController`'s `topViewController`. This meant the navigation controller and its children remained live until the end of the test, which did not accurately reflect the behavior of the app when running without KIF.

<img src="http://cl.ly/image/1g2G2S0j2Q0B/Screen%20Shot%202014-06-30%20at%2013.27.57.png">

(This replaces #423, which ended up with an extra commit in it.)
