### PR TITLE
Add accessibilityValue parameter to swipe functions

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -373,12 +373,22 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 
 /*!
  @abstract Swipes a particular view in the view hierarchy in the given direction.
+ @discussion The view will get the view with the specified accessibility label and swipe the screen in the given direction from the view's center.
+ @param label The accessibility label of the view to swipe.
+ @param value The accessibility value of the view to swipe.
+ @param direction The direction in which to swipe.
+ */
+- (void)swipeViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value inDirection:(KIFSwipeDirection)direction;
+
+/*!
+ @abstract Swipes a particular view in the view hierarchy in the given direction.
  @discussion This step will get the view with the specified accessibility label and swipe the screen in the given direction from the view's center.
  @param label The accessibility label of the view to swipe.
+ @param value The accessibility value of the view to swipe.
  @param traits The accessibility traits of the view to swipe. Elements that do not include at least these traits are ignored.
  @param direction The direction in which to swipe.
  */
-- (void)swipeViewWithAccessibilityLabel:(NSString *)label traits:(UIAccessibilityTraits)traits inDirection:(KIFSwipeDirection)direction;
+- (void)swipeViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits inDirection:(KIFSwipeDirection)direction;
 
 /*!
  @abstract Scrolls a particular view in the view hierarchy by an amount indicated as a fraction of its size.

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -639,10 +639,15 @@
 
 - (void)swipeViewWithAccessibilityLabel:(NSString *)label inDirection:(KIFSwipeDirection)direction
 {
-    [self swipeViewWithAccessibilityLabel:label traits:UIAccessibilityTraitNone inDirection:direction];
+    [self swipeViewWithAccessibilityLabel:label value:nil traits:UIAccessibilityTraitNone inDirection:direction];
 }
 
-- (void)swipeViewWithAccessibilityLabel:(NSString *)label traits:(UIAccessibilityTraits)traits inDirection:(KIFSwipeDirection)direction
+- (void)swipeViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value inDirection:(KIFSwipeDirection)direction
+{
+    [self swipeViewWithAccessibilityLabel:label value:value traits:UIAccessibilityTraitNone inDirection:direction];
+}
+
+- (void)swipeViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits inDirection:(KIFSwipeDirection)direction
 {
     const NSUInteger kNumberOfPointsInSwipePath = 20;
 
@@ -651,7 +656,7 @@
     UIView *viewToSwipe = nil;
     UIAccessibilityElement *element = nil;
 
-    [self waitForAccessibilityElement:&element view:&viewToSwipe withLabel:label value:nil traits:traits tappable:NO];
+    [self waitForAccessibilityElement:&element view:&viewToSwipe withLabel:label value:value traits:traits tappable:NO];
 
     // Within this method, all geometry is done in the coordinate system of the view to swipe.
 

--- a/KIF Tests/GestureTests.m
+++ b/KIF Tests/GestureTests.m
@@ -55,31 +55,31 @@
 
 - (void)testSwipingLeftWithTraits
 {
-    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" traits:UIAccessibilityTraitStaticText inDirection:KIFSwipeDirectionLeft];
+    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" value:nil traits:UIAccessibilityTraitStaticText inDirection:KIFSwipeDirectionLeft];
     [tester waitForViewWithAccessibilityLabel:@"Left"];
 }
 
 - (void)testSwipingRightWithTraits
 {
-    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" traits:UIAccessibilityTraitStaticText inDirection:KIFSwipeDirectionRight];
+    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" value:nil traits:UIAccessibilityTraitStaticText inDirection:KIFSwipeDirectionRight];
     [tester waitForViewWithAccessibilityLabel:@"Right"];
 }
 
 - (void)testSwipingUpWithTraits
 {
-    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" traits:UIAccessibilityTraitStaticText inDirection:KIFSwipeDirectionUp];
+    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" value:nil traits:UIAccessibilityTraitStaticText inDirection:KIFSwipeDirectionUp];
     [tester waitForViewWithAccessibilityLabel:@"Up"];
 }
 
 - (void)testSwipingDownWithTraits
 {
-    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" traits:UIAccessibilityTraitStaticText inDirection:KIFSwipeDirectionDown];
+    [tester swipeViewWithAccessibilityLabel:@"Swipe Me" value:nil traits:UIAccessibilityTraitStaticText inDirection:KIFSwipeDirectionDown];
     [tester waitForViewWithAccessibilityLabel:@"Down"];
 }
 
 - (void)testMissingSwipeableElementWithTraits
 {
-    KIFExpectFailure([[tester usingTimeout:0.25] swipeViewWithAccessibilityLabel:@"Unknown" traits:UIAccessibilityTraitStaticText inDirection:KIFSwipeDirectionDown]);
+    KIFExpectFailure([[tester usingTimeout:0.25] swipeViewWithAccessibilityLabel:@"Unknown" value:nil traits:UIAccessibilityTraitStaticText inDirection:KIFSwipeDirectionDown]);
 }
 
 - (void)testScrolling


### PR DESCRIPTION
Needed this to swipe my table cells that are accessed via `viewWithAccessibilityLabel:value:`, figured it should just be part of the interface.
