### PR TITLE
Remove obsolete command-line support

### DIFF
--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -27,19 +27,6 @@
     @autoreleasepool {
         NSLog(@"KIFTester loaded");
         [KIFTestActor _enableAccessibility];
-
-#ifndef KIF_SENTEST
-        if ([[[NSProcessInfo processInfo] environment] objectForKey:@"StartKIFManually"]) {
-            [[NSUserDefaults standardUserDefaults] setBool:YES forKey:XCTestToolKey];
-            XCTSelfTestMain();
-        }
-#else
-        if ([[[NSProcessInfo processInfo] environment] objectForKey:@"StartKIFManually"]) {
-            [[NSUserDefaults standardUserDefaults] setBool:YES forKey:SenTestToolKey];
-            SenSelfTestMain();
-        }
-#endif
-
         [UIApplication swizzleRunLoop];
     }
 }


### PR DESCRIPTION
The command-line support is not needed now that xcodebuild supports test targets. This PR removes the relevant code. This fixes a compilation issue (#434).
