### PR TITLE
Fixes for choosePhotoInAlbum

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -534,12 +534,10 @@
 
 - (void)choosePhotoInAlbum:(NSString *)albumName atRow:(NSInteger)row column:(NSInteger)column
 {
-    [self tapViewWithAccessibilityLabel:@"Choose Photo"];
-    
     // This is basically the same as the step to tap with an accessibility label except that the accessibility labels for the albums have the number of photos appended to the end, such as "My Photos (3)." This means that we have to do a prefix match rather than an exact match.
     [self runBlock:^KIFTestStepResult(NSError **error) {
         
-        NSString *labelPrefix = [NSString stringWithFormat:@"%@,   (", albumName];
+        NSString *labelPrefix = [NSString stringWithFormat:@"%@", albumName];
         UIAccessibilityElement *element = [[UIApplication sharedApplication] accessibilityElementMatchingBlock:^(UIAccessibilityElement *element) {
             return [element.accessibilityLabel hasPrefix:labelPrefix];
         }];
@@ -565,7 +563,7 @@
     }];
     
     // Wait for media picker view controller to be pushed.
-    [self waitForTimeInterval:0.5];
+    [self waitForTimeInterval:1];
     
     // Tap the desired photo in the grid
     // TODO: This currently only works for the first page of photos. It should scroll appropriately at some point.


### PR DESCRIPTION
1) I'm not sure why there was a dependency on the image picker being launched with an element with the accessibility label: "Choose Photo", so I removed that dependency. The app I am testing is using the image picker to select videos, so the "Choose Photo" accessibility label does not make sense.

2) The accessibility label for albums no longer appends the number of photos to the end, so that needed to be removed from the selecting an album.

3) The wait interval for image picker after selecting an album was too short, so I increased it.
