### PR TITLE
Fix scrolling in table view cells

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -129,7 +129,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
         if ([superview isKindOfClass:[UIScrollView class]]) {
             UIScrollView *scrollView = (UIScrollView *)superview;
             
-            if ((UIAccessibilityElement *)view == element) {
+            if (((UIAccessibilityElement *)view == element) && ![view isKindOfClass:[UITableViewCell class]]) {
                 [scrollView scrollViewToVisible:view animated:YES];
             } else {
                 CGRect elementFrame = [view.window convertRect:element.accessibilityFrame toView:scrollView];


### PR DESCRIPTION
Cells sit inside an intermediate UITableViewWrapperView and aren't always within its bounds.  Calling scrollViewToVisible on the wrapper when a cell is outside its bounds causes unnecessary scrolling, and then taps are sent to the wrong cell.  The accessibility frames do lie within its bounds, so the scrolling doesn't happen, and the taps end up in the right place.
