### PR TITLE
Only call scrollRectToVisible if the view isn't already visible

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -133,7 +133,13 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
                 [scrollView scrollViewToVisible:view animated:YES];
             } else {
                 CGRect elementFrame = [view.window convertRect:element.accessibilityFrame toView:scrollView];
-                [scrollView scrollRectToVisible:elementFrame animated:YES];
+                CGRect visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y, CGRectGetWidth(scrollView.bounds), CGRectGetHeight(scrollView.bounds));
+                
+                // Only call scrollRectToVisible if the element isn't already visible
+                // iOS 8 will sometimes incorrectly scroll table views so the element scrolls out of view
+                if (!CGRectContainsRect(visibleRect, elementFrame)) {
+                    [scrollView scrollRectToVisible:elementFrame animated:YES];
+                }
             }
             
             // Give the scroll view a small amount of time to perform the scroll.


### PR DESCRIPTION
I've found that scrollRectToVisible will act a bit oddly on iOS 8 when dealing with table view that have custom section headers and large contentInsets. Asking to scroll to a specific rect row will cause that row to scroll up under the section header, which then makes the row untappable. Skipping the call to scrollRectToVisible fixes the problem for me and doesn't affect any of the other KIF tests.
