### PR TITLE
iOS 8 fix: UITableViews are now wrapped in a scrollable UITableViewWrapper view

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -126,7 +126,8 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
             break;
         }
         
-        if ([superview isKindOfClass:[UIScrollView class]]) {
+        // On iOS8+ UITableViews are wrapped in a scrollable UITableViewWrapperView, which if we adjust its offset will not update the internal scroll view and as a result not trigger needed delegate logic to account for the offset, excluding UITableViewWrapperView from here avoids this issue
+        if ([superview isKindOfClass:[UIScrollView class]] && superview.class != NSClassFromString(@"UITableViewWrapperView")) {
             UIScrollView *scrollView = (UIScrollView *)superview;
             
             if ((UIAccessibilityElement *)view == element) {


### PR DESCRIPTION
This causes issues when KIF moves the content of the scroll view instead of the actual UIScrollView dependent, as none of the UIScrollViewDelegate calls are made to the actual instance. 

Excluding this class works around this issue. 