### PR TITLE
@selector(waitForAccessibilityElement:view:withIdentifier:tappable:) can not work

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -79,7 +79,7 @@
         [self failWithError:[NSError KIFErrorWithFormat:@"Running test on platform that does not support accessibilityIdentifier"] stopTest:YES];
     }
     
-    [self waitForAccessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", identifier] tappable:mustBeTappable];
+    [self waitForAccessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithFormat:@"accessibilityLabel = %@", identifier] tappable:mustBeTappable];
 }
 
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable


### PR DESCRIPTION
@selector(waitForAccessibilityElement:view:withIdentifier:tappable:) cannot work
UIAccessibilityElement just has accessibilityLabel property, without accessibilityIdentifier property. So the NSPredicate will always evaluate to false.
