### PR TITLE
Guard against using iOS 8 APIs in Xcode < 6

### DIFF
--- a/Additions/XCTestCase-KIFAdditions.m
+++ b/Additions/XCTestCase-KIFAdditions.m
@@ -60,6 +60,8 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
 
 @end
 
+#ifdef __IPHONE_8_0
+
 @interface XCTestSuite ()
 - (void)_recordUnexpectedFailureForTestRun:(id)arg1 description:(id)arg2 exception:(id)arg3;
 @end
@@ -80,5 +82,6 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
     }
 }
 
-
 @end
+
+#endif


### PR DESCRIPTION
KIF doesn't build in Xcode 5 due to the use of `XCTestCase` APIs that only exist in the iOS 8 SDK.
This PR adds a simple preprocessor guard condition to get things compiling again on Xcode 5.
