### PR TITLE
Create the screenshot directory if needed

### DIFF
--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -141,8 +141,7 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
     outputPath = [outputPath stringByExpandingTildeInPath];
 
     NSError *directoryCreationError = nil;
-    [[NSFileManager defaultManager] createDirectoryAtPath:outputPath withIntermediateDirectories:YES attributes:nil error:&directoryCreationError];
-    if (directoryCreationError) {
+    if (![[NSFileManager defaultManager] createDirectoryAtPath:outputPath withIntermediateDirectories:YES attributes:nil error:&directoryCreationError]) {
         *error = [NSError KIFErrorWithFormat:@"Couldn't create directory at path %@ (details: %@)", outputPath, directoryCreationError];
         return NO;
     }


### PR DESCRIPTION
Self-explanatory. The screenshot directory provided by `KIF_SCREENSHOTS` should be auto-created.
