### PR TITLE
Fix the resolution of screenshots taken after errors. (320x* => 640x*)

### DIFF
--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -131,7 +131,7 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
         return NO;
     }
     
-    UIGraphicsBeginImageContext([[windows objectAtIndex:0] bounds].size);
+    UIGraphicsBeginImageContextWithOptions([[windows objectAtIndex:0] bounds].size, YES, 0);
     for (UIWindow *window in windows) {
         [window.layer renderInContext:UIGraphicsGetCurrentContext()];
     }


### PR DESCRIPTION
I noticed the screenshots were kind of small and fuzzy (320x568). I swapped out the `UIGraphicsBeginImageContext` function with the one that takes a scale parameter, which defaults to the scale of the device's screen. So the screenshots are now the actual screen size of the device (640x1136).

``` objc
void UIGraphicsBeginImageContextWithOptions ( CGSize size, BOOL opaque, CGFloat scale );
```

> The scale factor to apply to the bitmap. If you specify a value of 0.0,
> the scale factor is set to the scale factor of the device’s main
> screen."

([Apple Docs](https://developer.apple.com/library/ios/documentation/uikit/reference/uikitfunctionreference/index.html#//apple_ref/c/func/UIGraphicsBeginImageContextWithOptions))
