### PR TITLE
Extend hidden check to use also alpha value

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -157,7 +157,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     }
     
     // If we don't require tappability, at least make sure it's not hidden
-    if ([view isHidden]) {
+    if ([view isHidden] || view.alpha == 0.0) {
         if (error) {
             *error = [NSError KIFErrorWithFormat:@"Accessibility element with label \"%@\" is hidden.", element.accessibilityLabel];
         }

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -119,7 +119,7 @@
         KIFTestWaitCondition(view, error, @"Cannot find view containing accessibility element with the label \"%@\"", label);
 
         // Hidden views count as absent
-        KIFTestWaitCondition([view isHidden] || [view superview] == nil, error, @"Accessibility element with label \"%@\" is visible and not hidden.", label);
+        KIFTestWaitCondition([view isHidden] || view.alpha == 0.0 || [view superview] == nil, error, @"Accessibility element with label \"%@\" is visible and not hidden.", label);
         
         return KIFTestStepResultSuccess;
     }];

--- a/IdentifierTests/KIFUITestActor-IdentifierTests.m
+++ b/IdentifierTests/KIFUITestActor-IdentifierTests.m
@@ -55,7 +55,7 @@
         KIFTestWaitCondition(view, error, @"Cannot find view containing accessibility element with the identifier \"%@\"", accessibilityIdentifier);
         
         // Hidden views count as absent
-        KIFTestWaitCondition([view isHidden] || [view superview] == nil, error, @"Accessibility element with identifier \"%@\" is visible and not hidden.", accessibilityIdentifier);
+        KIFTestWaitCondition([view isHidden] || view.alpha == 0.0 || [view superview] == nil, error, @"Accessibility element with identifier \"%@\" is visible and not hidden.", accessibilityIdentifier);
         
         return KIFTestStepResultSuccess;
     }];


### PR DESCRIPTION
Use also alpha value as indicator of view visibility. Resolve #514 when system back button indicator for root view controller is on the view, has hidden = NO but alpha = 0. In current versions of iOS views with alpha = 0 are not intractable, so should be considered as hidden, because KIF cannot interact with them and user cannot see them.
