### PR TITLE
Let `continueAfterFailure` default to YES

### DIFF
--- a/Classes/KIFTestCase.m
+++ b/Classes/KIFTestCase.m
@@ -39,9 +39,7 @@ NSComparisonResult selectorSort(NSInvocation *invocOne, NSInvocation *invocTwo, 
         return nil;
     }
 
-#ifndef KIF_SENTEST
-    self.continueAfterFailure = NO;
-#else
+#ifdef KIF_SENTEST
     [self raiseAfterFailure];
 #endif
     return self;


### PR DESCRIPTION
Setting the `continueAfterFailure` property to `NO` is very problematic when using the XCTest asynchronous API or the `KIFTestActor runBlock:` API, yet it is [the default](https://github.com/kif-framework/KIF/blob/dfea65f5352c3a7ce26774bde909cdaf84b9e694/Classes/KIFTestCase.m#L43) for a KIFTestCase.

The [-[XCTestCase recordFailureWithDescription:…]](https://gist.github.com/0xced/15580ed23ef303c5c128/68da10a48e770f50ee7a8a1253c7667a19b3a0e8#file-xctestcase-m-L15-L17) method dispatches and raises an `_XCTestCaseInterruptionException`. The block (calling `[_XCTestCaseInterruptionException interruptTest]`) will eventually be executed in [_dispatch_client_callout](https://github.com/aosm/libdispatch/blob/ec3d1496203b87a2280df04bb1be46b34fea7a71/src/object.m#L493-L495) which catches the exception and calls `objc_terminate`. Since this exception is caught inside libdispatch, there’s [nothing we can do](http://prod.lists.apple.com/archives/cocoa-dev/2014/Apr/msg00152.html) and the test process will be terminated.

By letting the `continueAfterFailure` property default to `YES` it becomes possible to write a test like this which doesn't terminate the test process with an uncaught exception:

```objc
- (void) testAsynchronousFailure
{
	dispatch_async(dispatch_get_main_queue(), ^{
		XCTFail(@"This failing assertion causes the test process to terminate because of uncaught exception of type _XCTestCaseInterruptionException if continueAfterFailure == NO");
		[[NSNotificationCenter defaultCenter] postNotificationName:@"AsnychronousTaskDidComplete" object:self];
	});
	[system waitForNotificationName:@"AsnychronousTaskDidComplete" object:self];
}
```