### PR TITLE
Adding the property "animationWaitingTimeout" that controls how long tes...

### DIFF
--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -89,6 +89,7 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 @property (nonatomic, readonly) NSInteger line;
 @property (weak, nonatomic, readonly) id<KIFTestActorDelegate> delegate;
 @property (nonatomic) NSTimeInterval executionBlockTimeout;
+@property (nonatomic) NSTimeInterval animationWaitingTimeout;
 
 - (instancetype)usingTimeout:(NSTimeInterval)executionBlockTimeout;
 

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -64,6 +64,7 @@
         _line = line;
         _delegate = delegate;
         _executionBlockTimeout = [[self class] defaultTimeout];
+        _animationWaitingTimeout = 0.5f;
     }
     return self;
 }
@@ -179,7 +180,13 @@ static NSTimeInterval KIFTestStepDelay = 0.1;
 }
 
 -(void)waitForAnimationsToFinish {
-    NSTimeInterval maximumWaitingTimeInterval = 3;
+    NSTimeInterval maximumWaitingTimeInterval = self.animationWaitingTimeout;
+    if(maximumWaitingTimeInterval <= 0) {
+        return;
+    }
+    
+    // Wait for the view to stabilize and give them a chance to start animations before we wait for them.
+    [self waitForTimeInterval:0.5f];
     
     NSTimeInterval startTime = [NSDate timeIntervalSinceReferenceDate];
     [self runBlock:^KIFTestStepResult(NSError **error) {

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -168,9 +168,6 @@
         
         return KIFTestStepResultSuccess;
     }];
-    
-    // Wait for the view to stabilize.
-    [self waitForTimeInterval:0.5];
 
     [self waitForAnimationsToFinish];
 }
@@ -695,9 +692,6 @@
     CGRect cellFrame = [cell.contentView convertRect:cell.contentView.frame toView:tableView];
     [tableView tapAtPoint:CGPointCenteredInRect(cellFrame)];
     
-    // Wait for the view to stabilize.
-    [tester waitForTimeInterval:0.5];
-
     [self waitForAnimationsToFinish];
 }
 
@@ -720,9 +714,6 @@
     CGRect cellFrame = [cell.contentView convertRect:cell.contentView.frame toView:collectionView];
     [collectionView tapAtPoint:CGPointCenteredInRect(cellFrame)];
     
-    // Wait for the view to stabilize.
-    [tester waitForTimeInterval:0.5];
-
     [self waitForAnimationsToFinish];
 }
 


### PR DESCRIPTION
...ts will wait for animations to finish. Its default-value is 0.5 second. It can also be deactivated by setting it to 0. This should fix #530.

Also moving the waitForTimeInterval-call into the animationWaitingTimeout-call. The call is necessary to give the views a chance to start animations, before we wait for animations to finish. Thus, the call is necessary that animationWaitingTimeout will work properly.