### PR TITLE
Fixed an analyzer warning

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -500,6 +500,7 @@
                 UILabel *label = (labels.count > 0 ? labels[0] : nil);
                 rowTitle = label.text;
             }
+            NSAssert(rowTitle != nil, @"Unknown picker type. Delegate responds neither to pickerView:titleForRow:forComponent: nor to pickerView:viewForRow:forComponent:reusingView:");
             [dataToSelect addObject: rowTitle];
         }
     }


### PR DESCRIPTION
The analyzer complains as rowTitle might be nil if the delegate responds to neither of the tested methods.

Original warning: Argument to 'NSMutableArray' method 'addObject:' cannot be nil

Adding the assert appeases the analyzer and has the added advantage to give a more helpful error message if that case occurs instead of just crashing with "trying to insert nil".