### PR TITLE
Fix analyzer warning regardless of `ENABLE_NS_ASSERTIONS` setting

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -500,8 +500,12 @@
                 UILabel *label = (labels.count > 0 ? labels[0] : nil);
                 rowTitle = label.text;
             }
-            NSAssert(rowTitle != nil, @"Unknown picker type. Delegate responds neither to pickerView:titleForRow:forComponent: nor to pickerView:viewForRow:forComponent:reusingView:");
-            [dataToSelect addObject: rowTitle];
+            
+            if (rowTitle) {
+                [dataToSelect addObject: rowTitle];
+            } else {
+                @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Unknown picker type. Delegate responds neither to pickerView:titleForRow:forComponent: nor to pickerView:viewForRow:forComponent:reusingView:" userInfo:nil];
+            }
         }
     }
     


### PR DESCRIPTION
The analyzer warning fix proposed in #557 works fine when ENABLE_NS_ASSERTIONS=YES. But if assertions are disabled (which is the case when integrating KIF with CocoaPods) the analyzer warning comes back.