### PR TITLE
Fix KIF for collections

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -755,6 +755,12 @@
     [self tapItemAtIndexPath:indexPath inCollectionView:collectionView];
 }
 
+-(void)tapItemInCollectionViewWithAccessibilityLabel:(NSString *)collectionLabel atIndexPath:(NSIndexPath *)indexPath
+{
+    UICollectionView *collection = (UICollectionView *)[self waitForViewWithAccessibilityLabel:collectionLabel];
+    [self tapItemAtIndexPath:indexPath inCollectionView:collection];
+}
+
 - (void)acknowledgeSystemAlert {
     [UIAutomationHelper acknowledgeSystemAlert];
 }


### PR DESCRIPTION
This addition is to have Collections follow the same pattern as Tables.
Also the current method:

- (void)tapItemAtIndexPath:(NSIndexPath *)indexPath inCollectionViewWithAccessibilityIdentifier:(NSString *)identifier

Does not work as expected. (IMO)