### PR TITLE
KIFUIViewTestActor

### DIFF
--- a/Additions/NSPredicate+KIFAdditions.h
+++ b/Additions/NSPredicate+KIFAdditions.h
@@ -1,0 +1,14 @@
+//
+//  NSPredicate+KIFAdditions.h
+//  KIF
+//
+//  Created by Alex Odawa on 2/3/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSPredicate (KIFAdditions)
+- (NSArray *)flatten;
+- (NSCompoundPredicate *)minusSubpredicatesFrom:(NSPredicate *)otherPredicate;
+@end

--- a/Additions/NSPredicate+KIFAdditions.m
+++ b/Additions/NSPredicate+KIFAdditions.m
@@ -1,0 +1,40 @@
+//
+//  NSPredicate+KIFAdditions.m
+//  KIF
+//
+//  Created by Alex Odawa on 2/3/15.
+//
+//
+
+#import "NSPredicate+KIFAdditions.h"
+
+@implementation NSPredicate (KIFAdditions)
+
+- (NSArray *)flatten
+{
+    NSMutableArray *result = [[NSMutableArray alloc] init];
+    
+    if ([self isKindOfClass:[NSCompoundPredicate class]]) {
+        for (NSPredicate *predicate in ((NSCompoundPredicate *)self).subpredicates) {
+            [result addObjectsFromArray:[predicate flatten]];
+        }
+    } else {
+        [result addObject:self];
+    }
+    
+    return result;
+}
+
+- (NSCompoundPredicate *)minusSubpredicatesFrom:(NSPredicate *)otherPredicate;
+{
+    if (self == otherPredicate) {
+        return nil;
+    }
+    NSMutableSet *subpredicates = [NSMutableSet setWithArray:[self flatten]];
+    NSMutableSet *otherSubpredicates = [NSMutableSet setWithArray:[otherPredicate flatten]];
+    [subpredicates minusSet:otherSubpredicates];
+    return [[NSCompoundPredicate alloc] initWithType:NSAndPredicateType
+                                       subpredicates:[subpredicates allObjects]];
+}
+
+@end

--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -8,6 +8,7 @@
 //  which Square, Inc. licenses this file to you.
 
 #import "NSError-KIFAdditions.h"
+#import "NSPredicate+KIFAdditions.h"
 #import "UIAccessibilityElement-KIFAdditions.h"
 #import "UIApplication-KIFAdditions.h"
 #import "UIScrollView-KIFAdditions.h"
@@ -62,7 +63,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     
     if (!element) {
         if (error) {
-            *error = [NSError KIFErrorWithFormat:@"Could not find view matching: %@", predicate];
+            *error = [self errorForFailingPredicate:predicate];
         }
         return NO;
     }
@@ -172,6 +173,54 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     }
     
     return view;
+}
+
++ (NSError *)errorForFailingPredicate:(NSPredicate*)failingPredicate;
+{
+    NSPredicate *closestMatchingPredicate = [self findClosestMatchingPredicate:failingPredicate];
+    if (closestMatchingPredicate) {
+        return [NSError KIFErrorWithFormat:@"Found element matching predicate '%@' but not '%@'", \
+                closestMatchingPredicate, \
+                [failingPredicate minusSubpredicatesFrom:closestMatchingPredicate]];
+    }
+    return [NSError KIFErrorWithFormat:@"Could not find element matching predicate '%@'", failingPredicate];
+}
+
++ (NSPredicate *)findClosestMatchingPredicate:(NSPredicate *)aPredicate;
+{
+    if (!aPredicate) {
+        return nil;
+    }
+    
+    UIAccessibilityElement *match = [[UIApplication sharedApplication] accessibilityElementMatchingBlock:^BOOL (UIAccessibilityElement *element) {
+        return [aPredicate evaluateWithObject:element];
+    }];
+    if (match) {
+        return aPredicate;
+    }
+    
+    // Breadth-First algorithm to match as many subpredicates as possible
+    NSMutableArray *queue = [NSMutableArray arrayWithObject:aPredicate];
+    while (queue.count > 0) {
+        // Dequeuing
+        NSPredicate *predicate = [queue firstObject];
+        [queue removeObject:predicate];
+        
+        // Remove one subpredicate at a time an then check if an element would match this resulting predicate
+        for (NSPredicate *subpredicate in [predicate flatten]) {
+            NSPredicate *predicateMinusOneCondition = [predicate minusSubpredicatesFrom:subpredicate];
+            if (predicateMinusOneCondition) {
+                UIAccessibilityElement *match = [[UIApplication sharedApplication] accessibilityElementMatchingBlock:^BOOL (UIAccessibilityElement *element) {
+                    return [predicateMinusOneCondition evaluateWithObject:element];
+                }];
+                if (match) {
+                    return predicateMinusOneCondition;
+                }
+                [queue addObject:predicateMinusOneCondition];
+            }
+        }
+    }
+    return nil;
 }
 
 @end

--- a/Classes/KIF.h
+++ b/Classes/KIF.h
@@ -13,6 +13,9 @@
 #import "KIFUITestActor.h"
 #import "KIFUITestActor-ConditionalTests.h"
 
+#import "KIFUIViewTestActor.h"
+#import "KIFUIObject.h"
+
 #ifndef KIF_SENTEST
 #import "XCTestCase-KIFAdditions.h"
 #else

--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -51,7 +51,6 @@ return KIFTestStepResultWait; \
 } \
 })
 
-
 /*!
  @enum KIFTestStepResult
  @abstract Result codes from a test step.
@@ -98,7 +97,6 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 - (void)runBlock:(KIFTestExecutionBlock)executionBlock timeout:(NSTimeInterval)timeout;
 - (void)runBlock:(KIFTestExecutionBlock)executionBlock;
 
-
 /*!
  @discussion Attempts to run the test block similar to -runBlock:complete:timeout: but does not halt the test on completion, instead returning NO on failure and providing an error description to the optional error parameter.
  */
@@ -137,6 +135,8 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 - (void)fail;
 
 - (void)failWithError:(NSError *)error stopTest:(BOOL)stopTest;
+
+- (void)failWithMessage:(NSString *)message, ...;
 
 /*!
  @abstract Waits for a certain amount of time before returning.

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -164,6 +164,16 @@ static NSTimeInterval KIFTestStepDelay = 0.1;
     }];
 }
 
+- (void)failWithMessage:(NSString *)message, ...;
+{
+    va_list args;
+    va_start(args, message);
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
+    NSError *error = [NSError errorWithDomain:@"KIFTest" code:KIFTestStepResultFailure userInfo:[NSDictionary dictionaryWithObjectsAndKeys:formattedMessage, NSLocalizedDescriptionKey, nil]];
+    [self failWithError:error stopTest:YES];
+    va_end(args);
+}
+
 - (void)failWithError:(NSError *)error stopTest:(BOOL)stopTest
 {
     [self.delegate failWithException:[NSException failureInFile:self.file atLine:(int)self.line withDescription:error.localizedDescription] stopTest:stopTest];

--- a/Classes/KIFUIObject.h
+++ b/Classes/KIFUIObject.h
@@ -1,0 +1,18 @@
+//
+//  KIFUIObject.h
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@interface KIFUIObject : NSObject
+
+@property (nonatomic, weak, readonly) UIView *view;
+@property (nonatomic, weak, readonly) UIAccessibilityElement *element;
+
+- (instancetype)initWithElement:(UIAccessibilityElement *)element view:(UIView *)view;
+
+@end

--- a/Classes/KIFUIObject.m
+++ b/Classes/KIFUIObject.m
@@ -1,0 +1,28 @@
+//
+//  KIFUIObject.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+#import "KIFUIObject.h"
+
+
+@implementation KIFUIObject
+
+- (instancetype)initWithElement:(UIAccessibilityElement *)element view:(UIView *)view;
+{
+    self = [super init];
+    if (self) {
+        _element = element;
+        _view = view;
+    }
+    return self;
+}
+
+- (NSString *)description;
+{
+    return [NSString stringWithFormat:@"<%@;\n| element=%@;\n| |  view=%@>", [super description], self.element, self.view];
+}
+@end

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -44,11 +44,10 @@ typedef NS_ENUM(NSUInteger, KIFPickerType) {
 
 static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirection direction)
 {
-    switch (direction)
-    {
-            // As discovered on the Frank mailing lists, it won't register as a
-            // swipe if you move purely horizontally or vertically, so need a
-            // slight orthogonal offset too.
+    switch (direction) {
+        // As discovered on the Frank mailing lists, it won't register as a
+        // swipe if you move purely horizontally or vertically, so need a
+        // slight orthogonal offset too.
         case KIFSwipeDirectionRight:
             return CGPointMake(kKIFMajorSwipeDisplacement, kKIFMinorSwipeDisplacement);
         case KIFSwipeDirectionLeft:
@@ -292,6 +291,16 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 
 /*!
  @abstract Enters text into a particular view in the view hierarchy.
+ @discussion If the element isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, a tap event is simulated in the center of the view or element, then text is entered into the view by simulating taps on the appropriate keyboard keys.
+ @param text The text to enter.
+ @param expectedResult What the text value should be after entry, including any formatting done by the field. If this is nil, the "text" parameter will be used.
+ @param element the element to type into.
+ @param view the view to type into.
+ */
+- (void)enterText:(NSString *)text intoElement:(UIAccessibilityElement *)element inView:(UIView *)view expectedResult:(NSString *)expectedResult;
+
+/*!
+ @abstract Enters text into a particular view in the view hierarchy.
  @discussion The view or accessibility element with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, a tap event is simulated in the center of the view or element, then text is entered into the view by simulating taps on the appropriate keyboard keys.
  @param text The text to enter.
  @param label The accessibility label of the element to type into.
@@ -311,7 +320,7 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 - (void)clearTextFromFirstResponder;
 - (void)clearTextFromViewWithAccessibilityLabel:(NSString *)label;
 - (void)clearTextFromViewWithAccessibilityLabel:(NSString *)label traits:(UIAccessibilityTraits)traits;
-- (void)clearTextFromElement:(UIAccessibilityElement*)element inView:(UIView*)view;
+- (void)clearTextFromElement:(UIAccessibilityElement *)element inView:(UIView *)view;
 
 - (void)clearTextFromAndThenEnterTextIntoCurrentFirstResponder:(NSString *)text;
 - (void)clearTextFromAndThenEnterText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label;
@@ -339,7 +348,7 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
  @discussion With a date picker view already visible, this step will select the different rotating weel values in order of how the array parameter is passed in. After it is done it will hide the date picker. It works with all 4 UIDatePickerMode* modes. The input parameter of type NSArray has to match in what order the date picker is displaying the values/columns. So if the locale is changing the input parameter has to be adjusted. Example: Mode: UIDatePickerModeDate, Locale: en_US, Input param: NSArray *date = @[@"June", @"17", @"1965"];. Example: Mode: UIDatePickerModeDate, Locale: de_DE, Input param: NSArray *date = @[@"17.", @"Juni", @"1965".
  @param datePickerColumnValues Each element in the NSArray represents a rotating wheel in the date picker control. Elements from 0 - n are listed in the order of the rotating wheels, left to right.
  */
-- (void) selectDatePickerValue:(NSArray*)datePickerColumnValues;
+- (void)selectDatePickerValue:(NSArray *)datePickerColumnValues;
 
 /*!
  @abstract Toggles a UISwitch into a specified position.
@@ -348,6 +357,16 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
  @param label The accessibility label of the element to switch.
  */
 - (void)setOn:(BOOL)switchIsOn forSwitchWithAccessibilityLabel:(NSString *)label;
+
+/*!
+ @abstract Toggles a UISwitch into a specified position.
+ @discussion If the Switch isn't currently tappable, then the step will attempt to wait until it is. Once the view is present, the step will return if it's already in the desired position. If the switch is tappable but not in the desired position, a tap event is simulated in the center of the view or element, toggling the switch into the desired position.
+ @param switchIsOn The desired position of the UISwitch.
+ @param switchView The switch to switch.
+ @param element The accessibility element for the switch.
+
+ */
+- (void)setSwitch:(UISwitch *)switchView element:(UIAccessibilityElement *)element On:(BOOL)switchIsOn;
 
 /*!
  @abstract Slides a UISlider to a specified value.
@@ -382,7 +401,7 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
  @param tableViewLabel Accessibility label of the table view.
  @param indexPath Index path of the row to tap.
  */
-- (void)tapRowInTableViewWithAccessibilityLabel:(NSString*)tableViewLabel atIndexPath:(NSIndexPath *)indexPath KIF_DEPRECATED("Use tapRowAtIndexPath:inTableViewWithAccessibilityIdentifier:");
+- (void)tapRowInTableViewWithAccessibilityLabel:(NSString *)tableViewLabel atIndexPath:(NSIndexPath *)indexPath KIF_DEPRECATED("Use tapRowAtIndexPath:inTableViewWithAccessibilityIdentifier:");
 
 /*!
  @abstract Taps the row at indexPath in a table view with the given identifier.
@@ -396,6 +415,17 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 - (void)tapRowAtIndexPath:(NSIndexPath *)indexPath inTableViewWithAccessibilityIdentifier:(NSString *)identifier NS_AVAILABLE_IOS(5_0);
 
 /*!
+ @abstract Taps the row at indexPath in a given table view.
+ @discussion This step will tap the row at indexPath.
+ 
+ For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+ 
+ @param indexPath Index path of the row to tap.
+ @param tableView UITableView containing row to tap.
+ */
+- (void)tapRowAtIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView;
+
+/*!
  @abstract Taps the item at indexPath in a collection view with the given identifier.
  @discussion This step will get the view with the specified accessibility identifier and tap the item at indexPath.
  
@@ -405,6 +435,17 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
  @param identifier Accessibility identifier of the collection view.
  */
 - (void)tapItemAtIndexPath:(NSIndexPath *)indexPath inCollectionViewWithAccessibilityIdentifier:(NSString *)identifier;
+
+/*!
+ @abstract Taps the item at indexPath in a given collection view.
+ @discussion This step will get the view with the specified accessibility identifier and tap the item at indexPath.
+ 
+ For cases where you may need to work from the end of a collection view rather than the beginning, negative sections count back from the end of the collection view (-1 is the last section) and negative items count back from the end of the section (-1 is the last item for that section).
+ 
+ @param indexPath Index path of the item to tap.
+ @param collectionView the UICollectionView containing the item.
+ */
+- (void)tapItemAtIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView;
 
 #if TARGET_IPHONE_SIMULATOR
 /*!
@@ -442,6 +483,15 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 - (void)swipeViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits inDirection:(KIFSwipeDirection)direction;
 
 /*!
+@abstract Swipes a particular view in the view hierarchy in the given direction.
+@discussion This step will swipe the screen in the given direction from the view's center.
+@param element The accessibility element of the view to swipe.
+@param viewToSwipe The view to swipe.
+@param direction The direction in which to swipe.
+ */
+- (void)swipeElement:(UIAccessibilityElement *)element inView:(UIView *)viewToSwipe inDirection:(KIFSwipeDirection)direction;
+
+/*!
  @abstract Scrolls a particular view in the view hierarchy by an amount indicated as a fraction of its size.
  @discussion The view will get the view with the specified accessibility label and scroll it by the indicated fraction of its size, with the scroll centered on the center of the view.
  @param label The accessibility label of the view to scroll.
@@ -458,6 +508,16 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
  @param verticalFraction The vertical displacement of the scroll action, as a fraction of the height of the view.
  */
 - (void)scrollViewWithAccessibilityIdentifier:(NSString *)identifier byFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction NS_AVAILABLE_IOS(5_0);
+
+/*!
+ @abstract Scrolls a particular view in the view hierarchy by an amount indicated as a fraction of its size.
+ @discussion The view will scroll by the indicated fraction of its size, with the scroll centered on the center of the view.
+ @param element The accessibility element of the view to scroll.
+ @param viewToScroll the view to scroll.
+ @param horizontalFraction The horizontal displacement of the scroll action, as a fraction of the width of the view.
+ @param verticalFraction The vertical displacement of the scroll action, as a fraction of the height of the view.
+ */
+- (void)scrollAccessibilityElement:(UIAccessibilityElement *)element inView:(UIView *)viewToScroll byFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction;
 
 /*!
  @abstract Waits until a view or accessibility element is the first responder.
@@ -493,6 +553,31 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 - (UITableViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inTableViewWithAccessibilityIdentifier:(NSString *)identifier;
 
 /*!
+ @abstract Waits for the cell at indexPath in a given table view.
+ @discussion This step will get the cell at the indexPath.
+ 
+ For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+ 
+ @param indexPath Index path of the cell.
+ @param tableView UITableView containing the cell.
+ @result Table view cell at index path
+ */
+- (UITableViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView;
+
+/*!
+ @abstract Waits for the cell at indexPath in a given collection view.
+ @discussion This step will get the cell at the indexPath.
+ 
+ For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+ 
+ @param indexPath Index path of the cell.
+ @param collectionView UICollectionView containing the cell.
+ @result Collection view cell at index path
+ */
+- (UICollectionViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView;
+
+
+/*!
  @abstract Waits for the cell at indexPath in a collection view with the given identifier.
  @discussion This step will get the view with the specified accessibility identifier and then get the cell at indexPath.
  
@@ -515,4 +600,17 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
  @param identifier Accessibility identifier of the table view.
  */
 - (void)moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath inTableViewWithAccessibilityIdentifier:(NSString *)identifier;
+
+/*!
+ @abstract Moves the row at sourceIndexPath to destinationIndexPath in a given table view.
+ @discussion This step will move the row at sourceIndexPath to destinationIndexPath.
+ 
+ For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+ 
+ @param sourceIndexPath Index path of the row to move.
+ @param destinationIndexPath Desired final index path of the row after moving.
+ @param tableView UITableView containing the cell.
+ */
+- (void)moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath inTableView:(UITableView *)tableView;
+
 @end

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -60,10 +60,11 @@
 - (UIView *)waitForViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits tappable:(BOOL)mustBeTappable
 {
     UIView *view = nil;
-    @autoreleasepool {
+    @autoreleasepool
+    {
         [self waitForAccessibilityElement:NULL view:&view withLabel:label value:value traits:traits tappable:mustBeTappable];
     }
-    
+
     return view;
 }
 
@@ -79,7 +80,7 @@
     if (![UIAccessibilityElement instancesRespondToSelector:@selector(accessibilityIdentifier)]) {
         [self failWithError:[NSError KIFErrorWithFormat:@"Running test on platform that does not support accessibilityIdentifier"] stopTest:YES];
     }
-    
+
     [self waitForAccessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", identifier] tappable:mustBeTappable];
 }
 
@@ -178,7 +179,8 @@
 
 - (void)tapViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits
 {
-    @autoreleasepool {
+    @autoreleasepool
+    {
         UIView *view = nil;
         UIAccessibilityElement *element = nil;
         [self waitForAccessibilityElement:&element view:&view withLabel:label value:value traits:traits tappable:YES];
@@ -252,7 +254,8 @@
 
 - (void)longPressViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits duration:(NSTimeInterval)duration;
 {
-    @autoreleasepool {
+    @autoreleasepool
+    {
         UIView *view = nil;
         UIAccessibilityElement *element = nil;
         [self waitForAccessibilityElement:&element view:&view withLabel:label value:value traits:traits tappable:YES];
@@ -277,7 +280,7 @@
         
         return KIFTestStepResultSuccess;
     }];
-    
+
     // Wait for view to settle.
     [self waitForTimeInterval:0.5];
 }
@@ -330,17 +333,17 @@
 {
     for (NSUInteger characterIndex = 0; characterIndex < [text length]; characterIndex++) {
         NSString *characterString = [text substringWithRange:NSMakeRange(characterIndex, 1)];
-        
+
         if (![KIFTypist enterCharacter:characterString]) {
             // Attempt to cheat if we couldn't find the character
             if (!fallbackView) {
                 UIResponder *firstResponder = [[[UIApplication sharedApplication] keyWindow] firstResponder];
-                
+
                 if ([firstResponder isKindOfClass:[UIView class]]) {
                     fallbackView = (UIView *)firstResponder;
                 }
             }
-            
+
             if ([fallbackView isKindOfClass:[UITextField class]] || [fallbackView isKindOfClass:[UITextView class]] || [fallbackView isKindOfClass:[UISearchBar class]]) {
                 NSLog(@"KIF: Unable to find keyboard key for %@. Inserting manually.", characterString);
                 [(UITextField *)fallbackView setText:[[(UITextField *)fallbackView text] stringByAppendingString:characterString]];
@@ -360,10 +363,16 @@
 {
     UIView *view = nil;
     UIAccessibilityElement *element = nil;
-    
+
     [self waitForAccessibilityElement:&element view:&view withLabel:label value:nil traits:traits tappable:YES];
+
+    [self enterText:text intoElement:element inView:view expectedResult:expectedResult];
+}
+
+- (void)enterText:(NSString *)text intoElement:(UIAccessibilityElement *)element inView:(UIView *)view expectedResult:(NSString *)expectedResult;
+{
     [self tapAccessibilityElement:element inView:view];
-    [self waitForTimeInterval:0.25];
+    [self waitForTimeInterval:0.25]; // should confirm the view became first responder
     [self enterTextIntoCurrentFirstResponder:text fallbackView:view];
     [self expectView:view toContainText:expectedResult ?: text];
 }
@@ -374,9 +383,9 @@
     if (![view respondsToSelector:@selector(text)]) {
         return;
     }
-    
+
     UITextView *textView = (UITextView *)view;
-    
+
     // Some slower machines take longer for typing to catch up, so wait for a bit before failing
     [self runBlock:^KIFTestStepResult(NSError **error) {
         // We trim \n and \r because they trigger the return key, so they won't show up in the final product on single-line inputs.
@@ -409,18 +418,18 @@
 {
     UIView *view = nil;
     UIAccessibilityElement *element = nil;
-    
+
     [self waitForAccessibilityElement:&element view:&view withLabel:label value:nil traits:traits tappable:YES];
-	[self clearTextFromElement:element inView:view];
+    [self clearTextFromElement:element inView:view];
 }
 
-- (void)clearTextFromElement:(UIAccessibilityElement*)element inView:(UIView*)view
+- (void)clearTextFromElement:(UIAccessibilityElement *)element inView:(UIView *)view
 {
     [self tapAccessibilityElement:element inView:view];
 
     // Per issue #294, the tap occurs in the center of the text view.  If the text is too long, this means not all text gets cleared.  To address this for most cases, we can check if the selected view conforms to UITextInput and select the whole text range.
     if ([view conformsToProtocol:@protocol(UITextInput)]) {
-        id <UITextInput> textInput = (id <UITextInput>)view;
+        id<UITextInput> textInput = (id<UITextInput>)view;
         [textInput setSelectedTextRange:[textInput textRangeFromPosition:textInput.beginningOfDocument toPosition:textInput.endOfDocument]];
         
         [self waitForTimeInterval:0.1];
@@ -455,47 +464,46 @@
     [self enterTextIntoCurrentFirstResponder:text];
 }
 
-- (void) selectDatePickerValue:(NSArray*)datePickerColumnValues {
+- (void)selectDatePickerValue:(NSArray *)datePickerColumnValues
+{
     [self selectPickerValue:datePickerColumnValues pickerType:KIFUIDatePicker];
 }
 
 - (void)selectPickerViewRowWithTitle:(NSString *)title
 {
-    NSArray *dataToSelect = @[title];
+    NSArray *dataToSelect = @[ title ];
     [self selectPickerValue:dataToSelect pickerType:KIFUIPickerView];
 }
 
 - (void)selectPickerViewRowWithTitle:(NSString *)title inComponent:(NSInteger)component
 {
     NSMutableArray *dataToSelect = [[NSMutableArray alloc] init];
-    
+
     // Assume it is datePicker and then test our hypothesis later!
     UIPickerView *pickerView = [[[[UIApplication sharedApplication] datePickerWindow] subviewsWithClassNameOrSuperClassNamePrefix:@"UIPickerView"] lastObject];
-    
+
     // Check which type of UIPickerVIew is visible on current window.
     KIFPickerType pickerType = 0;
     if ([pickerView respondsToSelector:@selector(setDate:animated:)]) {
         pickerType = KIFUIDatePicker;
-    }
-    else {
+    } else {
         pickerType = KIFUIPickerView;
         pickerView = [[[[UIApplication sharedApplication] pickerViewWindow] subviewsWithClassNameOrSuperClassNamePrefix:@"UIPickerView"] lastObject];
     }
-    
+
     // Add title at component index and add empty strings for other.
     // This support legacy function re-use.
     for (int i = 0; i < pickerView.numberOfComponents; i++) {
         if (component == i) {
             [dataToSelect addObject:title];
-        }
-        else {
+        } else {
             NSInteger currentIndex = [pickerView selectedRowInComponent:i];
             NSString *rowTitle = nil;
             if ([pickerView.delegate respondsToSelector:@selector(pickerView:titleForRow:forComponent:)]) {
-                rowTitle = [pickerView.delegate pickerView:pickerView titleForRow:currentIndex forComponent: i];
+                rowTitle = [pickerView.delegate pickerView:pickerView titleForRow:currentIndex forComponent:i];
             } else if ([pickerView.delegate respondsToSelector:@selector(pickerView:viewForRow:forComponent:reusingView:)]) {
                 // This delegate inserts views directly, so try to figure out what the title is by looking for a label
-                UIView *rowView = [pickerView.delegate pickerView:pickerView viewForRow:currentIndex forComponent: i reusingView:nil];
+                UIView *rowView = [pickerView.delegate pickerView:pickerView viewForRow:currentIndex forComponent:i reusingView:nil];
                 NSArray *labels = [rowView subviewsWithClassNameOrSuperClassNamePrefix:@"UILabel"];
                 UILabel *label = (labels.count > 0 ? labels[0] : nil);
                 rowTitle = label.text;
@@ -508,12 +516,12 @@
             }
         }
     }
-    
+
     [self selectPickerValue:dataToSelect pickerType:pickerType];
 }
 
-- (void) selectPickerValue:(NSArray*)pickerColumnValues pickerType:(KIFPickerType)pickerType {
-    
+- (void)selectPickerValue:(NSArray *)pickerColumnValues pickerType:(KIFPickerType)pickerType
+{
     [self runBlock:^KIFTestStepResult(NSError **error) {
         NSInteger columnCount = [pickerColumnValues count];
         NSMutableArray* found_values = [NSMutableArray arrayWithCapacity:columnCount];
@@ -598,39 +606,42 @@
         
         return KIFTestStepResultSuccess;
     }];
-    
 }
 
 - (void)setOn:(BOOL)switchIsOn forSwitchWithAccessibilityLabel:(NSString *)label
 {
     UIView *view = nil;
     UIAccessibilityElement *element = nil;
-    
+
     [self waitForAccessibilityElement:&element view:&view withLabel:label value:nil traits:UIAccessibilityTraitButton tappable:YES];
-    
+
     if (![view isKindOfClass:[UISwitch class]]) {
         [self failWithError:[NSError KIFErrorWithFormat:@"View with accessibility label \"%@\" is a %@, not a UISwitch", label, NSStringFromClass([view class])] stopTest:YES];
     }
-    
     UISwitch *switchView = (UISwitch *)view;
-    
+
+    [self setSwitch:switchView element:element On:switchIsOn];
+}
+
+- (void)setSwitch:(UISwitch *)switchView element:(UIAccessibilityElement *)element On:(BOOL)switchIsOn
+{
     // No need to switch it if it's already in the correct position
     if (switchView.isOn == switchIsOn) {
         return;
     }
-    
-    [self tapAccessibilityElement:element inView:view];
-    
+
+    [self tapAccessibilityElement:element inView:switchView];
+
     // If we succeeded, stop the test.
     if (switchView.isOn == switchIsOn) {
         return;
     }
-    
-    NSLog(@"Faking turning switch %@ with accessibility label %@", switchIsOn ? @"ON" : @"OFF", label);
+
+    NSLog(@"Faking turning switch %@", switchIsOn ? @"ON" : @"OFF");
     [switchView setOn:switchIsOn animated:YES];
     [switchView sendActionsForControlEvents:UIControlEventValueChanged];
     [self waitForTimeInterval:0.5];
-    
+
     // We gave it our best shot.  Fail the test.
     if (switchView.isOn != switchIsOn) {
         [self failWithError:[NSError KIFErrorWithFormat:@"Failed to toggle switch to \"%@\"; instead, it was \"%@\"", switchIsOn ? @"ON" : @"OFF", switchView.on ? @"ON" : @"OFF"] stopTest:YES];
@@ -638,32 +649,31 @@
 }
 
 
-
 - (void)setValue:(float)value forSliderWithAccessibilityLabel:(NSString *)label
 {
     UISlider *slider = nil;
     UIAccessibilityElement *element = nil;
     [self waitForAccessibilityElement:&element view:&slider withLabel:label value:nil traits:UIAccessibilityTraitNone tappable:YES];
-    
+
     if (![slider isKindOfClass:[UISlider class]]) {
         [self failWithError:[NSError KIFErrorWithFormat:@"View with accessibility label \"%@\" is a %@, not a UISlider", label, NSStringFromClass([slider class])] stopTest:YES];
     }
-	[self setValue:value forSlider:slider];
+    [self setValue:value forSlider:slider];
 }
 
 - (void)setValue:(float)value forSlider:(UISlider *)slider
 {
-	if (value < slider.minimumValue) {
-		[self failWithError:[NSError KIFErrorWithFormat:@"Cannot slide past minimum value of %f", slider.minimumValue] stopTest:YES];
-	}
-	
-	if (value > slider.maximumValue) {
-		[self failWithError:[NSError KIFErrorWithFormat:@"Cannot slide past maximum value of %f", slider.maximumValue] stopTest:YES];
-	}
+    if (value < slider.minimumValue) {
+        [self failWithError:[NSError KIFErrorWithFormat:@"Cannot slide past minimum value of %f", slider.minimumValue] stopTest:YES];
+    }
 
-	CGRect trackRect = [slider trackRectForBounds:slider.bounds];
-	CGPoint currentPosition = CGPointCenteredInRect([slider thumbRectForBounds:slider.bounds trackRect:trackRect value:slider.value]);
-	CGPoint finalPosition = CGPointCenteredInRect([slider thumbRectForBounds:slider.bounds trackRect:trackRect value:value]);
+    if (value > slider.maximumValue) {
+        [self failWithError:[NSError KIFErrorWithFormat:@"Cannot slide past maximum value of %f", slider.maximumValue] stopTest:YES];
+    }
+
+    CGRect trackRect = [slider trackRectForBounds:slider.bounds];
+    CGPoint currentPosition = CGPointCenteredInRect([slider thumbRectForBounds:slider.bounds trackRect:trackRect value:slider.value]);
+    CGPoint finalPosition = CGPointCenteredInRect([slider thumbRectForBounds:slider.bounds trackRect:trackRect value:value]);
 
     if (value == slider.minimumValue) {
         finalPosition.x = 0;
@@ -671,7 +681,7 @@
         finalPosition.x = slider.bounds.size.width;
     }
 
-	[slider dragFromPoint:currentPosition toPoint:finalPosition steps:10];
+    [slider dragFromPoint:currentPosition toPoint:finalPosition steps:10];
 }
 
 - (void)dismissPopover
@@ -715,10 +725,10 @@
         
         return KIFTestStepResultSuccess;
     }];
-    
+
     // Wait for media picker view controller to be pushed.
     [self waitForTimeInterval:1];
-    
+
     // Tap the desired photo in the grid
     // TODO: This currently only works for the first page of photos. It should scroll appropriately at some point.
     const CGFloat headerHeight = 64.0;
@@ -737,7 +747,7 @@
     [self tapRowAtIndexPath:indexPath inTableView:tableView];
 }
 
-- (void)tapRowInTableViewWithAccessibilityLabel:(NSString*)tableViewLabel atIndexPath:(NSIndexPath *)indexPath
+- (void)tapRowInTableViewWithAccessibilityLabel:(NSString *)tableViewLabel atIndexPath:(NSIndexPath *)indexPath
 {
     UITableView *tableView = (UITableView *)[self waitForViewWithAccessibilityLabel:tableViewLabel];
     [self tapRowAtIndexPath:indexPath inTableView:tableView];
@@ -748,7 +758,7 @@
     UITableViewCell *cell = [self waitForCellAtIndexPath:indexPath inTableView:tableView];
     CGRect cellFrame = [cell.contentView convertRect:cell.contentView.frame toView:tableView];
     [tableView tapAtPoint:CGPointCenteredInRect(cellFrame)];
-    
+
     [self waitForAnimationsToFinish];
 }
 
@@ -759,7 +769,8 @@
     [self tapItemAtIndexPath:indexPath inCollectionView:collectionView];
 }
 
-- (void)acknowledgeSystemAlert {
+- (void)acknowledgeSystemAlert
+{
     [UIAutomationHelper acknowledgeSystemAlert];
 }
 
@@ -767,10 +778,10 @@
 {
     UICollectionViewCell *cell;
     cell = [self waitForCellAtIndexPath:indexPath inCollectionView:collectionView];
-    
+
     CGRect cellFrame = [cell.contentView convertRect:cell.contentView.frame toView:collectionView];
     [collectionView tapAtPoint:CGPointCenteredInRect(cellFrame)];
-    
+
     [self waitForAnimationsToFinish];
 }
 
@@ -786,15 +797,19 @@
 
 - (void)swipeViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits inDirection:(KIFSwipeDirection)direction
 {
-    const NSUInteger kNumberOfPointsInSwipePath = 20;
-
-    // The original version of this came from http://groups.google.com/group/kif-framework/browse_thread/thread/df3f47eff9f5ac8c
-
     UIView *viewToSwipe = nil;
     UIAccessibilityElement *element = nil;
 
     [self waitForAccessibilityElement:&element view:&viewToSwipe withLabel:label value:value traits:traits tappable:NO];
 
+    [self swipeElement:element inView:viewToSwipe inDirection:direction];
+}
+
+- (void)swipeElement:(UIAccessibilityElement *)element inView:(UIView *)viewToSwipe inDirection:(KIFSwipeDirection)direction
+{
+    const NSUInteger kNumberOfPointsInSwipePath = 20;
+
+    // The original version of this came from http://groups.google.com/group/kif-framework/browse_thread/thread/df3f47eff9f5ac8c
     // Within this method, all geometry is done in the coordinate system of the view to swipe.
 
     CGRect elementFrame = [viewToSwipe.windowOrIdentityWindow convertRect:element.accessibilityFrame toView:viewToSwipe];
@@ -803,6 +818,7 @@
 
     [viewToSwipe dragFromPoint:swipeStart displacement:swipeDisplacement steps:kNumberOfPointsInSwipePath];
 }
+
 
 - (void)scrollViewWithAccessibilityLabel:(NSString *)label byFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction
 {
@@ -823,17 +839,17 @@
 - (void)scrollAccessibilityElement:(UIAccessibilityElement *)element inView:(UIView *)viewToScroll byFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction
 {
     const NSUInteger kNumberOfPointsInScrollPath = 5;
-    
+
     // Within this method, all geometry is done in the coordinate system of the view to scroll.
-    
+
     CGRect elementFrame = [viewToScroll.windowOrIdentityWindow convertRect:element.accessibilityFrame toView:viewToScroll];
-    
+
     KIFDisplacement scrollDisplacement = CGPointMake(elementFrame.size.width * horizontalFraction, elementFrame.size.height * verticalFraction);
-    
+
     CGPoint scrollStart = CGPointCenteredInRect(elementFrame);
     scrollStart.x -= scrollDisplacement.x / 2;
     scrollStart.y -= scrollDisplacement.y / 2;
-    
+
     [viewToScroll dragFromPoint:scrollStart displacement:scrollDisplacement steps:kNumberOfPointsInScrollPath];
 }
 
@@ -913,9 +929,9 @@
         
         return KIFTestStepResultSuccess;
     }];
-    
+
     [self waitForTimeInterval:0.1]; // Let things settle.
-    
+
 
     return cell;
 }
@@ -932,15 +948,15 @@
     if (![collectionView isKindOfClass:[UICollectionView class]]) {
         [self failWithError:[NSError KIFErrorWithFormat:@"View is not a collection view"] stopTest:YES];
     }
-    
+
     NSInteger section = indexPath.section;
-    NSInteger item    = indexPath.item;
-    
+    NSInteger item = indexPath.item;
+
     // If section < 0, search from the end of the table.
     if (section < 0) {
         section += collectionView.numberOfSections;
     }
-    
+
     // If item < 0, search from the end of the section.
     if (item < 0) {
         item += [collectionView numberOfItemsInSection:section];
@@ -975,7 +991,7 @@
     }
     
     if (!cell) {
-        [self failWithError:[NSError KIFErrorWithFormat: @"Collection view cell at index path %@ not found", indexPath] stopTest:YES];
+        [self failWithError:[NSError KIFErrorWithFormat:@"Collection view cell at index path %@ not found", indexPath] stopTest:YES];
     }
 
     return cell;
@@ -987,14 +1003,14 @@
         KIFTestWaitCondition(![UIApplication sharedApplication].statusBarHidden, error, @"Expected status bar to be visible.");
         return KIFTestStepResultSuccess;
     }];
-    
+
     UIWindow *statusBarWindow = [[UIApplication sharedApplication] statusBarWindow];
     NSArray *statusBars = [statusBarWindow subviewsWithClassNameOrSuperClassNamePrefix:@"UIStatusBar"];
-    
+
     if (statusBars.count == 0) {
-        [self failWithError:[NSError KIFErrorWithFormat: @"Could not find the status bar"] stopTest:YES];
+        [self failWithError:[NSError KIFErrorWithFormat:@"Could not find the status bar"] stopTest:YES];
     }
-    
+
     [self tapAccessibilityElement:statusBars[0] inView:statusBars[0]];
 }
 
@@ -1002,9 +1018,13 @@
 {
     UITableView *tableView;
     [self waitForAccessibilityElement:NULL view:&tableView withIdentifier:identifier tappable:NO];
-    
+    [self moveRowAtIndexPath:sourceIndexPath toIndexPath:destinationIndexPath inTableView:tableView];
+}
+
+- (void)moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath inTableView:(UITableView *)tableView
+{
     UITableViewCell *cell = [self waitForCellAtIndexPath:sourceIndexPath inTableView:tableView];
-    
+
     NSError *error = nil;
     if (![tableView dragCell:cell toIndexPath:destinationIndexPath error:&error]) {
         [self failWithError:error stopTest:YES];
@@ -1012,4 +1032,3 @@
 }
 
 @end
-

--- a/Classes/KIFUIViewTestActor.h
+++ b/Classes/KIFUIViewTestActor.h
@@ -1,0 +1,81 @@
+//
+//  KIFUIViewActor.h
+//  KIF
+//
+//  Created by Alex Odawa on 1/21/15.
+//
+//
+
+#import <KIF/KIF.h>
+
+#define viewTester KIFActorWithClass(KIFUIViewTestActor)
+
+
+@interface KIFUIViewTestActor : KIFTestActor
+
+@property (nonatomic, strong, readonly) UIView *view;
+@property (nonatomic, strong, readonly) UIAccessibilityElement *element;
+@property (nonatomic, strong, readonly) NSPredicate *predicate;
+@property (nonatomic, assign, readonly) BOOL hasMatch;
+
+- (instancetype)usingPredicate:(NSPredicate *)predicate;
+- (instancetype)usingAccessibilityLabel:(NSString *)accessibilityLabel;
+- (instancetype)usingAccessibilityIdentifier:(NSString *)accessibilityIdentifier;
+- (instancetype)usingTraits:(UIAccessibilityTraits)traits;
+- (instancetype)usingValue:(NSString *)value;
+
+- (void)tap;
+- (void)longPress;
+- (void)longPressWithDuration:(NSTimeInterval)duration;
+
+- (void)tapScreenAtPoint:(CGPoint)screenPoint;
+- (void)swipeInDirection:(KIFSwipeDirection)direction;
+
+- (void)waitForView;
+- (void)waitForAbsenceOfView;
+- (void)waitToBecomeTappable;
+- (void)waitToBecomeFirstResponder;
+
+- (BOOL)tryFindingView;
+- (BOOL)tryFindingTappableView;
+
+- (void)enterText:(NSString *)text;
+- (void)enterText:(NSString *)text expectedResult:(NSString *)expectedResult;
+- (void)enterTextIntoCurrentFirstResponder:(NSString *)text;
+- (void)enterTextIntoCurrentFirstResponder:(NSString *)text fallbackView:(UIView *)fallbackView;
+
+- (void)clearText;
+- (void)clearTextFromFirstResponder;
+- (void)clearAndEnterText:(NSString *)text;
+- (void)clearAndEnterText:(NSString *)text expectedResult:(NSString *)expectedResult;
+
+- (void)waitForSoftwareKeyboard;
+- (void)waitForAbsenceOfSoftwareKeyboard;
+- (void)waitForKeyInputReady;
+
+- (void)setSliderValue:(float)value;
+- (void)setSwitchOn:(BOOL)switchIsOn;
+
+- (void)tapRowInTableViewAtIndexPath:(NSIndexPath *)indexPath;
+- (UITableViewCell *)waitForCellInTableViewAtIndexPath:(NSIndexPath *)indexPath;
+- (void)moveRowInTableViewAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath;
+
+- (void)tapCollectionViewItemAtIndexPath:(NSIndexPath *)indexPath;
+- (UICollectionViewCell *)waitForCellInCollectionViewAtIndexPath:(NSIndexPath *)indexPath;
+
+- (void)scrollByFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction;
+
+- (void)selectPickerViewRowWithTitle:(NSString *)title;
+- (void)selectPickerViewRowWithTitle:(NSString *)title inComponent:(NSInteger)component;
+- (void)selectDatePickerValue:(NSArray *)datePickerColumnValues;
+- (void)choosePhotoInAlbum:(NSString *)albumName atRow:(NSInteger)row column:(NSInteger)column;
+
+- (void)tapStatusBar;
+- (void)dismissPopover;
+
+#if TARGET_IPHONE_SIMULATOR
+- (void)acknowledgeSystemAlert;
+#endif
+
+
+@end

--- a/Classes/KIFUIViewTestActor.m
+++ b/Classes/KIFUIViewTestActor.m
@@ -1,0 +1,395 @@
+//
+//  KIFUIViewActor.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/21/15.
+//
+//
+
+#import "KIFUIViewTestActor.h"
+#import "UIWindow-KIFAdditions.h"
+
+
+@interface KIFUIViewTestActor ()
+
+@property (nonatomic, strong, readonly) KIFUITestActor *actor;
+@property (nonatomic, strong, readwrite) NSPredicate *predicate;
+
+@end
+
+
+@implementation KIFUIViewTestActor
+
+#pragma mark - Initialization
+
+- (instancetype)usingPredicate:(NSPredicate *)predicate;
+{
+
+    [self _appendPredicate:predicate];
+    return  self;
+}
+
+- (instancetype)usingAccessibilityLabel:(NSString *)accessibilityLabel;
+{
+    int systemVersion = [UIDevice currentDevice].systemVersion.intValue;
+
+    if ([accessibilityLabel rangeOfString:@"\n"].location == NSNotFound || systemVersion == 6) {
+        return [self usingPredicate:[NSPredicate predicateWithFormat:@"accessibilityLabel == %@", accessibilityLabel]];
+    }
+
+    // On iOS 6 the accessibility label may contain line breaks, so when trying to find the
+    // element, these line breaks are necessary. But on iOS 7 the system replaces them with
+    // spaces. So the same test breaks on either iOS 6 or iOS 7. iOS 8 befuddles this again by
+    // limiting replacement to spaces in between strings.
+    // UNLESS the accessibility label is set programatically in which case the line breaks remain regardless of OS version.
+    // To work around this replace the line breaks using the preferred method and try matching both.
+
+    //this feels horribly hacky and looks bad in our - (NSString *)description :( but tests are passing
+    // We might consider replaceing the predicate with a block that can do cleaner checking,
+
+    NSString *alternate = nil;
+    if (systemVersion == 7) {
+        alternate = [accessibilityLabel stringByReplacingOccurrencesOfString:@"\n" withString:@" "];
+    } else {
+        alternate = [accessibilityLabel stringByReplacingOccurrencesOfString:@"\\b\\n\\b" withString:@" " options:NSRegularExpressionSearch range:NSMakeRange(0, accessibilityLabel.length)];
+    }
+
+    return [self usingPredicate:[NSPredicate predicateWithFormat:@"accessibilityLabel == %@ OR accessibilityLabel == %@", accessibilityLabel, alternate]];
+}
+
+- (instancetype)usingAccessibilityIdentifier:(NSString *)accessibilityIdentifier;
+{
+    return [self usingPredicate:[NSPredicate predicateWithFormat:@"accessibilityIdentifier == %@", accessibilityIdentifier]];
+}
+
+- (instancetype)usingTraits:(UIAccessibilityTraits)traits;
+{
+    return [self usingPredicate:[NSPredicate predicateWithFormat:@"(accessibilityTraits & %@) == %@", @(traits), @(traits)]];
+}
+
+- (instancetype)usingValue:(NSString *)value;
+{
+    return [self usingPredicate:[NSPredicate predicateWithFormat:@"accessibilityValue == %@", value]];
+}
+
+#pragma mark - System Actions
+
+#if TARGET_IPHONE_SIMULATOR
+- (void)acknowledgeSystemAlert;
+{
+    [self.actor acknowledgeSystemAlert];
+}
+#endif
+
+- (void)tapStatusBar;
+{
+    [self.actor tapStatusBar];
+}
+
+- (void)dismissPopover;
+{
+    [self.actor dismissPopover];
+}
+
+#pragma mark - Waiting
+
+- (void)waitForView;
+{
+    [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+}
+
+- (void)waitForAbsenceOfView;
+{
+    [self runBlock:^KIFTestStepResult(NSError **error) {
+        // If the app is ignoring interaction events, then wait before doing our analysis
+        KIFTestWaitCondition(![[UIApplication sharedApplication] isIgnoringInteractionEvents], error, @"Application is ignoring interaction events.");
+        
+        // If the element can't be found, then we're done
+        KIFUIObject *found = [self _predicateSearchWithRequiresMatch:NO mustBeTappable:NO];
+        if (!found) {
+            return KIFTestStepResultSuccess;
+        }
+        
+        // If we found an element, but it's not associated with a view, then something's wrong. Wait it out and try again.
+        KIFTestWaitCondition(found.view, error, @"Cannot find view containing accessibility element \"%@\"", found.element);
+        
+        // Hidden views count as absent
+        KIFTestWaitCondition([found.view isHidden] || [found.view superview] == nil, error, @"Accessibility element \"%@\" is visible and not hidden.", found);
+        
+        return KIFTestStepResultSuccess;
+    }];
+}
+
+- (void)waitToBecomeTappable;
+
+{
+    [self _predicateSearchWithRequiresMatch:YES mustBeTappable:YES];
+}
+
+- (void)waitToBecomeFirstResponder;
+{
+    [self runBlock:^KIFTestStepResult(NSError **error) {
+        UIResponder *firstResponder = [[[UIApplication sharedApplication] keyWindow] firstResponder];
+
+        KIFTestWaitCondition([self.predicate evaluateWithObject:firstResponder], error, @"Expected first responder to match '%@', got '%@'", self.predicate, firstResponder);
+        return KIFTestStepResultSuccess;
+    }];
+}
+#pragma mark Typist Waiting
+
+- (void)waitForSoftwareKeyboard;
+{
+    [self.actor waitForSoftwareKeyboard];
+}
+- (void)waitForAbsenceOfSoftwareKeyboard;
+{
+    [self.actor waitForAbsenceOfSoftwareKeyboard];
+}
+- (void)waitForKeyInputReady;
+{
+    [self.actor waitForKeyInputReady];
+}
+
+#pragma mark - Conditionals
+
+- (BOOL)tryFindingView;
+{
+    return [self _predicateSearchWithRequiresMatch:NO mustBeTappable:NO];
+}
+
+- (BOOL)tryFindingTappableView;
+{
+    return [self _predicateSearchWithRequiresMatch:NO mustBeTappable:YES];
+}
+
+
+#pragma mark - Tap Actions
+
+- (void)tap;
+{
+    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:YES];
+    [self.actor tapAccessibilityElement:found.element inView:found.view];
+}
+
+- (void)longPress;
+{
+    [self longPressWithDuration:.5];
+}
+
+- (void)longPressWithDuration:(NSTimeInterval)duration;
+{
+    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:YES];
+    [self.actor longPressAccessibilityElement:found.element inView:found.view duration:duration];
+}
+
+#pragma mark - Text Actions;
+
+- (void)clearText;
+{
+    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    [self.actor clearTextFromElement:found.element inView:found.view];
+}
+
+- (void)clearTextFromFirstResponder;
+{
+    [self.actor clearTextFromFirstResponder];
+}
+
+- (void)enterText:(NSString *)text;
+{
+    [self enterText:text expectedResult:nil];
+}
+
+- (void)enterText:(NSString *)text expectedResult:(NSString *)expectedResult;
+{
+    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    [self.actor enterText:text intoElement:found.element inView:found.view expectedResult:expectedResult];
+}
+
+- (void)clearAndEnterText:(NSString *)text;
+{
+    [self clearAndEnterText:text expectedResult:nil];
+}
+
+- (void)clearAndEnterText:(NSString *)text expectedResult:(NSString *)expectedResult;
+{
+    [self clearText];
+    [self enterText:text expectedResult:expectedResult];
+}
+
+- (void)enterTextIntoCurrentFirstResponder:(NSString *)text;
+{
+    [self.actor enterTextIntoCurrentFirstResponder:text];
+}
+
+- (void)enterTextIntoCurrentFirstResponder:(NSString *)text fallbackView:(UIView *)fallbackView;
+{
+    [self.actor enterTextIntoCurrentFirstResponder:text fallbackView:fallbackView];
+}
+
+- (void)expectToContainText:(NSString *)expectedResult;
+{
+    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    [self.actor expectView:found.view toContainText:expectedResult];
+}
+
+
+#pragma mark - Touch Actions
+
+- (void)tapScreenAtPoint:(CGPoint)screenPoint;
+{
+    [self.actor tapScreenAtPoint:screenPoint];
+}
+
+- (void)swipeInDirection:(KIFSwipeDirection)direction;
+{
+    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    [self.actor swipeElement:found.element inView:found.view inDirection:direction];
+}
+
+#pragma mark - Scroll/Table/CollectionView Actions
+
+- (void)scrollByFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction;
+{
+    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    [self.actor scrollAccessibilityElement:found.element inView:found.view byFractionOfSizeHorizontal:horizontalFraction vertical:verticalFraction];
+}
+
+- (void)tapRowInTableViewAtIndexPath:(NSIndexPath *)indexPath;
+{
+    KIFUIObject *found = [[self _usingExpectedClass:[UITableView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    [self.actor tapRowAtIndexPath:indexPath inTableView:(UITableView *)found.view];
+}
+
+- (UITableViewCell *)waitForCellInTableViewAtIndexPath:(NSIndexPath *)indexPath;
+{
+    KIFUIObject *found = [[self _usingExpectedClass:[UITableView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    return [self.actor waitForCellAtIndexPath:indexPath inTableView:(UITableView *)found.view];
+}
+
+- (void)moveRowInTableViewAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath;
+{
+    KIFUIObject *found = [[self _usingExpectedClass:[UITableView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    [self.actor moveRowAtIndexPath:sourceIndexPath toIndexPath:destinationIndexPath inTableView:(UITableView *)found.view];
+}
+
+
+- (void)tapCollectionViewItemAtIndexPath:(NSIndexPath *)indexPath;
+{
+    KIFUIObject *found = [[self _usingExpectedClass:[UICollectionView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    [self.actor tapItemAtIndexPath:indexPath inCollectionView:(UICollectionView *)found.view];
+}
+
+- (UICollectionViewCell *)waitForCellInCollectionViewAtIndexPath:(NSIndexPath *)indexPath;
+{
+    KIFUIObject *found = [[self _usingExpectedClass:[UICollectionView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    return [self.actor waitForCellAtIndexPath:indexPath inCollectionView:(UICollectionView *)found.view];
+}
+
+
+#pragma mark - UIControl Actions
+
+- (void)setSliderValue:(float)value;
+{
+    KIFUIObject *found = [[self _usingExpectedClass:[UISlider class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    [self.actor setValue:value forSlider:(UISlider *)found.view];
+}
+
+- (void)setSwitchOn:(BOOL)switchIsOn;
+{
+    KIFUIObject *found = [[self _usingExpectedClass:[UISwitch class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    [self.actor setSwitch:(UISwitch *)found.view element:found.element On:switchIsOn];
+}
+
+#pragma mark - Picker Actions
+
+- (void)selectPickerViewRowWithTitle:(NSString *)title;
+{
+    [self.actor selectPickerViewRowWithTitle:title];
+}
+
+- (void)selectPickerViewRowWithTitle:(NSString *)title inComponent:(NSInteger)component;
+{
+    [self.actor selectPickerViewRowWithTitle:title inComponent:component];
+}
+
+- (void)selectDatePickerValue:(NSArray *)datePickerColumnValues;
+{
+    [self.actor selectDatePickerValue:datePickerColumnValues];
+}
+
+- (void)choosePhotoInAlbum:(NSString *)albumName atRow:(NSInteger)row column:(NSInteger)column;
+{
+    [self.actor choosePhotoInAlbum:albumName atRow:row column:column];
+}
+
+
+#pragma mark - Getters
+
+- (UIView *)view;
+{
+    return [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO].view;
+}
+
+- (UIAccessibilityElement *)element;
+{
+    return [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO].element;
+}
+
+- (BOOL)hasMatch;
+{
+    return [self _predicateSearchWithRequiresMatch:NO mustBeTappable:NO];
+}
+
+- (KIFUITestActor *)actor;
+{
+    return [[KIFUITestActor actorInFile:self.file atLine:self.line delegate:self.delegate] usingTimeout:self.executionBlockTimeout];
+}
+
+#pragma mark - NSObject
+
+- (NSString *)description;
+{
+    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    return [NSString stringWithFormat:@"<%@; view=%@; element=%@; predicate=%@>", [super description], found.view, found.element, self.predicate];
+}
+
+#pragma mark - Private Methods
+
+- (instancetype)_usingExpectedClass:(Class)expectedClass;
+{
+    return [self usingPredicate:[NSPredicate predicateWithFormat:@"self isKindOfClass: %@", expectedClass]];
+}
+
+- (void)_appendPredicate:(NSPredicate *)newPredicate;
+{
+    if (!self.predicate) {
+        self.predicate = newPredicate;
+    } else {
+        NSPredicate *compoundPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[ self.predicate, newPredicate ]];
+        self.predicate = compoundPredicate;
+    }
+}
+
+- (KIFUIObject *)_predicateSearchWithRequiresMatch:(BOOL)requiresMatch mustBeTappable:(BOOL)tappable;
+{
+    __block UIView *foundView = nil;
+    __block UIAccessibilityElement *foundElement = nil;
+
+    if (requiresMatch) {
+        [self.actor waitForAccessibilityElement:&foundElement view:&foundView withElementMatchingPredicate:self.predicate tappable:tappable];
+    } else {
+        NSError *error;
+        [self tryRunningBlock:^KIFTestStepResult(NSError **error) {
+            KIFTestWaitCondition([self.actor tryFindingAccessibilityElement:&foundElement view:&foundView withElementMatchingPredicate:self.predicate tappable:tappable error:error], error, @"Waiting on view matching predicate %@", self.predicate);
+            return KIFTestStepResultSuccess;
+        } complete:nil timeout:1.0 error:&error];
+    }
+
+    if (foundView && foundElement) {
+        return [[KIFUIObject alloc] initWithElement:foundElement view:foundView];
+    }
+    return nil;
+}
+
+@end

--- a/KIF Tests/AccessibilityIdentifierTests_ViewTestActor.m
+++ b/KIF Tests/AccessibilityIdentifierTests_ViewTestActor.m
@@ -1,0 +1,97 @@
+//
+//  NewAccessibilityIdentifierTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+#import <KIF/KIF.h>
+#import <KIF/KIFTestStepValidation.h>
+
+@implementation KIFUIViewTestActor (accessibilityIdentifierTests)
+
+- (instancetype)xButton;
+{
+    return [viewTester usingAccessibilityIdentifier:@"X_BUTTON"];
+}
+
+- (instancetype)notXButton;
+{
+    return [viewTester usingAccessibilityIdentifier:@"NOT_X_BUTTON"];
+}
+
+- (instancetype)idGreeting;
+{
+return [viewTester usingAccessibilityIdentifier:@"idGreeting"];
+}
+
+@end
+
+@interface AccessibilityIdentifierTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation AccessibilityIdentifierTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"Tapping"] tap];
+}
+
+- (void)testWaitingForViewWithAccessibilityIdentifier
+{
+    // Since the tap has occurred in setup, we just need to wait for the result.
+    [[viewTester xButton] waitForView];
+    KIFExpectFailure([[[viewTester notXButton] usingTimeout:0.5] waitForView]);
+}
+
+- (void)testTappingViewWithAccessibilityIdentifier
+{
+    [[viewTester xButton] tap];
+    [[[viewTester usingAccessibilityLabel:@"X"] usingTraits:UIAccessibilityTraitButton | UIAccessibilityTraitSelected] waitForView];
+    KIFExpectFailure([[[viewTester notXButton] usingTimeout:0.5] tap]);
+}
+
+- (void)testWaitingForAbscenceOfViewWithAccessibilityIdentifier
+{
+    // Since the tap has occurred in setup, we just need to wait for the result.
+    [[viewTester xButton] waitForView];
+    [[viewTester notXButton] waitForAbsenceOfView];
+    KIFExpectFailure([[[viewTester notXButton] usingTimeout:0.5] waitForView]);
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+    [[viewTester xButton] waitForAbsenceOfView];
+    [[viewTester usingAccessibilityLabel:@"Tapping"] tap];
+}
+
+- (void)testLongPressingViewWithAccessibilityIdentifier
+{
+    [[viewTester idGreeting] longPressWithDuration:2];
+    [[viewTester usingAccessibilityLabel:@"Select All"] tap];
+}
+
+- (void)testEnteringTextIntoViewWithAccessibilityIdentifier
+{
+    [[viewTester idGreeting] longPressWithDuration:2];
+    [[viewTester usingAccessibilityLabel:@"Select All"] tap];
+    [[viewTester usingAccessibilityLabel:@"Cut"] tap];
+    [[viewTester idGreeting] enterText:@"Yo"];
+}
+
+- (void)testEnteringTextIntoViewWithAccessibilityIdentifierExpectingResults
+{
+    [[viewTester idGreeting] enterText:@", world" expectedResult:@"Hello, world"];
+    [[[[viewTester usingAccessibilityLabel:@"Greeting"] usingValue:@"Hello, world"] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+- (void)testClearingAndEnteringTextIntoViewWithAccessibilityLabel
+{
+    [[viewTester idGreeting] clearAndEnterText:@"Yo"];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+@end

--- a/KIF Tests/CollectionViewTests_ViewTestActor.m
+++ b/KIF Tests/CollectionViewTests_ViewTestActor.m
@@ -1,0 +1,82 @@
+//
+//  NewCollectionViewTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/27/15.
+//
+//
+
+#import <KIF/KIF.h>
+#import "KIFTestStepValidation.h"
+
+@implementation KIFUIViewTestActor (collectionViewTests)
+
+- (instancetype)collectionView;
+{
+    return [viewTester usingAccessibilityIdentifier:@"CollectionView Tests CollectionView"];
+}
+
+- (instancetype)firstCell;
+{
+    return [viewTester usingAccessibilityLabel:@"First Cell"];
+}
+
+- (instancetype)lastCell;
+{
+    return [viewTester usingAccessibilityLabel:@"Last Cell"];
+}
+
+@end
+
+@interface CollectionViewTests_ViewTestActor : KIFTestCase
+@end
+
+@implementation CollectionViewTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"CollectionViews"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testTappingItems
+{
+    [[viewTester collectionView] tapCollectionViewItemAtIndexPath:[NSIndexPath indexPathForItem:199 inSection:0]];
+    [[[viewTester lastCell] usingTraits:UIAccessibilityTraitSelected] waitForView];
+    [[viewTester collectionView] tapCollectionViewItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+    [[[viewTester firstCell] usingTraits:UIAccessibilityTraitSelected] waitForView];
+}
+
+- (void)testTappingLastItemAndSection
+{
+    [[viewTester collectionView] tapCollectionViewItemAtIndexPath:[NSIndexPath indexPathForItem:-1 inSection:-1]];
+    [[[viewTester lastCell] usingTraits:UIAccessibilityTraitSelected] waitForView];
+}
+
+- (void)testOutOfBounds
+{
+    KIFExpectFailure([[[viewTester usingTimeout:1] usingAccessibilityIdentifier:@"CollectionView Tests CollectionView"] tapCollectionViewItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:99]]);
+}
+
+- (void)testUnknownCollectionView
+{
+    KIFExpectFailure([[[viewTester usingTimeout:1] usingAccessibilityIdentifier:@"Unknown CollectionView"] tapCollectionViewItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
+}
+
+- (void)testTappingItemsByLabel
+{
+    // Tap the first item, which is already visible
+    [[viewTester firstCell] tap];
+
+    // Tap the last item, which will need to be scrolled up
+    [[viewTester lastCell] tap];
+
+    // Tap the first item, which will need to be scrolled down
+    [[viewTester firstCell] tap];
+}
+
+@end

--- a/KIF Tests/CompositionTests_ViewTestActor.m
+++ b/KIF Tests/CompositionTests_ViewTestActor.m
@@ -1,0 +1,68 @@
+//
+//  NewCompositionTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/27/15.
+//
+//
+
+#import <KIF/KIF.h>
+#import "UIApplication-KIFAdditions.h"
+#import "UIAccessibilityElement-KIFAdditions.h"
+
+@interface KIFUIViewTestActor (Composition)
+
+- (void)tapViewIfNotSelected:(NSString *)label;
+- (void)tapViewWithAccessibilityHint:(NSString *)hint;
+
+@end
+
+@implementation KIFUIViewTestActor (Composition)
+
+- (void)tapViewIfNotSelected:(NSString *)label
+{
+    UIAccessibilityElement *element = [viewTester usingAccessibilityLabel:label].element;
+    if ((element.accessibilityTraits & UIAccessibilityTraitSelected) == UIAccessibilityTraitNone) {
+        [[[viewTester usingAccessibilityLabel:label] usingPredicate:[NSPredicate predicateWithFormat:@"(accessibilityTraits & %i) == %i", UIAccessibilityTraitSelected, UIAccessibilityTraitNone]] tap];
+    }
+}
+
+- (void)tapViewWithAccessibilityHint:(NSString *)hint
+{
+    [[viewTester usingPredicate:[NSPredicate predicateWithFormat:@"accessibilityHint like %@", hint]] tap];
+}
+
+@end
+
+@interface CompositionTests_ViewTestActor : KIFTestCase
+@end
+
+@implementation CompositionTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"Show/Hide"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testTappingViewWithHint
+{
+    [viewTester tapViewWithAccessibilityHint:@"A button for A"];
+    [[[viewTester usingAccessibilityLabel:@"A"] usingTraits:UIAccessibilityTraitSelected] waitForView];
+}
+
+- (void)testTappingOnlyIfNotSelected
+{
+    [viewTester tapViewIfNotSelected:@"A"];
+    [[[viewTester usingAccessibilityLabel:@"A"] usingTraits:UIAccessibilityTraitSelected] waitForView];
+
+    // This should not deselect the element.
+    [viewTester tapViewIfNotSelected:@"A"];
+    [[[viewTester usingAccessibilityLabel:@"A"] usingTraits:UIAccessibilityTraitSelected] waitForView];
+}
+
+@end

--- a/KIF Tests/ExistTests_ViewTestActor.m
+++ b/KIF Tests/ExistTests_ViewTestActor.m
@@ -1,0 +1,46 @@
+//
+//  NewExistsTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+#import <KIF/KIF.h>
+@implementation KIFUIViewTestActor (absenceTests)
+
+- (instancetype)tapping;
+{
+    return [viewTester usingAccessibilityLabel:@"Tapping"];
+}
+
+- (instancetype)testSuite;
+{
+    return [viewTester usingAccessibilityLabel:@"Test Suite"];
+}
+
+@end
+
+
+@interface ExistTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation ExistTests_ViewTestActor
+
+- (void)testExistsViewWithAccessibilityLabel
+{
+    if ([[viewTester tapping] tryFindingTappableView] && ![[[viewTester testSuite] usingTraits:UIAccessibilityTraitButton] tryFindingTappableView]) {
+        [[viewTester tapping] tap];
+    } else {
+        [viewTester fail];
+    }
+
+    if ([[viewTester testSuite] tryFindingTappableView] && ![[viewTester tapping] tryFindingTappableView]) {
+        [[[viewTester testSuite] usingTraits:UIAccessibilityTraitButton] tap];
+    } else {
+        [viewTester fail];
+    }
+}
+
+@end

--- a/KIF Tests/GestureTests_ViewTestActor.m
+++ b/KIF Tests/GestureTests_ViewTestActor.m
@@ -1,0 +1,127 @@
+//
+//  NewGestureTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/27/15.
+//
+//
+
+
+#import <KIF/KIF.h>
+#import <KIF/KIFTestStepValidation.h>
+@implementation KIFUIViewTestActor (gestureTests)
+
+- (instancetype)swipeMe
+{
+    return [self usingAccessibilityLabel:@"Swipe Me"];
+}
+
+- (instancetype)right;
+{
+    return [viewTester usingAccessibilityLabel:@"Right"];
+}
+
+- (instancetype)left;
+{
+    return [viewTester usingAccessibilityLabel:@"Left"];
+}
+
+- (instancetype)up;
+{
+    return [viewTester usingAccessibilityLabel:@"Up"];
+}
+
+- (instancetype)down;
+{
+    return [viewTester usingAccessibilityLabel:@"Down"];
+}
+@end
+
+
+@interface GestureTests_ViewTestActor : KIFTestCase
+@end
+
+@implementation GestureTests_ViewTestActor
+
+- (void)beforeAll
+{
+    [[viewTester usingAccessibilityLabel:@"Gestures"] tap];
+}
+
+- (void)afterAll
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testSwipingLeft
+{
+    [[viewTester swipeMe] swipeInDirection:KIFSwipeDirectionLeft];
+    [[viewTester left] waitForView];
+}
+
+- (void)testSwipingRight
+{
+    [[viewTester swipeMe] swipeInDirection:KIFSwipeDirectionRight];
+    [[viewTester right] waitForView];
+}
+
+- (void)testSwipingUp
+{
+    [[viewTester swipeMe] swipeInDirection:KIFSwipeDirectionUp];
+    [[viewTester up] waitForView];
+}
+
+- (void)testSwipingDown
+{
+    [[viewTester swipeMe] swipeInDirection:KIFSwipeDirectionDown];
+    [[viewTester down] waitForView];
+}
+
+- (void)testMissingSwipeableElement
+{
+    KIFExpectFailure([[[viewTester usingTimeout:0.25] usingAccessibilityLabel:@"Unknown"] swipeInDirection:KIFSwipeDirectionDown]);
+}
+
+- (void)testSwipingLeftWithTraits
+{
+    [[[viewTester swipeMe] usingTraits:UIAccessibilityTraitStaticText] swipeInDirection:KIFSwipeDirectionLeft];
+    [[viewTester left] waitForView];
+}
+
+- (void)testSwipingRightWithTraits
+{
+    [[[viewTester swipeMe] usingTraits:UIAccessibilityTraitStaticText] swipeInDirection:KIFSwipeDirectionRight];
+    [[viewTester right] waitForView];
+}
+
+- (void)testSwipingUpWithTraits
+{
+    [[[viewTester swipeMe] usingTraits:UIAccessibilityTraitStaticText] swipeInDirection:KIFSwipeDirectionUp];
+    [[viewTester up] waitForView];
+}
+
+- (void)testSwipingDownWithTraits
+{
+    [[[viewTester swipeMe] usingTraits:UIAccessibilityTraitStaticText] swipeInDirection:KIFSwipeDirectionDown];
+    [[viewTester down] waitForView];
+}
+
+- (void)testMissingSwipeableElementWithTraits
+{
+    KIFExpectFailure([[[[viewTester usingTimeout:0.25] usingAccessibilityLabel:@"Unknown"] usingTraits:UIAccessibilityTraitStaticText] swipeInDirection:KIFSwipeDirectionDown]);
+}
+
+- (void)testScrolling
+{
+    [[viewTester usingAccessibilityIdentifier:@"Scroll View"] scrollByFractionOfSizeHorizontal:-0.9 vertical:-0.9];
+    [[viewTester usingAccessibilityLabel:@"Bottom Right"] waitToBecomeTappable];
+    [[viewTester usingAccessibilityIdentifier:@"Scroll View"] scrollByFractionOfSizeHorizontal:0.9 vertical:0.9];
+    [[viewTester usingAccessibilityLabel:@"Top Left"] waitToBecomeTappable];
+}
+
+- (void)testMissingScrollableElement
+{
+    KIFExpectFailure([[[viewTester usingTimeout:0.25] usingAccessibilityIdentifier:@"Unknown"] scrollByFractionOfSizeHorizontal:0.5 vertical:0.5]);
+}
+
+@end

--- a/KIF Tests/LandscapeTests_ViewTestActor.m
+++ b/KIF Tests/LandscapeTests_ViewTestActor.m
@@ -1,0 +1,40 @@
+//
+//  NewLandscapeTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/27/15.
+//
+//
+
+#import <KIF/KIF.h>
+
+@interface LandscapeTests_ViewTestActor : KIFTestCase
+@end
+
+@implementation LandscapeTests_ViewTestActor
+
+- (void)beforeAll
+{
+    [system simulateDeviceRotationToOrientation:UIDeviceOrientationLandscapeLeft];
+    [[viewTester usingAccessibilityIdentifier:@"Test Suite TableView"] scrollByFractionOfSizeHorizontal:0 vertical:-0.2];
+}
+
+- (void)afterAll
+{
+    [system simulateDeviceRotationToOrientation:UIDeviceOrientationPortrait];
+    [viewTester waitForTimeInterval:0.5];
+}
+
+- (void)beforeEach
+{
+    [viewTester waitForTimeInterval:0.25];
+}
+
+- (void)testThatAlertViewsCanBeTappedInLandscape
+{
+    [[viewTester usingAccessibilityLabel:@"UIAlertView"] tap];
+    [[viewTester usingAccessibilityLabel:@"Continue"] tap];
+    [[viewTester usingAccessibilityLabel:@"Message"] waitForAbsenceOfView];
+}
+
+@end

--- a/KIF Tests/LongPressTests_ViewTestActor.m
+++ b/KIF Tests/LongPressTests_ViewTestActor.m
@@ -1,0 +1,59 @@
+//
+//  ViewLongPressTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+#import <KIF/KIF.h>
+
+@implementation KIFUIViewTestActor (longPressTests)
+
+-(instancetype)greeting;
+{
+    return [viewTester usingAccessibilityLabel:@"Greeting"];
+}
+
+-(instancetype)selectAll;
+{
+    return [viewTester usingAccessibilityLabel:@"Select All"];
+}
+
+@end
+
+@interface LongPressTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation LongPressTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"Tapping"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testLongPressingViewWithAccessibilityLabel
+{
+    [[viewTester greeting] longPressWithDuration:2];
+    [[viewTester selectAll] tap];
+}
+
+- (void)testLongPressingViewViewWithTraits
+{
+    [[[viewTester greeting] usingValue:@"Hello"] longPressWithDuration:2];
+    [[viewTester selectAll] tap];
+}
+
+- (void)testLongPressingViewViewWithValue
+{
+    [[[[viewTester greeting] usingValue:@"Hello"] usingTraits:UIAccessibilityTraitUpdatesFrequently] longPressWithDuration:2];
+    [[viewTester selectAll] tap];
+}
+
+@end

--- a/KIF Tests/ModalViewTests_ViewTestActor.m
+++ b/KIF Tests/ModalViewTests_ViewTestActor.m
@@ -1,0 +1,60 @@
+//
+//  NewModalViewTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/27/15.
+//
+//
+
+#import <KIF/KIF.h>
+
+@interface ModalViewTests_ViewTestActor : KIFTestCase
+@end
+
+@implementation ModalViewTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [viewTester waitForTimeInterval:0.25];
+}
+
+- (void)testInteractionWithAnAlertView
+{
+    [[viewTester usingAccessibilityLabel:@"UIAlertView"] tap];
+    [[viewTester usingAccessibilityLabel:@"Alert View"] waitForView];
+    [[viewTester usingAccessibilityLabel:@"Message"] waitForView];
+    [[viewTester usingAccessibilityLabel:@"Cancel"] waitToBecomeTappable];
+    [[viewTester usingAccessibilityLabel:@"Continue"] waitToBecomeTappable];
+    [[viewTester usingAccessibilityLabel:@"Continue"] tap];
+    [[viewTester usingAccessibilityLabel:@"Message"] waitForAbsenceOfView];
+}
+
+- (void)testInteractionWithAnActionSheet
+{
+    [[viewTester usingAccessibilityLabel:@"UIActionSheet"] tap];
+    [[viewTester usingAccessibilityLabel:@"Action Sheet"] waitForView];
+    [[viewTester usingAccessibilityLabel:@"Destroy"] waitToBecomeTappable];
+    [[viewTester usingAccessibilityLabel:@"A"] waitToBecomeTappable];
+    [[viewTester usingAccessibilityLabel:@"B"] waitToBecomeTappable];
+
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        [viewTester dismissPopover];
+    } else {
+        [[viewTester usingAccessibilityLabel:@"Cancel"] tap];
+    }
+}
+
+- (void)testInteractionWithAnActivityViewController
+{
+    if (!NSClassFromString(@"UIActivityViewController")) {
+        return;
+    }
+
+    [[viewTester usingAccessibilityLabel:@"UIActivityViewController"] tap];
+    [[viewTester usingAccessibilityLabel:@"Copy"] waitToBecomeTappable];
+    [[viewTester usingAccessibilityLabel:@"Mail"] waitToBecomeTappable];
+    [[viewTester usingAccessibilityLabel:@"Cancel"] waitToBecomeTappable];
+    [[viewTester usingAccessibilityLabel:@"Cancel"] tap];
+}
+
+@end

--- a/KIF Tests/MultiFingerTests_ViewTestActor.m
+++ b/KIF Tests/MultiFingerTests_ViewTestActor.m
@@ -1,0 +1,85 @@
+//
+//  NewMultiFingerTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/27/15.
+//
+//
+
+
+#import <KIF/KIF.h>
+#import "KIFTestStepValidation.h"
+#import <KIF/UIApplication-KIFAdditions.h>
+
+@interface MultiFingerTests_ViewTestActor : KIFTestCase
+@property (nonatomic, readwrite) BOOL twoFingerPanSuccess;
+@property (nonatomic, readwrite) BOOL zoomSuccess;
+@end
+
+@implementation MultiFingerTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"ScrollViews"] tap];
+    // reset scroll view
+    UIScrollView *scrollView = (UIScrollView *)[viewTester usingAccessibilityLabel:@"Scroll View"].view;
+    scrollView.contentOffset = CGPointZero;
+
+    self.twoFingerPanSuccess = NO;
+    self.zoomSuccess = NO;
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+    self.twoFingerPanSuccess = NO;
+    self.zoomSuccess = NO;
+}
+
+- (void)testTwoFingerPan
+{
+    CGFloat offset = 50.0;
+
+    UIScrollView *scrollView = (UIScrollView *)[viewTester usingAccessibilityLabel:@"Scroll View"].view;
+    UIPanGestureRecognizer *panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingerPanned)];
+    panGestureRecognizer.minimumNumberOfTouches = 2;
+    [scrollView addGestureRecognizer:panGestureRecognizer];
+
+    CGPoint startPoint = CGPointMake(CGRectGetMidX(scrollView.bounds), CGRectGetMidY(scrollView.bounds));
+    CGPoint endPoint = CGPointMake(startPoint.x, startPoint.y + offset);
+    [scrollView twoFingerPanFromPoint:startPoint toPoint:endPoint steps:10];
+
+    __KIFAssertEqual(self.twoFingerPanSuccess, YES);
+}
+
+- (void)twoFingerPanned
+{
+    self.twoFingerPanSuccess = YES;
+}
+
+- (void)testZoom
+{
+    CGFloat distance = 50.0;
+
+    UIScrollView *scrollView = (UIScrollView *)[viewTester usingAccessibilityLabel:@"Scroll View"].view;
+    UIPinchGestureRecognizer *pinchRecognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self
+                                                                                          action:@selector(zoomed:)];
+
+    [scrollView addGestureRecognizer:pinchRecognizer];
+
+    CGPoint startPoint = CGPointMake(CGRectGetMidX(scrollView.bounds), CGRectGetMidY(scrollView.bounds));
+    [scrollView zoomAtPoint:startPoint distance:distance steps:10];
+
+    __KIFAssertEqual(self.zoomSuccess, YES);
+}
+
+- (void)zoomed:(UIPinchGestureRecognizer *)pinchRecognizer
+{
+    if (pinchRecognizer.state == UIGestureRecognizerStateChanged) {
+        if (pinchRecognizer.scale > 1) {
+            self.zoomSuccess = YES;
+        }
+    }
+}
+
+@end

--- a/KIF Tests/PickerTests_ViewTestActor.m
+++ b/KIF Tests/PickerTests_ViewTestActor.m
@@ -1,0 +1,114 @@
+//
+//  NewPickerTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/27/15.
+//
+//
+
+#import <KIF/KIF.h>
+
+@implementation KIFUIViewTestActor (pickertests)
+
+- (KIFUIViewTestActor *)dateSelector
+{
+    return [self usingAccessibilityLabel:@"Date Selection"];
+}
+
+- (KIFUIViewTestActor *)dateTimeSelector
+{
+    return [self usingAccessibilityLabel:@"Date Time Selection"];
+}
+
+- (KIFUIViewTestActor *)timeSelector
+{
+    return [self usingAccessibilityLabel:@"Time Selection"];
+}
+
+- (KIFUIViewTestActor * )countdownSelector
+{
+    return [self usingAccessibilityLabel:@"Countdown Selection"];
+}
+
+@end
+
+
+@interface PickerTests_ViewTestActor : KIFTestCase
+@end
+
+@implementation PickerTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"Pickers"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testSelectingDateInPast
+{
+    [[viewTester dateSelector] tap];
+    NSArray *date = @[ @"June", @"17", @"1965" ];
+    // If the UIDatePicker LocaleIdentifier would be de_DE then the date to set
+    // would look like this: NSArray *date = @[@"17.", @"Juni", @"1965"
+    [viewTester selectDatePickerValue:date];
+    [[[[viewTester dateSelector] usingValue:@"Jun 17, 1965"] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+- (void)testSelectingDateInFuture
+{
+    [[viewTester dateSelector] tap];
+    NSArray *date = @[ @"December", @"31", @"2030" ];
+    [viewTester selectDatePickerValue:date];
+    [[[[viewTester dateSelector] usingValue:@"Dec 31, 2030"] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+- (void)testSelectingDateTime
+{
+    [[viewTester dateTimeSelector] tap];
+    NSArray *dateTime = @[ @"Jun 17", @"6", @"43", @"AM" ];
+    [viewTester selectDatePickerValue:dateTime];
+    [[[[viewTester dateTimeSelector] usingValue:@"Jun 17, 06:43 AM"] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+- (void)testSelectingTime
+{
+    [[viewTester timeSelector] tap];
+    NSArray *time = @[ @"7", @"44", @"AM" ];
+    [viewTester selectDatePickerValue:time];
+    [[[[viewTester timeSelector] usingValue:@"7:44 AM"] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+- (void)testSelectingCountdown
+{
+    [[viewTester countdownSelector] tap];
+    NSArray *countdown = @[ @"4", @"10" ];
+    [viewTester selectDatePickerValue:countdown];
+    [[[[viewTester countdownSelector] usingValue:@"15000.000000"] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+- (void)testSelectingAPickerRow
+{
+    [viewTester selectPickerViewRowWithTitle:@"Charlie"];
+
+    NSOperatingSystemVersion iOS8 = {8, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS8]) {
+        [[[[viewTester usingAccessibilityLabel:@"Call Sign"] usingValue:@"Charlie"] usingTraits:UIAccessibilityTraitNone] waitForView];
+    } else {
+        [[[[viewTester usingAccessibilityLabel:@"Call Sign"] usingValue:@"Charlie. 3 of 3"] usingTraits:UIAccessibilityTraitNone] waitForView];
+    }
+}
+
+- (void)testSelectingRowInComponent
+{
+    [[viewTester dateSelector] tap];
+    NSArray *date = @[ @"December", @"31", @"2030" ];
+    [viewTester selectDatePickerValue:date];
+    [viewTester selectPickerViewRowWithTitle:@"17" inComponent:1];
+    [[[[viewTester dateSelector] usingValue:@"Dec 17, 2030"] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+@end

--- a/KIF Tests/ScrollViewTests_ViewTestActor.m
+++ b/KIF Tests/ScrollViewTests_ViewTestActor.m
@@ -1,0 +1,40 @@
+//
+//  NewScrollViewTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/27/15.
+//
+//
+
+#import <KIF/KIF.h>
+#import "KIFTestStepValidation.h"
+
+@interface ScrollViewTests_ViewTestActor : KIFTestCase
+@end
+
+@implementation ScrollViewTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"ScrollViews"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testScrollingToTapOffscreenViews
+{
+    [[viewTester usingAccessibilityLabel:@"Down"] tap];
+    [[viewTester usingAccessibilityLabel:@"Up"] tap];
+    [[viewTester usingAccessibilityLabel:@"Right"] tap];
+    [[viewTester usingAccessibilityLabel:@"Left"] tap];
+}
+
+- (void)testScrollingToTapOffscreenTextView
+{
+    [[viewTester usingAccessibilityLabel:@"TextView"] tap];
+}
+
+@end

--- a/KIF Tests/SearchFieldTests_ViewTestActor.m
+++ b/KIF Tests/SearchFieldTests_ViewTestActor.m
@@ -1,0 +1,37 @@
+//
+//  ViewSearchFieldTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+
+#import <KIF/KIF.h>
+#import <KIF/UIApplication-KIFAdditions.h>
+
+@interface SearchFieldTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation SearchFieldTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"TableViews"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testWaitingForSearchFieldToBecomeFirstResponder
+{
+    [[viewTester usingTraits:UIAccessibilityTraitSearchField] tap];
+    [[viewTester usingTraits:UIAccessibilityTraitSearchField] waitToBecomeFirstResponder];
+    [viewTester enterTextIntoCurrentFirstResponder:@"text"];
+    [[[viewTester usingValue:@"text"] usingTraits:UIAccessibilityTraitSearchField] waitForView];
+}
+
+@end

--- a/KIF Tests/SpecificControlTests.m
+++ b/KIF Tests/SpecificControlTests.m
@@ -43,7 +43,8 @@
     [tester waitForViewWithAccessibilityLabel:@"Slider" value:@"5" traits:UIAccessibilityTraitNone];
 }
 
-- (void)testPickingAPhoto {
+- (void)testPickingAPhoto
+{
     [tester tapViewWithAccessibilityLabel:@"Photos"];
     [tester acknowledgeSystemAlert];
     [tester waitForTimeInterval:0.5f]; // Wait for view to stabilize

--- a/KIF Tests/SpecificControlTests_ViewTestActor.m
+++ b/KIF Tests/SpecificControlTests_ViewTestActor.m
@@ -1,0 +1,74 @@
+//
+//  NewSpecificControlTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/27/15.
+//
+//
+
+#import <KIF/KIF.h>
+
+@implementation KIFUIViewTestActor (specifiControlTests)
+
+- (instancetype)happySwitch;
+{
+    return [viewTester usingAccessibilityLabel:@"Happy"];
+}
+
+- (instancetype)slider;
+{
+    return [viewTester usingAccessibilityLabel:@"Slider"];
+}
+@end
+
+@interface SpecificControlTests_ViewTestActor : KIFTestCase
+@end
+
+@implementation SpecificControlTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"Tapping"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testTogglingASwitch
+{
+    [[[viewTester happySwitch] usingValue:@"1"] waitForView];
+    [[viewTester happySwitch] setSwitchOn:NO];
+    [[[viewTester happySwitch] usingValue:@"0"] waitForView];
+    [[viewTester happySwitch] setSwitchOn:YES];
+    [[[viewTester happySwitch] usingValue:@"1"] waitForView];
+}
+
+- (void)testMovingASlider
+{
+    [viewTester waitForTimeInterval:1];
+    [[viewTester slider] setSliderValue:3];
+    [[[viewTester slider] usingValue:@"3"] waitForView];
+    [[viewTester slider] setSliderValue:0];
+    [[[viewTester slider] usingValue:@"0"] waitForView];
+    [[viewTester slider] setSliderValue:5];
+    [[[viewTester slider] usingValue:@"5"] waitForView];
+}
+
+- (void)testPickingAPhoto
+{
+    [[viewTester usingAccessibilityLabel:@"Photos"] tap];
+    [viewTester acknowledgeSystemAlert];
+    [viewTester waitForTimeInterval:0.5f]; // Wait for view to stabilize
+
+    NSOperatingSystemVersion iOS8 = {8, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS8]) {
+        [viewTester choosePhotoInAlbum:@"Camera Roll" atRow:1 column:2];
+    } else {
+        [viewTester choosePhotoInAlbum:@"Saved Photos" atRow:1 column:2];
+    }
+    [[viewTester usingAccessibilityLabel:@"{834, 1250}"] waitForView];
+}
+
+@end

--- a/KIF Tests/SystemAlertTests_ViewTestActor.m
+++ b/KIF Tests/SystemAlertTests_ViewTestActor.m
@@ -1,0 +1,47 @@
+//
+//  NewSystemAlertTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+
+#import <KIF/KIF.h>
+
+@interface SystemAlertTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation SystemAlertTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"System Alerts"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testAuthorizingLocationServices
+{
+    [[viewTester usingAccessibilityLabel:@"Location Services"] tap];
+    [viewTester acknowledgeSystemAlert];
+}
+
+- (void)testAuthorizingPhotosAccess
+{
+    [[viewTester usingAccessibilityLabel:@"Photos"] tap];
+    [viewTester acknowledgeSystemAlert];
+    [[viewTester usingAccessibilityLabel:@"Cancel"] tap];
+}
+
+- (void)testNotificationScheduling
+{
+    [[viewTester usingAccessibilityLabel:@"Notifications"] tap];
+    [viewTester acknowledgeSystemAlert];
+}
+
+@end

--- a/KIF Tests/TableViewTests_ViewTestActor.m
+++ b/KIF Tests/TableViewTests_ViewTestActor.m
@@ -1,0 +1,193 @@
+//
+//  NewTableViewTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/27/15.
+//
+//
+
+
+#import <KIF/KIF.h>
+#import "KIFTestStepValidation.h"
+#import "UIApplication-KIFAdditions.h"
+
+@implementation KIFUIViewTestActor (tableViewTests)
+
+- (instancetype)table;
+{
+    return [viewTester usingAccessibilityIdentifier:@"TableView Tests Table"];
+}
+
+- (instancetype)doneButton;
+{
+    return [viewTester usingAccessibilityLabel:@"Done"];
+}
+
+- (instancetype)editButton;
+{
+    return [viewTester usingAccessibilityLabel:@"Edit"];
+}
+
+- (instancetype)button;
+{
+    return [viewTester usingAccessibilityLabel:@"Button"];
+}
+
+- (instancetype)firstCell;
+{
+    return [viewTester usingAccessibilityLabel:@"First Cell"];
+}
+
+- (instancetype)lastCell;
+{
+    return [viewTester usingAccessibilityLabel:@"Last Cell"];
+}
+
+- (instancetype)tableViewSwitch;
+{
+    return [viewTester usingAccessibilityLabel:@"Table View Switch"];
+}
+
+@end
+
+@interface TableViewTests_ViewTestActor : KIFTestCase
+@end
+
+@implementation TableViewTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"TableViews"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testTappingRows
+{
+    [[viewTester table] tapRowInTableViewAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:2]];
+    [[[viewTester lastCell] usingTraits:UIAccessibilityTraitSelected] waitForView];
+    [[viewTester table] tapRowInTableViewAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+    [[[viewTester firstCell] usingTraits:UIAccessibilityTraitSelected] waitForView];
+}
+
+- (void)testTappingLastRowAndSection
+{
+    [[viewTester table] tapRowInTableViewAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:-1]];
+    [[[viewTester lastCell] usingTraits:UIAccessibilityTraitSelected] waitForView];
+}
+
+- (void)testOutOfBounds
+{
+    KIFExpectFailure([[[viewTester table ]usingTimeout:1] tapRowInTableViewAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:99]]);
+}
+
+- (void)testUnknownTable
+{
+    KIFExpectFailure([[[viewTester usingTimeout:1] usingAccessibilityIdentifier:@"Unknown Table"] tapRowInTableViewAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]]);
+}
+
+- (void)testScrollingToTop
+{
+    [[viewTester table] tapRowInTableViewAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:2]];
+    [viewTester tapStatusBar];
+
+    UITableView *tableView = (UITableView *)[viewTester table].view;
+    [viewTester runBlock:^KIFTestStepResult(NSError *__autoreleasing *error) {
+        KIFTestWaitCondition(tableView.contentOffset.y == - tableView.contentInset.top, error, @"Waited for scroll view to scroll to top, but it ended at %@", NSStringFromCGPoint(tableView.contentOffset));
+        return KIFTestStepResultSuccess;
+    }];
+}
+
+- (void)testTappingRowsByLabel
+{
+    // Tap the first row, which is already visible
+    [[viewTester firstCell] tap];
+
+    // Tap the last row, which will need to be scrolled up
+    [[viewTester lastCell] tap];
+
+    // Tap the first row, which will need to be scrolled down
+    [[viewTester firstCell] tap];
+}
+
+- (void)testMoveRowDown
+{
+    [[viewTester editButton] tap];
+
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:1]].textLabel.text, @"Cell 0", @"");
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:4 inSection:1]].textLabel.text, @"Cell 4", @"");
+
+    [[viewTester table] moveRowInTableViewAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:1] toIndexPath:[NSIndexPath indexPathForRow:4 inSection:1]];
+
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:1]].textLabel.text, @"Cell 1", @"");
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:4 inSection:1]].textLabel.text, @"Cell 0", @"");
+
+    [[viewTester doneButton] tap];
+}
+
+- (void)testMoveRowUp
+{
+    [[viewTester editButton] tap];
+
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:1]].textLabel.text, @"Cell 0", @"");
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:4 inSection:1]].textLabel.text, @"Cell 4", @"");
+
+    [[viewTester table] moveRowInTableViewAtIndexPath:[NSIndexPath indexPathForRow:4 inSection:1] toIndexPath:[NSIndexPath indexPathForRow:0 inSection:1]];
+
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:1]].textLabel.text, @"Cell 4", @"");
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:4 inSection:1]].textLabel.text, @"Cell 3", @"");
+
+    [[viewTester doneButton] tap];
+}
+
+- (void)testMoveRowUpUsingNegativeRowIndexes
+{
+    [[viewTester editButton] tap];
+
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:-3 inSection:1]].textLabel.text, @"Cell 35", @"");
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:1]].textLabel.text, @"Cell 37", @"");
+
+    [[viewTester table] moveRowInTableViewAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:1] toIndexPath:[NSIndexPath indexPathForRow:-3 inSection:1]];
+
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:-3 inSection:1]].textLabel.text, @"Cell 37", @"");
+    __KIFAssertEqualObjects([[viewTester table] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:1]].textLabel.text, @"Cell 36", @"");
+
+    [[viewTester doneButton] tap];
+}
+
+- (void)testTogglingSwitch
+{
+    [[viewTester tableViewSwitch] setSwitchOn:NO];
+    [[viewTester tableViewSwitch] setSwitchOn:YES];
+}
+
+- (void)testButtonAbsentAfterRemoveFromSuperview
+{
+    [[viewTester button] waitForView];
+
+    [[viewTester button].view removeFromSuperview];
+    [[viewTester button] waitForAbsenceOfView];
+}
+
+- (void)testButtonAbsentAfterSetHidden
+{
+    [[viewTester button] waitForView];
+
+    UIView *button = [viewTester button].view;
+
+    [button setHidden:YES];
+    [[viewTester button] waitForAbsenceOfView];
+
+    [button setHidden:NO];
+    [[viewTester button] waitForView];
+}
+
+- (void)testEnteringTextIntoATextFieldInATableCell
+{
+    [[viewTester usingAccessibilityLabel:@"TextField"] enterText:@"Test-Driven Development"];
+}
+
+@end

--- a/KIF Tests/TappingTests_ViewTestActor.m
+++ b/KIF Tests/TappingTests_ViewTestActor.m
@@ -1,0 +1,84 @@
+//
+//  ViewTappingTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+
+#import <KIF/KIF.h>
+
+@implementation KIFUIViewTestActor (tappingtests)
+
+- (KIFUIViewTestActor *)xButton;
+{
+    return [[self usingAccessibilityLabel:@"X"] usingTraits:UIAccessibilityTraitButton];
+}
+
+- (KIFUIViewTestActor *)greeting;
+{
+    return [self usingAccessibilityLabel:@"Greeting"];
+}
+
+@end
+
+@interface TappingTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation TappingTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"Tapping"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testTappingViewWithAccessibilityLabel
+{
+    // Since the tap has occurred in setup, we just need to wait for the result.
+    [[viewTester usingAccessibilityLabel:@"TapViewController"] waitForView];
+}
+
+- (void)testTappingViewWithTraits
+{
+    [[viewTester xButton] tap];
+    [[[viewTester xButton] usingTraits:UIAccessibilityTraitSelected] waitForView];
+}
+
+- (void)testTappingViewWithValue
+{
+    [[[[viewTester greeting] usingValue:@"Hello"] usingTraits:UIAccessibilityTraitNone] tap];
+    [[viewTester greeting] waitToBecomeFirstResponder];
+}
+
+- (void)testTappingViewWithScreenAtPoint
+{
+    [viewTester waitForTimeInterval:0.75];
+    [viewTester tapScreenAtPoint:CGPointMake(15, 200)];
+    [[[viewTester xButton] usingTraits:UIAccessibilityTraitSelected] waitForView];
+}
+
+- (void)testTappingViewPartiallyOffscreenAndWithinScrollView
+{
+    [[viewTester usingAccessibilityLabel:@"Slightly Offscreen Button"] tap];
+}
+
+- (void)testTappingViewWithTapGestureRecognizer
+{
+    [[viewTester usingAccessibilityLabel:@"Label with Tap Gesture Recognizer"] tap];
+}
+
+- (void)testTappingLabelWithLineBreaks
+{
+    [[viewTester usingAccessibilityLabel:@"Label with\nLine Break\n\n"] tap];
+    [[viewTester usingAccessibilityLabel:@"A\nB\nC\n\n"] tap];
+}
+
+
+@end

--- a/KIF Tests/TypingTests_ViewTestActor.m
+++ b/KIF Tests/TypingTests_ViewTestActor.m
@@ -1,0 +1,119 @@
+//
+//  ViewTypingTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+#import <KIF/KIF.h>
+#import "KIFTestStepValidation.h"
+
+@implementation KIFUIViewTestActor (typingTests)
+
+- (instancetype)greeting;
+{
+    return [viewTester usingAccessibilityLabel:@"Greeting"];
+}
+
+- (instancetype)selectAll;
+{
+    return [viewTester usingAccessibilityLabel:@"Select All"];
+}
+
+- (instancetype)otherText;
+{
+    return [viewTester usingAccessibilityLabel:@"Other Text"];
+}
+
+@end
+
+
+@interface TypingTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation TypingTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"Tapping"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testWaitingForFirstResponder
+{
+    [[[[viewTester greeting] usingValue:@"Hello"] usingTraits:UIAccessibilityTraitNone] tap];
+    [[viewTester greeting] waitToBecomeFirstResponder];
+}
+
+- (void)testMissingFirstResponder
+{
+    KIFExpectFailure([[[viewTester usingTimeout:1] usingAccessibilityLabel:@"Greeting"] waitToBecomeFirstResponder]);
+}
+
+- (void)testEnteringTextIntoFirstResponder
+{
+    [[[viewTester greeting] usingValue:@"Hello"] longPressWithDuration:2];
+    [[viewTester selectAll] tap];
+    [viewTester enterTextIntoCurrentFirstResponder:@"Yo"];
+    [[[[viewTester greeting] usingValue:@"Yo"] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+- (void)testFailingToEnterTextIntoFirstResponder
+{
+    KIFExpectFailure([[viewTester usingTimeout:1] enterTextIntoCurrentFirstResponder:@"Yo"]);
+}
+
+- (void)testEnteringTextIntoViewWithAccessibilityLabel
+{
+    [[[viewTester greeting] usingValue:@"Hello"] longPressWithDuration:2];
+    [[viewTester selectAll] tap];
+    [[viewTester usingAccessibilityLabel:@"Cut"] tap];
+    [[viewTester greeting] enterText:@"Yo"];
+    [[[[viewTester greeting] usingValue:@"Yo"] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+- (void)testEnteringTextIntoViewWithAccessibilityLabelExpectingResults
+{
+    [[[viewTester greeting] usingTraits:UIAccessibilityTraitNone] enterText:@", world" expectedResult:@"Hello, world"];
+    [[[[viewTester greeting] usingValue:@"Hello, world"] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+- (void)testClearingAndEnteringTextIntoViewWithAccessibilityLabel
+{
+    [[viewTester greeting] clearAndEnterText:@"Yo"];
+}
+
+- (void)testEnteringReturnCharacterIntoViewWithAccessibilityLabel
+{
+    [[viewTester otherText] enterText:@"Hello\n"];
+    [[viewTester greeting] waitToBecomeFirstResponder];
+    [[viewTester greeting] waitForView];
+    [[[viewTester greeting] usingTraits:UIAccessibilityTraitNone] enterText:@", world\n" expectedResult:@"Hello, world"];
+}
+
+- (void)testClearingALongTextField
+{
+    [[viewTester greeting] clearAndEnterText:@"A man, a plan, a canal, Panama.  Able was I, ere I saw Elba."];
+    [[viewTester greeting] clearText];
+}
+
+- (void)testThatClearingTextHitsTheDelegate
+{
+    [[viewTester otherText] enterText:@"hello"];
+    [[viewTester otherText] clearText];
+    [[[[viewTester greeting] usingValue:@"Deleted something."] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+- (void)testThatBackspaceDeletesOneCharacter
+{
+    [[[viewTester otherText] usingTraits:UIAccessibilityTraitNone] enterText:@"hi\bello" expectedResult:@"hello"];
+    [[[[viewTester greeting] usingValue:@"Deleted something."] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+@end

--- a/KIF Tests/WaitForAbscenceTests_ViewTestActor.m
+++ b/KIF Tests/WaitForAbscenceTests_ViewTestActor.m
@@ -1,0 +1,52 @@
+//
+//  NewWaitForAbsenceTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+
+#import <KIF/KIF.h>
+
+@implementation KIFUIViewTestActor (absenceTests)
+
+- (instancetype)tapping;
+{
+    return [viewTester usingAccessibilityLabel:@"Tapping"];
+}
+
+@end
+
+@interface WaitForAbscenceTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation WaitForAbscenceTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester tapping] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testWaitingForAbsenceOfViewWithAccessibilityLabel
+{
+    [[viewTester tapping] waitForAbsenceOfView];
+}
+
+- (void)testWaitingForAbsenceOfViewWithTraits
+{
+    [[[viewTester tapping] usingTraits:UIAccessibilityTraitStaticText] waitForAbsenceOfView];
+}
+
+- (void)testWaitingForAbsenceOfViewWithValue
+{
+    [[[[viewTester usingAccessibilityLabel:@"Switch 1"] usingValue:@"1"] usingTraits:UIAccessibilityTraitNone] waitForAbsenceOfView];
+}
+
+@end

--- a/KIF Tests/WaitForAnimationTests_ViewTestActor.m
+++ b/KIF Tests/WaitForAnimationTests_ViewTestActor.m
@@ -1,0 +1,35 @@
+//
+//  ViewWaitForAnimationTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+#import <KIF/KIF.h>
+
+@interface WaitForAnimationTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation WaitForAnimationTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"Tapping"] tap];
+    [[viewTester usingAccessibilityLabel:@"Animations"] tap];
+}
+
+- (void)afterEach
+{
+    [[viewTester usingAccessibilityLabel:@"Back"] tap];
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testWaitForFinishingAnimation
+{
+    [viewTester tapScreenAtPoint:CGPointMake(100, 100)];
+    [[viewTester usingAccessibilityLabel:@"Label"] waitForView];
+}
+
+@end

--- a/KIF Tests/WaitForTappableViewTests_ViewTestActor.m
+++ b/KIF Tests/WaitForTappableViewTests_ViewTestActor.m
@@ -1,0 +1,52 @@
+//
+//  ViewWaitForTappableViewTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+#import <KIF/KIF.h>
+
+@implementation KIFUIViewTestActor (waitForTappableViewTests)
+
+- (instancetype)bButton;
+{
+    return [viewTester usingAccessibilityLabel:@"B"];
+}
+
+@end
+
+@interface WaitForTappableViewTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation WaitForTappableViewTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"Show/Hide"] tap];
+    [[viewTester usingAccessibilityLabel:@"Cover/Uncover"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testWaitingForTappableViewWithAccessibilityLabel
+{
+    [[viewTester bButton] waitToBecomeTappable];
+}
+
+- (void)testWaitingForViewWithTraits
+{
+    [[[viewTester bButton] usingTraits:UIAccessibilityTraitButton] waitToBecomeTappable];
+}
+
+- (void)testWaitingForViewWithValue
+{
+    [[[[viewTester bButton] usingValue:@"BB"] usingTraits:UIAccessibilityTraitButton] waitToBecomeTappable];
+}
+
+@end

--- a/KIF Tests/WaitForViewTests_ViewTestActor.m
+++ b/KIF Tests/WaitForViewTests_ViewTestActor.m
@@ -1,0 +1,33 @@
+//
+//  ViewWaitForViewTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+
+#import <KIF/KIF.h>
+
+@interface WaitForViewTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation WaitForViewTests_ViewTestActor
+
+- (void)testWaitingForViewWithAccessibilityLabel
+{
+    [[viewTester usingAccessibilityLabel:@"Test Suite"] waitForView];
+}
+
+- (void)testWaitingForViewWithTraits
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitStaticText] waitForView];
+}
+
+- (void)testWaitingForViewWithValue
+{
+    [[[[viewTester usingAccessibilityLabel:@"Switch 1"] usingValue:@"1"] usingTraits:UIAccessibilityTraitNone] waitForView];
+}
+
+@end

--- a/KIF Tests/WebViewTests_ViewTestActor.m
+++ b/KIF Tests/WebViewTests_ViewTestActor.m
@@ -1,0 +1,47 @@
+//
+//  NewWebViewTests.m
+//  KIF
+//
+//  Created by Alex Odawa on 1/26/15.
+//
+//
+
+#import <KIF/KIFTestCase.h>
+#import <KIF/KIFUITestActor-IdentifierTests.h>
+#import <KIF/KIFTestStepValidation.h>
+
+@interface WebViewTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation WebViewTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingAccessibilityLabel:@"WebViews"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingAccessibilityLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testTappingLinks
+{
+    [[viewTester usingAccessibilityLabel:@"A link"] tap];
+    [[viewTester usingAccessibilityLabel:@"Page 2"] waitForView];
+}
+
+- (void)testScrolling
+{
+    // Off screen, the web view will need to be scrolled down
+    [[viewTester usingAccessibilityLabel:@"Footer"] waitForView];
+}
+
+- (void)testEnteringText
+{
+    [[viewTester usingAccessibilityLabel:@"Input Label"] tap];
+    [viewTester enterTextIntoCurrentFirstResponder:@"Keyboard text"];
+}
+
+@end

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -188,6 +188,34 @@
 		EBAE488217A460E50005EE19 /* NSError-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = EBAE488017A460E50005EE19 /* NSError-KIFAdditions.m */; };
 		EBAE488717A4E5C30005EE19 /* KIFTestStepValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = EBAE488517A4E5C30005EE19 /* KIFTestStepValidation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EBAE488817A4E5C30005EE19 /* KIFTestStepValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = EBAE488617A4E5C30005EE19 /* KIFTestStepValidation.m */; };
+		FA1C7B751A7733BA00E7DD97 /* ExistTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA1C7B741A7733BA00E7DD97 /* ExistTests_ViewTestActor.m */; };
+		FA49155A1A781E6800A78E57 /* MultiFingerTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA4915591A781E6800A78E57 /* MultiFingerTests_ViewTestActor.m */; };
+		FA49155C1A781F6600A78E57 /* LandscapeTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA49155B1A781F6600A78E57 /* LandscapeTests_ViewTestActor.m */; };
+		FA49155E1A78206E00A78E57 /* CompositionTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA49155D1A78206E00A78E57 /* CompositionTests_ViewTestActor.m */; };
+		FA4915601A7823E500A78E57 /* ScrollViewTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA49155F1A7823E500A78E57 /* ScrollViewTests_ViewTestActor.m */; };
+		FA4915631A78261300A78E57 /* ModalViewTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA4915621A78261300A78E57 /* ModalViewTests_ViewTestActor.m */; };
+		FA4915651A7827D000A78E57 /* PickerTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA4915641A7827D000A78E57 /* PickerTests_ViewTestActor.m */; };
+		FA4915671A783C5500A78E57 /* TableViewTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA4915661A783C5500A78E57 /* TableViewTests_ViewTestActor.m */; };
+		FA4915691A78449C00A78E57 /* CollectionViewTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA4915681A78449C00A78E57 /* CollectionViewTests_ViewTestActor.m */; };
+		FA64D8341A78171000D96787 /* SpecificControlTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA64D8331A78171000D96787 /* SpecificControlTests_ViewTestActor.m */; };
+		FA8A3C551A77157F00206350 /* LongPressTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8A3C541A77157F00206350 /* LongPressTests_ViewTestActor.m */; };
+		FA8A3C571A771B6F00206350 /* WaitForViewTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8A3C561A771B6F00206350 /* WaitForViewTests_ViewTestActor.m */; };
+		FA8A3C591A771C5500206350 /* SearchFieldTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8A3C581A771C5500206350 /* SearchFieldTests_ViewTestActor.m */; };
+		FA8A3C5B1A77281900206350 /* WebViewTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8A3C5A1A77281900206350 /* WebViewTests_ViewTestActor.m */; };
+		FA8A3C5D1A772CD100206350 /* WaitForAbscenceTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8A3C5C1A772CD100206350 /* WaitForAbscenceTests_ViewTestActor.m */; };
+		FA8A3C5F1A772E6800206350 /* AccessibilityIdentifierTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8A3C5E1A772E6800206350 /* AccessibilityIdentifierTests_ViewTestActor.m */; };
+		FA8A3C611A77320000206350 /* SystemAlertTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8A3C601A77320000206350 /* SystemAlertTests_ViewTestActor.m */; };
+		FA8BB6A81A778725003969FF /* GestureTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8BB6A71A778725003969FF /* GestureTests_ViewTestActor.m */; };
+		FA8BDCCD1A76B3A80042A989 /* KIFUIObject.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8BDCCB1A76B3A80042A989 /* KIFUIObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FA8BDCCE1A76B3A80042A989 /* KIFUIObject.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8BDCCC1A76B3A80042A989 /* KIFUIObject.m */; };
+		FA8DA74F1A7711E900E0C644 /* WaitForTappableViewTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8DA74E1A7711E900E0C644 /* WaitForTappableViewTests_ViewTestActor.m */; };
+		FA8DA7511A7712E300E0C644 /* WaitForAnimationTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA8DA7501A7712E300E0C644 /* WaitForAnimationTests_ViewTestActor.m */; };
+		FA914DB61A7707550073BB19 /* TypingTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FA914DB51A7707550073BB19 /* TypingTests_ViewTestActor.m */; };
+		FAB4C4741A815CA900C52EDF /* NSPredicate+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FAB4C4721A815CA900C52EDF /* NSPredicate+KIFAdditions.h */; };
+		FAB4C4751A815CA900C52EDF /* NSPredicate+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = FAB4C4731A815CA900C52EDF /* NSPredicate+KIFAdditions.m */; };
+		FAC3A53E1A703A8300802118 /* KIFUIViewTestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = FAC3A53C1A703A8300802118 /* KIFUIViewTestActor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FAC3A53F1A703A8300802118 /* KIFUIViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FAC3A53D1A703A8300802118 /* KIFUIViewTestActor.m */; };
+		FAE2D7631A76DDA90068B440 /* TappingTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = FAE2D7621A76DDA90068B440 /* TappingTests_ViewTestActor.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -324,6 +352,34 @@
 		EBAE488017A460E50005EE19 /* NSError-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError-KIFAdditions.m"; sourceTree = "<group>"; };
 		EBAE488517A4E5C30005EE19 /* KIFTestStepValidation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = KIFTestStepValidation.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		EBAE488617A4E5C30005EE19 /* KIFTestStepValidation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFTestStepValidation.m; sourceTree = "<group>"; };
+		FA1C7B741A7733BA00E7DD97 /* ExistTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExistTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA4915591A781E6800A78E57 /* MultiFingerTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultiFingerTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA49155B1A781F6600A78E57 /* LandscapeTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LandscapeTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA49155D1A78206E00A78E57 /* CompositionTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CompositionTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA49155F1A7823E500A78E57 /* ScrollViewTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ScrollViewTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA4915621A78261300A78E57 /* ModalViewTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ModalViewTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA4915641A7827D000A78E57 /* PickerTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PickerTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA4915661A783C5500A78E57 /* TableViewTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TableViewTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA4915681A78449C00A78E57 /* CollectionViewTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CollectionViewTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA64D8331A78171000D96787 /* SpecificControlTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SpecificControlTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA8A3C541A77157F00206350 /* LongPressTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LongPressTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA8A3C561A771B6F00206350 /* WaitForViewTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WaitForViewTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA8A3C581A771C5500206350 /* SearchFieldTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SearchFieldTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA8A3C5A1A77281900206350 /* WebViewTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WebViewTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA8A3C5C1A772CD100206350 /* WaitForAbscenceTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WaitForAbscenceTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA8A3C5E1A772E6800206350 /* AccessibilityIdentifierTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccessibilityIdentifierTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA8A3C601A77320000206350 /* SystemAlertTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SystemAlertTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA8BB6A71A778725003969FF /* GestureTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GestureTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA8BDCCB1A76B3A80042A989 /* KIFUIObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFUIObject.h; sourceTree = "<group>"; };
+		FA8BDCCC1A76B3A80042A989 /* KIFUIObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFUIObject.m; sourceTree = "<group>"; };
+		FA8DA74E1A7711E900E0C644 /* WaitForTappableViewTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WaitForTappableViewTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA8DA7501A7712E300E0C644 /* WaitForAnimationTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WaitForAnimationTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FA914DB51A7707550073BB19 /* TypingTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TypingTests_ViewTestActor.m; sourceTree = "<group>"; };
+		FAB4C4721A815CA900C52EDF /* NSPredicate+KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSPredicate+KIFAdditions.h"; sourceTree = "<group>"; };
+		FAB4C4731A815CA900C52EDF /* NSPredicate+KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSPredicate+KIFAdditions.m"; sourceTree = "<group>"; };
+		FAC3A53C1A703A8300802118 /* KIFUIViewTestActor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFUIViewTestActor.h; sourceTree = "<group>"; };
+		FAC3A53D1A703A8300802118 /* KIFUIViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFUIViewTestActor.m; sourceTree = "<group>"; };
+		FAE2D7621A76DDA90068B440 /* TappingTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TappingTests_ViewTestActor.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -447,6 +503,8 @@
 				AAB0728513971A98008AF393 /* KIF-Prefix.pch */,
 				C194255615D83DE9004FC314 /* KIFTypist.h */,
 				C194255715D83DE9004FC314 /* KIFTypist.m */,
+				FA8BDCCB1A76B3A80042A989 /* KIFUIObject.h */,
+				FA8BDCCC1A76B3A80042A989 /* KIFUIObject.m */,
 				EBAE488517A4E5C30005EE19 /* KIFTestStepValidation.h */,
 				EBAE488617A4E5C30005EE19 /* KIFTestStepValidation.m */,
 				EABD46D31857BE8600A5F081 /* KIF-XCTestPrefix.pch */,
@@ -469,6 +527,8 @@
 				AAB0729813971AB2008AF393 /* UIApplication-KIFAdditions.h */,
 				AAB0729913971AB2008AF393 /* UIApplication-KIFAdditions.m */,
 				AAB0729A13971AB2008AF393 /* UIScrollView-KIFAdditions.h */,
+				FAB4C4721A815CA900C52EDF /* NSPredicate+KIFAdditions.h */,
+				FAB4C4731A815CA900C52EDF /* NSPredicate+KIFAdditions.m */,
 				AAB0729B13971AB2008AF393 /* UIScrollView-KIFAdditions.m */,
 				AAB0729C13971AB2008AF393 /* UITouch-KIFAdditions.h */,
 				AAB0729D13971AB2008AF393 /* UITouch-KIFAdditions.m */,
@@ -510,6 +570,8 @@
 				EB4C3131167BA3AC00E31109 /* KIFSystemTestActor.m */,
 				EB4C3132167BA3AC00E31109 /* KIFUITestActor.h */,
 				EB4C3133167BA3AC00E31109 /* KIFUITestActor.m */,
+				FAC3A53C1A703A8300802118 /* KIFUIViewTestActor.h */,
+				FAC3A53D1A703A8300802118 /* KIFUIViewTestActor.m */,
 				EB2526461981BF7A00DBC747 /* KIFUITestActor-ConditionalTests.h */,
 				EB2526471981BF7A00DBC747 /* KIFUITestActor-ConditionalTests.m */,
 			);
@@ -567,13 +629,13 @@
 		EB60ECEF177F8DB3005A041A /* KIF Tests */ = {
 			isa = PBXGroup;
 			children = (
+				FA8DA74D1A77117A00E0C644 /* KIFUIViewTestActor Tests */,
 				2CED883D181F5EE1005ABD20 /* PickerTests.m */,
 				EB60ED19177F90C2005A041A /* GestureTests.m */,
 				3812FB621A12188700335733 /* WaitForAnimationTests.m */,
 				EB60ED07177F90BA005A041A /* LongPressTests.m */,
 				EB60ED08177F90BA005A041A /* ModalViewTests.m */,
 				EB60ED09177F90BA005A041A /* SpecificControlTests.m */,
-				EB60ED0A177F90BA005A041A /* SystemTests.m */,
 				EB60ED0B177F90BA005A041A /* TappingTests.m */,
 				EB3F654417AA0B8400469D18 /* TableViewTests.m */,
 				EA0F2546182979BE006FF825 /* CollectionViewTests.m */,
@@ -584,13 +646,14 @@
 				4A48107A19708CAB0003A32E /* ExistTests.m */,
 				EB60ED0E177F90BA005A041A /* WaitForTappableViewTests.m */,
 				EB60ED0F177F90BA005A041A /* WaitForViewTests.m */,
-				EB22B5AF17AF52640090B848 /* CascadingFailureTests.m */,
 				EB9FC00417E144B700138266 /* LandscapeTests.m */,
 				EB09000F17E3696A00AA15B1 /* SearchFieldTests.m */,
 				2EE1270F198991920031D347 /* MultiFingerTests.m */,
 				EB1A44D91A0C33AD004A3F61 /* AccessibilityIdentifierTests.m */,
 				AE62FCCF1A1D20E5002B10DA /* WebViewTests.m */,
 				84D293B01A2C891700C10944 /* SystemAlertTests.m */,
+				EB22B5AF17AF52640090B848 /* CascadingFailureTests.m */,
+				EB60ED0A177F90BA005A041A /* SystemTests.m */,
 				EB60ECF0177F8DB3005A041A /* Supporting Files */,
 			);
 			path = "KIF Tests";
@@ -607,6 +670,35 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		FA8DA74D1A77117A00E0C644 /* KIFUIViewTestActor Tests */ = {
+			isa = PBXGroup;
+			children = (
+				FA4915641A7827D000A78E57 /* PickerTests_ViewTestActor.m */,
+				FA8BB6A71A778725003969FF /* GestureTests_ViewTestActor.m */,
+				FA8DA7501A7712E300E0C644 /* WaitForAnimationTests_ViewTestActor.m */,
+				FA8A3C541A77157F00206350 /* LongPressTests_ViewTestActor.m */,
+				FA4915621A78261300A78E57 /* ModalViewTests_ViewTestActor.m */,
+				FA64D8331A78171000D96787 /* SpecificControlTests_ViewTestActor.m */,
+				FAE2D7621A76DDA90068B440 /* TappingTests_ViewTestActor.m */,
+				FA4915661A783C5500A78E57 /* TableViewTests_ViewTestActor.m */,
+				FA4915681A78449C00A78E57 /* CollectionViewTests_ViewTestActor.m */,
+				FA49155F1A7823E500A78E57 /* ScrollViewTests_ViewTestActor.m */,
+				FA49155D1A78206E00A78E57 /* CompositionTests_ViewTestActor.m */,
+				FA914DB51A7707550073BB19 /* TypingTests_ViewTestActor.m */,
+				FA8A3C5C1A772CD100206350 /* WaitForAbscenceTests_ViewTestActor.m */,
+				FA1C7B741A7733BA00E7DD97 /* ExistTests_ViewTestActor.m */,
+				FA8DA74E1A7711E900E0C644 /* WaitForTappableViewTests_ViewTestActor.m */,
+				FA8A3C561A771B6F00206350 /* WaitForViewTests_ViewTestActor.m */,
+				FA49155B1A781F6600A78E57 /* LandscapeTests_ViewTestActor.m */,
+				FA8A3C581A771C5500206350 /* SearchFieldTests_ViewTestActor.m */,
+				FA4915591A781E6800A78E57 /* MultiFingerTests_ViewTestActor.m */,
+				FA8A3C5E1A772E6800206350 /* AccessibilityIdentifierTests_ViewTestActor.m */,
+				FA8A3C5A1A77281900206350 /* WebViewTests_ViewTestActor.m */,
+				FA8A3C601A77320000206350 /* SystemAlertTests_ViewTestActor.m */,
+			);
+			name = "KIFUIViewTestActor Tests";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -620,13 +712,16 @@
 				EABD46921857A0C700A5F081 /* CGGeometry-KIFAdditions.h in Headers */,
 				EABD46931857A0C700A5F081 /* UIAccessibilityElement-KIFAdditions.h in Headers */,
 				EABD46941857A0C700A5F081 /* UIApplication-KIFAdditions.h in Headers */,
+				FAB4C4741A815CA900C52EDF /* NSPredicate+KIFAdditions.h in Headers */,
 				84D293BB1A2CC30B00C10944 /* UIAutomationHelper.h in Headers */,
 				EABD46951857A0C700A5F081 /* UIScrollView-KIFAdditions.h in Headers */,
+				FAC3A53E1A703A8300802118 /* KIFUIViewTestActor.h in Headers */,
 				EABD46971857A0C700A5F081 /* UITouch-KIFAdditions.h in Headers */,
 				EABD46981857A0C700A5F081 /* UIView-KIFAdditions.h in Headers */,
 				EABD46991857A0C700A5F081 /* UIWindow-KIFAdditions.h in Headers */,
 				EABD469A1857A0C700A5F081 /* NSFileManager-KIFAdditions.h in Headers */,
 				EABD469B1857A0C700A5F081 /* LoadableCategory.h in Headers */,
+				FA8BDCCD1A76B3A80042A989 /* KIFUIObject.h in Headers */,
 				EABD469C1857A0C700A5F081 /* KIFTypist.h in Headers */,
 				EABD469D1857A0C700A5F081 /* KIFTestActor.h in Headers */,
 				EABD469E1857A0C700A5F081 /* KIFTestCase.h in Headers */,
@@ -901,8 +996,11 @@
 				EAC8096B1864F19C000E819F /* NSException-KIFAdditions.m in Sources */,
 				EABD46881857A0C700A5F081 /* KIFUITestActor.m in Sources */,
 				EABD46891857A0C700A5F081 /* NSBundle-KIFAdditions.m in Sources */,
+				FAB4C4751A815CA900C52EDF /* NSPredicate+KIFAdditions.m in Sources */,
+				FAC3A53F1A703A8300802118 /* KIFUIViewTestActor.m in Sources */,
 				EABD468A1857A0C700A5F081 /* NSError-KIFAdditions.m in Sources */,
 				EABD468B1857A0C700A5F081 /* KIFTestStepValidation.m in Sources */,
+				FA8BDCCE1A76B3A80042A989 /* KIFUIObject.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -910,29 +1008,51 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA8A3C591A771C5500206350 /* SearchFieldTests_ViewTestActor.m in Sources */,
+				FA8A3C551A77157F00206350 /* LongPressTests_ViewTestActor.m in Sources */,
+				FA49155E1A78206E00A78E57 /* CompositionTests_ViewTestActor.m in Sources */,
+				FA8A3C5F1A772E6800206350 /* AccessibilityIdentifierTests_ViewTestActor.m in Sources */,
+				FA8A3C5D1A772CD100206350 /* WaitForAbscenceTests_ViewTestActor.m in Sources */,
+				FA8A3C5B1A77281900206350 /* WebViewTests_ViewTestActor.m in Sources */,
 				EABD46B11857A0F300A5F081 /* SearchFieldTests.m in Sources */,
 				EABD46B21857A0F300A5F081 /* CascadingFailureTests.m in Sources */,
 				EABD46B31857A0F300A5F081 /* CompositionTests.m in Sources */,
 				4A48107B19708CAB0003A32E /* ExistTests.m in Sources */,
 				EA4655881905B92500B2C60E /* PickerTests.m in Sources */,
 				3812FB631A12188700335733 /* WaitForAnimationTests.m in Sources */,
+				FA49155A1A781E6800A78E57 /* MultiFingerTests_ViewTestActor.m in Sources */,
 				EB1A44DA1A0C33AD004A3F61 /* AccessibilityIdentifierTests.m in Sources */,
 				EABD46B41857A0F300A5F081 /* LongPressTests.m in Sources */,
 				EABD46B51857A0F300A5F081 /* ModalViewTests.m in Sources */,
+				FA4915671A783C5500A78E57 /* TableViewTests_ViewTestActor.m in Sources */,
 				EABD46B61857A0F300A5F081 /* SpecificControlTests.m in Sources */,
+				FAE2D7631A76DDA90068B440 /* TappingTests_ViewTestActor.m in Sources */,
+				FA914DB61A7707550073BB19 /* TypingTests_ViewTestActor.m in Sources */,
+				FA8BB6A81A778725003969FF /* GestureTests_ViewTestActor.m in Sources */,
+				FA4915631A78261300A78E57 /* ModalViewTests_ViewTestActor.m in Sources */,
 				EABD46B71857A0F300A5F081 /* SystemTests.m in Sources */,
 				EABD46B81857A0F300A5F081 /* TappingTests.m in Sources */,
 				EABD46B91857A0F300A5F081 /* TypingTests.m in Sources */,
+				FA4915691A78449C00A78E57 /* CollectionViewTests_ViewTestActor.m in Sources */,
+				FA8DA74F1A7711E900E0C644 /* WaitForTappableViewTests_ViewTestActor.m in Sources */,
 				EABD46BA1857A0F300A5F081 /* WaitForAbscenceTests.m in Sources */,
 				EA47DA2818EDFD6F0034D2F5 /* CollectionViewTests.m in Sources */,
 				EABD46BB1857A0F300A5F081 /* WaitForTappableViewTests.m in Sources */,
 				EABD46BC1857A0F300A5F081 /* WaitForViewTests.m in Sources */,
 				EABD46BD1857A0F300A5F081 /* LandscapeTests.m in Sources */,
 				EABD46BE1857A0F300A5F081 /* TableViewTests.m in Sources */,
+				FA4915601A7823E500A78E57 /* ScrollViewTests_ViewTestActor.m in Sources */,
 				EABD46BF1857A0F300A5F081 /* GestureTests.m in Sources */,
+				FA8A3C571A771B6F00206350 /* WaitForViewTests_ViewTestActor.m in Sources */,
 				2EE12710198991920031D347 /* MultiFingerTests.m in Sources */,
+				FA8DA7511A7712E300E0C644 /* WaitForAnimationTests_ViewTestActor.m in Sources */,
+				FA64D8341A78171000D96787 /* SpecificControlTests_ViewTestActor.m in Sources */,
+				FA8A3C611A77320000206350 /* SystemAlertTests_ViewTestActor.m in Sources */,
+				FA1C7B751A7733BA00E7DD97 /* ExistTests_ViewTestActor.m in Sources */,
 				D9EA274118F05A6000D87E57 /* ScrollViewTests.m in Sources */,
 				AE62FCD01A1D20E5002B10DA /* WebViewTests.m in Sources */,
+				FA49155C1A781F6600A78E57 /* LandscapeTests_ViewTestActor.m in Sources */,
+				FA4915651A7827D000A78E57 /* PickerTests_ViewTestActor.m in Sources */,
 				84D293B11A2C891700C10944 /* SystemAlertTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
New KIFUIViewTestActor as outlined in https://github.com/kif-framework/KIF/issues/555
This actor decouples finding an element from acting upon the element.

This also allows you to define an actor for a specific view description, allowing you to reference the same view multiple times without worrying about stringly-typed errors. 
(see https://github.com/RoyalPineapple/KIF/blob/ca1b2baa5189e133c6aa50c6cbd86a1857f606c0/KIF%20Tests/PickerTests_ViewTestActor.m) for an example

This change will increase maintainiblity of the kif framework as well as our individual tests. 