### PR TITLE
Make touch UIEvent compatible with iOS 8.3

### DIFF
--- a/Additions/UIEvent+KIFAdditions.h
+++ b/Additions/UIEvent+KIFAdditions.h
@@ -1,0 +1,19 @@
+//
+//  UIEvent+KIFAdditions.h
+//  KIF
+//
+//  Created by Thomas on 3/1/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+// Exposes methods of UITouchesEvent so that the compiler doesn't complain
+@interface UIEvent (KIFAdditionsPrivateHeaders)
+- (void)_addTouch:(UITouch *)touch forDelayedDelivery:(BOOL)arg2;
+- (void)_clearTouches;
+@end
+
+@interface UIEvent (KIFAdditions)
+- (void)kif_setEventWithTouches:(NSArray *)touches;
+@end

--- a/Additions/UIEvent+KIFAdditions.m
+++ b/Additions/UIEvent+KIFAdditions.m
@@ -1,0 +1,152 @@
+//
+//  UIEvent+KIFAdditions.m
+//  KIF
+//
+//  Created by Thomas on 3/1/15.
+//
+//
+
+#import "UIEvent+KIFAdditions.h"
+#import "LoadableCategory.h"
+#import <mach/mach_time.h>
+
+MAKE_CATEGORIES_LOADABLE(UIEvent_KIFAdditions)
+
+/* IOKit Private Headers */
+#ifdef __LP64__
+typedef double IOHIDFloat;
+#else
+typedef float IOHIDFloat;
+#endif
+typedef struct __IOHIDEvent * IOHIDEventRef;
+typedef UInt32 IOOptionBits;
+typedef uint32_t IOHIDDigitizerTransducerType;
+void IOHIDEventAppendEvent(IOHIDEventRef event, IOHIDEventRef childEvent);
+enum {
+    kIOHIDDigitizerTransducerTypeStylus  = 0x20,
+    kIOHIDDigitizerTransducerTypePuck,
+    kIOHIDDigitizerTransducerTypeFinger,
+    kIOHIDDigitizerTransducerTypeHand
+};
+enum {
+    kIOHIDDigitizerEventRange                               = 0x00000001,
+    kIOHIDDigitizerEventTouch                               = 0x00000002,
+    kIOHIDDigitizerEventPosition                            = 0x00000004,
+    kIOHIDDigitizerEventStop                                = 0x00000008,
+    kIOHIDDigitizerEventPeak                                = 0x00000010,
+    kIOHIDDigitizerEventIdentity                            = 0x00000020,
+    kIOHIDDigitizerEventAttribute                           = 0x00000040,
+    kIOHIDDigitizerEventCancel                              = 0x00000080,
+    kIOHIDDigitizerEventStart                               = 0x00000100,
+    kIOHIDDigitizerEventResting                             = 0x00000200,
+    kIOHIDDigitizerEventSwipeUp                             = 0x01000000,
+    kIOHIDDigitizerEventSwipeDown                           = 0x02000000,
+    kIOHIDDigitizerEventSwipeLeft                           = 0x04000000,
+    kIOHIDDigitizerEventSwipeRight                          = 0x08000000,
+    kIOHIDDigitizerEventSwipeMask                           = 0xFF000000,
+};
+IOHIDEventRef IOHIDEventCreateDigitizerEvent(CFAllocatorRef allocator, AbsoluteTime timeStamp, IOHIDDigitizerTransducerType type,
+                                             uint32_t index, uint32_t identity, uint32_t eventMask, uint32_t buttonMask,
+                                             IOHIDFloat x, IOHIDFloat y, IOHIDFloat z, IOHIDFloat tipPressure, IOHIDFloat barrelPressure,
+                                             Boolean range, Boolean touch, IOOptionBits options);
+IOHIDEventRef IOHIDEventCreateDigitizerFingerEventWithQuality(CFAllocatorRef allocator, AbsoluteTime timeStamp,
+                                                              uint32_t index, uint32_t identity, uint32_t eventMask,
+                                                              IOHIDFloat x, IOHIDFloat y, IOHIDFloat z, IOHIDFloat tipPressure, IOHIDFloat twist,
+                                                              IOHIDFloat minorRadius, IOHIDFloat majorRadius, IOHIDFloat quality, IOHIDFloat density, IOHIDFloat irregularity,
+                                                              Boolean range, Boolean touch, IOOptionBits options);
+
+/* END of IOKit Private Headers */
+
+//
+// GSEvent is an undeclared object. We don't need to use it ourselves but some
+// Apple APIs (UIScrollView in particular) require the x and y fields to be present.
+//
+@interface KIFGSEventProxy : NSObject
+{
+@public
+    unsigned int flags;
+    unsigned int type;
+    unsigned int ignored1;
+    float x1;
+    float y1;
+    float x2;
+    float y2;
+    unsigned int ignored2[10];
+    unsigned int ignored3[7];
+    float sizeX;
+    float sizeY;
+    float x3;
+    float y3;
+    unsigned int ignored4[3];
+}
+@end
+
+@implementation KIFGSEventProxy
+@end
+
+typedef struct __GSEvent * GSEventRef;
+
+@interface UIEvent (KIFAdditionsMorePrivateHeaders)
+- (void)_setGSEvent:(GSEventRef)event;
+- (void)_setHIDEvent:(IOHIDEventRef)event;
+@end
+
+@implementation UIEvent (KIFAdditions)
+
+- (void)kif_setEventWithTouches:(NSArray *)touches
+{
+    NSOperatingSystemVersion iOS8 = {8, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)]
+        && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS8]) {
+        [self kif_setIOHIDEventWithTouches:touches];
+    } else {
+        [self kif_setGSEventWithTouches:touches];
+    }
+}
+
+- (void)kif_setGSEventWithTouches:(NSArray *)touches
+{
+    UITouch *touch = touches[0];
+    CGPoint location = [touch locationInView:touch.window];
+    KIFGSEventProxy *gsEventProxy = [[KIFGSEventProxy alloc] init];
+    gsEventProxy->x1 = location.x;
+    gsEventProxy->y1 = location.y;
+    gsEventProxy->x2 = location.x;
+    gsEventProxy->y2 = location.y;
+    gsEventProxy->x3 = location.x;
+    gsEventProxy->y3 = location.y;
+    gsEventProxy->sizeX = 1.0;
+    gsEventProxy->sizeY = 1.0;
+    gsEventProxy->flags = ([touch phase] == UITouchPhaseEnded) ? 0x1010180 : 0x3010180;
+    gsEventProxy->type = 3001;
+    
+    [self _setGSEvent:(GSEventRef)gsEventProxy];
+    
+}
+
+- (void)kif_setIOHIDEventWithTouches:(NSArray *)touches
+{
+    uint64_t abTime = mach_absolute_time();
+    AbsoluteTime timeStamp = *(AbsoluteTime *) &abTime;
+    
+    IOHIDEventRef handEvent = IOHIDEventCreateDigitizerEvent(kCFAllocatorDefault, timeStamp, kIOHIDDigitizerTransducerTypeHand, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    
+    for (UITouch *touch in touches)
+    {
+        uint32_t eventMask = (touch.phase == UITouchPhaseMoved) ? kIOHIDDigitizerEventPosition : (kIOHIDDigitizerEventRange | kIOHIDDigitizerEventTouch);
+        uint32_t isTouching = (touch.phase == UITouchPhaseEnded) ? 0 : 1;
+        
+        CGPoint touchLocation = [touch locationInView:touch.window];
+        
+        IOHIDEventRef fingerEvent = IOHIDEventCreateDigitizerFingerEventWithQuality(kCFAllocatorDefault, timeStamp,
+                                                                                    (UInt32)[touches indexOfObject:touch], 2,
+                                                                                    eventMask, (IOHIDFloat)touchLocation.x, (IOHIDFloat)touchLocation.y,
+                                                                                    0, 0, 0, 0, 0, 0, 0, 0,
+                                                                                    (IOHIDFloat)isTouching, (IOHIDFloat)isTouching, 0);
+        IOHIDEventAppendEvent(handEvent, fingerEvent);
+    }
+    
+    [self _setHIDEvent:handEvent];
+}
+
+@end

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -34,6 +34,11 @@
 		D927B9E218F9E47600DAD036 /* UITableView-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D927B9DE18F9E46400DAD036 /* UITableView-KIFAdditions.m */; };
 		D9EA274118F05A6000D87E57 /* ScrollViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EA274018F05A6000D87E57 /* ScrollViewTests.m */; };
 		D9EA274318F05A6700D87E57 /* ScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D9EA274218F05A6700D87E57 /* ScrollViewController.m */; };
+		E977D1071AA4062B005645BF /* UIEvent+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E977D1051AA4062B005645BF /* UIEvent+KIFAdditions.h */; };
+		E977D1081AA4062B005645BF /* UIEvent+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = E977D1061AA4062B005645BF /* UIEvent+KIFAdditions.m */; };
+		E977D1091AA40736005645BF /* UIEvent+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = E977D1061AA4062B005645BF /* UIEvent+KIFAdditions.m */; };
+		E9AD81FA1AA180B900B369FD /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9AD81F91AA180B900B369FD /* IOKit.framework */; };
+		E9F646F81AA3BABA00C37EA3 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9AD81F91AA180B900B369FD /* IOKit.framework */; };
 		EA0F2547182979BE006FF825 /* CollectionViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EA0F2546182979BE006FF825 /* CollectionViewTests.m */; };
 		EA0F254A1829839E006FF825 /* CollectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EA0F25491829839E006FF825 /* CollectionViewController.m */; };
 		EA4655881905B92500B2C60E /* PickerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CED883D181F5EE1005ABD20 /* PickerTests.m */; };
@@ -248,6 +253,9 @@
 		D927B9DE18F9E46400DAD036 /* UITableView-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITableView-KIFAdditions.m"; sourceTree = "<group>"; };
 		D9EA274018F05A6000D87E57 /* ScrollViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ScrollViewTests.m; sourceTree = "<group>"; };
 		D9EA274218F05A6700D87E57 /* ScrollViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ScrollViewController.m; sourceTree = "<group>"; };
+		E977D1051AA4062B005645BF /* UIEvent+KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIEvent+KIFAdditions.h"; sourceTree = "<group>"; };
+		E977D1061AA4062B005645BF /* UIEvent+KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIEvent+KIFAdditions.m"; sourceTree = "<group>"; };
+		E9AD81F91AA180B900B369FD /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/IOKit.framework; sourceTree = DEVELOPER_DIR; };
 		EA0F2546182979BE006FF825 /* CollectionViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CollectionViewTests.m; sourceTree = "<group>"; };
 		EA0F25491829839E006FF825 /* CollectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CollectionViewController.m; sourceTree = "<group>"; };
 		EABD46751857A07600A5F081 /* XCTestCase-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestCase-KIFAdditions.h"; sourceTree = "<group>"; };
@@ -326,6 +334,7 @@
 				EABD46D21857A24E00A5F081 /* XCTest.framework in Frameworks */,
 				EABD468E1857A0C700A5F081 /* Foundation.framework in Frameworks */,
 				EABD468F1857A0C700A5F081 /* UIKit.framework in Frameworks */,
+				E9AD81FA1AA180B900B369FD /* IOKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -338,6 +347,7 @@
 				EABD46C31857A0F300A5F081 /* UIKit.framework in Frameworks */,
 				EABD46C41857A0F300A5F081 /* Foundation.framework in Frameworks */,
 				EABD46C51857A0F300A5F081 /* CoreGraphics.framework in Frameworks */,
+				E9F646F81AA3BABA00C37EA3 /* IOKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -404,6 +414,7 @@
 		AAB0726A139719AC008AF393 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E9AD81F91AA180B900B369FD /* IOKit.framework */,
 				84D293B71A2C8DF700C10944 /* AddressBookUI.framework */,
 				84D293AE1A2C867300C10944 /* CoreLocation.framework */,
 				EABD46AB1857A0EB00A5F081 /* XCTest.framework */,
@@ -477,6 +488,8 @@
 				EABD46761857A07600A5F081 /* XCTestCase-KIFAdditions.m */,
 				EAC809681864F19C000E819F /* NSException-KIFAdditions.h */,
 				EAC809691864F19C000E819F /* NSException-KIFAdditions.m */,
+				E977D1051AA4062B005645BF /* UIEvent+KIFAdditions.h */,
+				E977D1061AA4062B005645BF /* UIEvent+KIFAdditions.m */,
 			);
 			path = Additions;
 			sourceTree = "<group>";
@@ -619,6 +632,7 @@
 				EABD469E1857A0C700A5F081 /* KIFTestCase.h in Headers */,
 				EABD469F1857A0C700A5F081 /* KIFSystemTestActor.h in Headers */,
 				EABD46A01857A0C700A5F081 /* KIFUITestActor.h in Headers */,
+				E977D1071AA4062B005645BF /* UIEvent+KIFAdditions.h in Headers */,
 				EABD46A11857A0C700A5F081 /* NSBundle-KIFAdditions.h in Headers */,
 				EAC8096A1864F19C000E819F /* NSException-KIFAdditions.h in Headers */,
 				EABD46961857A0C700A5F081 /* XCTestCase-KIFAdditions.h in Headers */,
@@ -882,6 +896,7 @@
 				EABD46861857A0C700A5F081 /* XCTestCase-KIFAdditions.m in Sources */,
 				EB1A44D61A0C3268004A3F61 /* KIFUITestActor-IdentifierTests.m in Sources */,
 				EB2526491981BF7A00DBC747 /* KIFUITestActor-ConditionalTests.m in Sources */,
+				E977D1081AA4062B005645BF /* UIEvent+KIFAdditions.m in Sources */,
 				EABD46871857A0C700A5F081 /* KIFSystemTestActor.m in Sources */,
 				EAC8096B1864F19C000E819F /* NSException-KIFAdditions.m in Sources */,
 				EABD46881857A0C700A5F081 /* KIFUITestActor.m in Sources */,
@@ -992,6 +1007,7 @@
 				EBAE488217A460E50005EE19 /* NSError-KIFAdditions.m in Sources */,
 				EBAE488817A4E5C30005EE19 /* KIFTestStepValidation.m in Sources */,
 				EABD474C185F509E00A5F081 /* SenTestCase-KIFAdditions.m in Sources */,
+				E977D1091AA40736005645BF /* UIEvent+KIFAdditions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1145,6 +1161,7 @@
 					DEBUG,
 					"KIF_XCTEST=1",
 				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = KIF;
 			};
@@ -1165,6 +1182,7 @@
 					DEBUG,
 					"KIF_XCTEST=1",
 				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = KIF;
 			};
@@ -1181,6 +1199,7 @@
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
 				GCC_PREFIX_HEADER = "Classes/KIF-XCTestPrefix.pch";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = KIF;
 			};
@@ -1212,6 +1231,7 @@
 					"$(inherited)",
 				);
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "KIF Tests/KIF Tests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1249,6 +1269,7 @@
 					"KIF_XCTEST=1",
 				);
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "KIF Tests/KIF Tests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1280,6 +1301,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "KIF Tests/KIF XCTests-Prefix.pch";
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "KIF Tests/KIF Tests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				OTHER_LDFLAGS = "-ObjC";
@@ -1371,6 +1393,7 @@
 					"$(inherited)",
 				);
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "KIF Tests/KIF Tests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1399,6 +1422,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "KIF Tests/KIF Tests-Prefix.pch";
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "KIF Tests/KIF Tests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				OTHER_LDFLAGS = "-ObjC";
@@ -1421,6 +1445,7 @@
 					DEBUG,
 					"KIF_SENTEST=1",
 				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "KIF-OCUnit";
 			};
@@ -1434,6 +1459,7 @@
 				DSTROOT = /tmp/KIF.dst;
 				FRAMEWORK_SEARCH_PATHS = "\"$(SDKROOT)/Developer/Library/Frameworks\"";
 				GCC_PREFIX_HEADER = "Classes/KIF-Prefix.pch";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "KIF-OCUnit";
 			};
@@ -1474,6 +1500,7 @@
 					DEBUG,
 					"KIF_SENTEST=1",
 				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "KIF-OCUnit";
 			};
@@ -1564,6 +1591,7 @@
 					"KIF_SENTEST=1",
 				);
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "KIF Tests/KIF Tests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
 				ONLY_ACTIVE_ARCH = YES;


### PR DESCRIPTION
Tentative fix for https://github.com/kif-framework/KIF/issues/574

Running KIF on iOS 8.3 (with XCode 6.3 Beta) leads to the following error
![screen shot 2015-03-01 at 10 51 33 pm](https://cloud.githubusercontent.com/assets/233326/6435164/8b434d78-c065-11e4-86e1-898704b44222.png)

Since it was referencing `IOHIDEvent` I looked into `[UIEvent _hidEvent]` [private attribute](https://github.com/nst/iOS-Runtime-Headers/blob/master/Frameworks/UIKit.framework/UIEvent.h#L15) and realized it was always nil for [UIEvent created by KIF](https://github.com/kif-framework/KIF/blob/a98d4102e6ee1f11e7fc88bf99ab724baf320ce5/Additions/UIView-KIFAdditions.m#L782) (unlike real UIEvents that have a valid `_hidEvent`).
My guess was that starting with iOS 8.3, the usage of `[UIEvent _gsEvent]` was deprecated in favor on `[UIEvent _hidEvent]`.
After some poking around, trial and error and the help of [some code](https://github.com/iolate/SimulateTouch/blob/master/SimulateTouch.mm#L170) found on github I was able to fake this `IOHIDEvent` attribute.
This solution relies heavily on iOS private APIs (IOKit private framework needs to be added) so I am not sure this is the best approach. @phatmann what do you think?

I have tested on iOS 7.1, 8.1 and 8.3.