### PR TITLE
Add URL Matcher for asserting on URL scheme

### DIFF
--- a/Classes/KIFSystemTestActor.h
+++ b/Classes/KIFSystemTestActor.h
@@ -62,6 +62,14 @@
 - (void)waitForApplicationToOpenAnyURLWhileExecutingBlock:(void(^)())block returning:(BOOL)returnValue;
 
 /*!
+ @abstract Waits for the application to request any URL with the given URL Scheme while executing a block.
+ @param URLScheme The scheme component of the URL to detect.
+ @param block The block of code to be executed.
+ @param returnValue The value to return from @c +[UIApplication openURL:].
+ */
+- (void)waitForApplicationToOpenURLWithScheme:(NSString *)URLScheme whileExecutingBlock:(void (^)())block returning:(BOOL)returnValue;
+
+/*!
  @abstract Captured a screenshot of the current screen and writes it to disk with an optional description.
  @discussion This step will fail if the @c KIF_SCREENSHOTS environment variable is not set or if the screenshot cannot be written to disk.
  @param description A description to use when writing the file to disk.

--- a/Classes/KIFSystemTestActor.m
+++ b/Classes/KIFSystemTestActor.m
@@ -69,21 +69,39 @@
     }
 }
 
+
 - (void)waitForApplicationToOpenAnyURLWhileExecutingBlock:(void (^)())block returning:(BOOL)returnValue
 {
     [self waitForApplicationToOpenURL:nil whileExecutingBlock:block returning:returnValue];
 }
 
-- (void)waitForApplicationToOpenURL:(NSString *)URLString whileExecutingBlock:(void (^)())block returning:(BOOL)returnValue
+- (void)waitForApplicationToOpenURLWithScheme:(NSString *)URLScheme whileExecutingBlock:(void (^)())block returning:(BOOL)returnValue {
+    [self waitForApplicationToOpenURLMatchingBlock:^(NSURL *actualURL){
+        if (URLScheme && ![URLScheme isEqualToString:actualURL.scheme]) {
+            [self failWithError:[NSError KIFErrorWithFormat:@"Expected %@ to start with %@", actualURL.absoluteString, URLScheme] stopTest:YES];
+        }
+    } whileExecutingBlock:block returning:returnValue];
+}
+
+- (void)waitForApplicationToOpenURL:(NSString *)URLString whileExecutingBlock:(void (^)())block returning:(BOOL)returnValue {
+    [self waitForApplicationToOpenURLMatchingBlock:^(NSURL *actualURL){
+
+        if (URLString && ![[actualURL absoluteString] isEqualToString:URLString]) {
+            [self failWithError:[NSError KIFErrorWithFormat:@"Expected %@, got %@", URLString, actualURL.absoluteString] stopTest:YES];
+        }
+    } whileExecutingBlock:block returning:returnValue];
+}
+
+- (void)waitForApplicationToOpenURLMatchingBlock:(void (^)(NSURL *actualURL))URLMatcherBlock whileExecutingBlock:(void (^)())block returning:(BOOL)returnValue
 {
     [UIApplication startMockingOpenURLWithReturnValue:returnValue];
     NSNotification *notification = [self waitForNotificationName:UIApplicationDidMockOpenURLNotification object:[UIApplication sharedApplication] whileExecutingBlock:block complete:^{
         [UIApplication stopMockingOpenURL];
     }];
-    
-    NSString *actualURLString = [[notification.userInfo objectForKey:UIApplicationOpenedURLKey] absoluteString];
-    if (URLString && ![URLString isEqualToString:actualURLString]) {
-        [self failWithError:[NSError KIFErrorWithFormat:@"Expected %@, got %@", URLString, actualURLString] stopTest:YES];
+
+    if (URLMatcherBlock) {
+        NSURL *actualURL = [notification.userInfo objectForKey:UIApplicationOpenedURLKey];
+        URLMatcherBlock(actualURL);
     }
 }
 

--- a/KIF Tests/SystemTests.m
+++ b/KIF Tests/SystemTests.m
@@ -88,6 +88,11 @@
         returnValue = [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"test123://"]];
     } returning:YES];
     KIFAssertEqual(YES, returnValue, @"openURL: should have returned YES");
+
+    [system waitForApplicationToOpenURLWithScheme:@"test123" whileExecutingBlock:^{
+        returnValue = [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"test123://"]];
+    } returning:YES];
+    KIFAssertEqual(YES, returnValue, @"openURL: should have returned YES");
     
     [system waitForApplicationToOpenAnyURLWhileExecutingBlock:^{
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"423543523454://"]];


### PR DESCRIPTION
This is useful for making an assertion that an app switches to a
particular app.

It has the benefit of being less technically prescriptive than a fully specified absolute URL,
but still more valuable in tests than a the more general assertion on _any_ URL.