### PR TITLE
Add identifier test: isElementWithAccessibilityIdentifierVisible

### DIFF
--- a/IdentifierTests/KIFUITestActor-IdentifierTests.h
+++ b/IdentifierTests/KIFUITestActor-IdentifierTests.h
@@ -70,4 +70,11 @@
  */
 - (void)waitForFirstResponderWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier;
 
+/*!
+ @abstract returns YES or NO if the element is visible.
+ @discussion if the element described by the accessibility identifier is visible, the method returns true.
+ @param accessibilityIdentifier The accessibility identifier of the element to query for
+ */
+- (BOOL) tryFindingViewWithAccessibilityIdentifier:(NSString *) accessibilityIdentifier;
+
 @end

--- a/IdentifierTests/KIFUITestActor-IdentifierTests.m
+++ b/IdentifierTests/KIFUITestActor-IdentifierTests.m
@@ -196,7 +196,11 @@
 	}];
 }
 
-
+- (BOOL) tryFindingViewWithAccessibilityIdentifier:(NSString *) accessibilityIdentifier
+{
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", accessibilityIdentifier];
+    return [UIAccessibilityElement accessibilityElement:nil view:nil withElementMatchingPredicate:predicate tappable:NO error:nil];
+}
 
 
 @end

--- a/KIF Tests/AccessibilityIdentifierTests.m
+++ b/KIF Tests/AccessibilityIdentifierTests.m
@@ -70,6 +70,18 @@
 	[tester clearTextFromAndThenEnterText:@"Yo" intoViewWithAccessibilityIdentifier:@"idGreeting"];
 }
 
+- (void)testTryFindingViewWithAccessibilityIdentifier
+{
+    if (![tester tryFindingViewWithAccessibilityIdentifier:@"idGreeting"])
+    {
+        [tester fail];
+    }
+
+    if ([tester tryFindingViewWithAccessibilityIdentifier:@"idDoesNotExist"])
+    {
+        [tester fail];
+    }
+}
 
 - (void)afterEach
 {


### PR DESCRIPTION
Add the ability to test whether an element is visible on the screen based on the accessibilityIdentifier. This pull request attempts to add that.