### PR TITLE
Fixes issue #464 (infinite recursion in UICollectionView)

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -221,7 +221,8 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                     [cell removeFromSuperview];
                     
                     // Skip this cell if it isn't the one we're looking for
-                    if (!element) {
+                    // Sometimes we get cells with no size here which can cause an endless loop, so we ignore those
+                    if (!element || CGSizeEqualToSize(cell.frame.size, CGSizeZero)) {
                         continue;
                     }
                 }


### PR DESCRIPTION
In my case, the UICollectionView was being searched for a cell, but was scrolling to a cell who's frame size was 0 over and over again. This PR fixes infinite recursion in those cases.