### PR TITLE
Syntax highlight Objective-C in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,72 +132,80 @@ The first step is to create a test class to test some functionality.  In our cas
 
 *LoginTestCase.h*
 
-	#import <KIF/KIF.h>
+```objective-c
+#import <KIF/KIF.h>
 
-	@interface LoginTests : KIFTestCase
-	@end
+@interface LoginTests : KIFTestCase
+@end
+```
 
 *LoginTestCase.m*
 
-	#import "LoginTests.h"
-	#import "KIFUITestActor+EXAdditions.h"
+```objective-c
+#import "LoginTests.h"
+#import "KIFUITestActor+EXAdditions.h"
 
-	@implementation LoginTests
+@implementation LoginTests
 
-	- (void)beforeEach
-	{
-	    [tester navigateToLoginPage];
-	}
+- (void)beforeEach
+{
+    [tester navigateToLoginPage];
+}
 
-	- (void)afterEach
-	{
-	    [tester returnToLoggedOutHomeScreen];
-	}
+- (void)afterEach
+{
+    [tester returnToLoggedOutHomeScreen];
+}
 
-	- (void)testSuccessfulLogin
-	{
-	    [tester enterText:@"user@example.com" intoViewWithAccessibilityLabel:@"Login User Name"];
-	    [tester enterText:@"thisismypassword" intoViewWithAccessibilityLabel:@"Login Password"];
-	    [tester tapViewWithAccessibilityLabel:@"Log In"];
+- (void)testSuccessfulLogin
+{
+    [tester enterText:@"user@example.com" intoViewWithAccessibilityLabel:@"Login User Name"];
+    [tester enterText:@"thisismypassword" intoViewWithAccessibilityLabel:@"Login Password"];
+    [tester tapViewWithAccessibilityLabel:@"Log In"];
 
-	    // Verify that the login succeeded
-	    [tester waitForTappableViewWithAccessibilityLabel:@"Welcome"];
-	}
+    // Verify that the login succeeded
+    [tester waitForTappableViewWithAccessibilityLabel:@"Welcome"];
+}
 
-	@end
+@end
+```
 
 Most of the tester actions in the test are already defined by the KIF framework, but `-navigateToLoginPage` and `-returnToLoggedOutHomeScreen` are not. These are examples of custom actions which are specific to your application. Adding such steps is easy, and is done using a factory method in a category of `KIFUITestActor`, similar to how we added the scenario.
 
 *KIFUITestActor+EXAdditions.h*
 
-	#import <KIF/KIF.h>
+```objective-c
+#import <KIF/KIF.h>
 
-	@interface KIFUITestActor (EXAdditions)
+@interface KIFUITestActor (EXAdditions)
 
-	- (void)navigateToLoginPage;
-	- (void)returnToLoggedOutHomeScreen;
+- (void)navigateToLoginPage;
+- (void)returnToLoggedOutHomeScreen;
 
-	@end
+@end
+```
 
 *KIFUITestActor+EXAdditions.m*
 
-	#import "KIFUITestActor+EXAdditions.h"
+```objective-c
+#import "KIFUITestActor+EXAdditions.h"
 
-	@implementation KIFUITestActor (EXAdditions)
+@implementation KIFUITestActor (EXAdditions)
 
-	- (void)navigateToLoginPage
-	{
-	    [self tapViewWithAccessibilityLabel:@"Login/Sign Up"];
-	    [self tapViewWithAccessibilityLabel:@"Skip this ad"];
-	}
+- (void)navigateToLoginPage
+{
+    [self tapViewWithAccessibilityLabel:@"Login/Sign Up"];
+    [self tapViewWithAccessibilityLabel:@"Skip this ad"];
+}
 
-	- (void)returnToLoggedOutHomeScreen
-	{
-	    [self tapViewWithAccessibilityLabel:@"Logout"];
-	    [self tapViewWithAccessibilityLabel:@"Logout"]; // Dismiss alert.
-	}
+- (void)returnToLoggedOutHomeScreen
+{
+    [self tapViewWithAccessibilityLabel:@"Logout"];
+    [self tapViewWithAccessibilityLabel:@"Logout"]; // Dismiss alert.
+}
 
-	@end
+@end
+```
 
 Everything should now be configured. When you run the integration tests using the test button, ⌘U, or the Xcode 5 Test Navigator (⌘5).
 
@@ -208,21 +216,23 @@ Use with other testing frameworks
 
 For example, the following [Specta](https://github.com/specta/specta) test works without any changes to KIF or Specta:
 
-    #import <Specta.h>
-    #import <KIF.h>
+```objective-c
+#import <Specta.h>
+#import <KIF.h>
 
-    SpecBegin(App)
+SpecBegin(App)
 
-    describe(@"Tab controller", ^{
+describe(@"Tab controller", ^{
 
-      it(@"should show second view when I tap on the second tab", ^{
-        [tester tapViewWithAccessibilityLabel:@"Second" traits:UIAccessibilityTraitButton];
-        [tester waitForViewWithAccessibilityLabel:@"Second View"];
-      });
+  it(@"should show second view when I tap on the second tab", ^{
+    [tester tapViewWithAccessibilityLabel:@"Second" traits:UIAccessibilityTraitButton];
+    [tester waitForViewWithAccessibilityLabel:@"Second View"];
+  });
 
-    });
+});
 
-    SpecEnd
+SpecEnd
+```
 
 If you want to use KIF with a test runner that does not subclass `XCTestCase`, your runner class just needs to implement the `KIFTestActorDelegate` protocol which contains two required methods.
 


### PR DESCRIPTION
Hello! I noticed the Objective-C code in the README wasn't syntax highlighted, but the other code blocks were. This PR fixes that!