### PR TITLE
Added printViewHierarchy to the UIView category. 

### DIFF
--- a/Additions/UIView-KIFAdditions.h
+++ b/Additions/UIView-KIFAdditions.h
@@ -115,4 +115,14 @@ typedef CGPoint KIFDisplacement;
  */
 @property (nonatomic, readonly) UIWindow *windowOrIdentityWindow;
 
+/*!
+ @abstract Prints the view hiererchy, starting from the top window(s), along with accessibility information, which is more related to KIF than the usual information given by the 'description' method.
+ */
++(void)printViewHierarchy;
+
+/*!
+ @abstract Prints the view hiererchy, starting from this view, along with accessibility information, which is more related to KIF than the usual information given by the 'description' method.
+ */
+-(void)printViewHierarchy;
+
 @end

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -831,4 +831,177 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     }
 }
 
+- (void)printViewHierarchy {
+    [self printViewHierarchyWithIndentation:0];
+}
+
++(void)printViewHierarchy {
+    NSArray* windows = [UIApplication sharedApplication].windows;
+    if(windows.count == 1) {
+        [windows[0] printViewHierarchy];
+    } else {
+        //more than one window, also print some information about each window
+        for (UIWindow* window in windows) {
+            printf("Window level %f", window.windowLevel);
+            if(window.isKeyWindow) printf(" (key window)");
+            printf("\n");
+            [window printViewHierarchy];
+            printf("\n");
+        }
+    }
+}
+
+- (void)printAccessibilityTraits:(UIAccessibilityTraits)traits {
+    
+    printf("traits: ");
+    bool didPrintOne = false;
+    if(traits == UIAccessibilityTraitNone) {
+        printf("none");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitButton) {
+        if(didPrintOne) printf(", ");
+        printf("button");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitLink) {
+        if(didPrintOne) printf(", ");
+        printf("link");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitHeader) {
+        if(didPrintOne) printf(", ");
+        printf("header");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitSearchField) {
+        if(didPrintOne) printf(", ");
+        printf("search field");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitImage) {
+        if(didPrintOne) printf(", ");
+        printf("image");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitSelected) {
+        if(didPrintOne) printf(", ");
+        printf("selected");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitPlaysSound) {
+        if(didPrintOne) printf(", ");
+        printf("plays sound");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitKeyboardKey) {
+        if(didPrintOne) printf(", ");
+        printf("keyboard key");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitStaticText) {
+        if(didPrintOne) printf(", ");
+        printf("static text");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitSummaryElement) {
+        if(didPrintOne) printf(", ");
+        printf("summary element");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitNotEnabled) {
+        if(didPrintOne) printf(", ");
+        printf("not enabled");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitUpdatesFrequently) {
+        if(didPrintOne) printf(", ");
+        printf("updates frequently");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitStartsMediaSession) {
+        if(didPrintOne) printf(", ");
+        printf("starts media session");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitAdjustable) {
+        if(didPrintOne) printf(", ");
+        printf("adjustable");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitAllowsDirectInteraction) {
+        if(didPrintOne) printf(", ");
+        printf("allows direct interaction");
+        didPrintOne = true;
+    }
+    if(traits & UIAccessibilityTraitCausesPageTurn) {
+        if(didPrintOne) printf(", ");
+        printf("causes page turn");
+        didPrintOne = true;
+    }
+    if(!didPrintOne) {
+        printf("unknown flags (0x%llx)", traits);
+    }
+}
+
+
+- (void)printViewHierarchyWithIndentation:(int)indent {
+    NSString* name = NSStringFromClass([self class]);
+    NSString* label = self.accessibilityLabel;
+    NSString* identifier = self.accessibilityIdentifier;
+    for(int i = 0; i < indent; ++i) {
+        printf("|\t");
+    }
+    printf("%s", name.UTF8String);
+    if(label != nil) {
+        printf(", label: %s", label.UTF8String);
+    } else if(identifier != nil) {
+        printf(", identifier: %s", identifier.UTF8String);
+    }
+    if(self.hidden) {
+        printf(" (invisible)");
+    }
+    
+    if([self isKindOfClass:[UIImageView class]]) {
+        if(((UIImageView*)self).highlighted) {
+            printf(" (highlighted)");
+        } else {
+            printf(" (not highlighted)");
+        }
+    }
+    
+    if([self isKindOfClass:[UIControl class]]) {
+        UIControl* ctrl = (UIControl*)self;
+        ctrl.enabled ? printf(" (enabled)") : printf(" (not enabled)");
+        ctrl.selected ? printf(" (selected)") : printf(" (not selected)");
+        ctrl.highlighted ? printf(" (highlighted)") : printf(" (not highlighted)");
+    }
+    printf("\n");
+    
+    //
+    NSInteger numOfAccElements = self.accessibilityElementCount;
+    if(numOfAccElements != NSNotFound) {
+        for (NSInteger i = 0; i < numOfAccElements; ++i) {
+            for(int i = 0; i < indent+1; ++i) {
+                printf("|\t");
+            }
+            UIAccessibilityElement *e = [(UIAccessibilityElement*)self accessibilityElementAtIndex:i];
+            printf("UIAccessibilityElement, label: %s", e.accessibilityLabel.UTF8String);
+            if(e.accessibilityValue && e.accessibilityValue.length > 0) {
+                printf(", value: %s", e.accessibilityValue.UTF8String);
+            }
+            if(e.accessibilityHint && e.accessibilityHint.length > 0) {
+                printf(", hint: %s", e.accessibilityHint.UTF8String);
+            }
+            printf(", ");
+            [self printAccessibilityTraits:e.accessibilityTraits];
+            printf("\n");
+        }
+    }
+    
+    for (UIView *subview in self.subviews) {
+        [subview printViewHierarchyWithIndentation:indent+1];
+    }
+}
+
 @end


### PR DESCRIPTION
It prints the view hierarchy along with KIF related information, like the accessibility label or identifier, whether the view is visible or not etc.. I found it quite useful for debugging when the waitForView... methods fail for unknown reasons. 
The methods comes in two variants, an instance method which prints the hierarchy starting with the given view and a class method, called with ```[UIView printViewHierarchy]``` which starts with the top window(s) and prints all the subviews from there.