### PR TITLE
Add ability to call canOpenURL: during waitForApplicationToOpenURL blocks

### DIFF
--- a/Additions/UIApplication-KIFAdditions.h
+++ b/Additions/UIApplication-KIFAdditions.h
@@ -17,6 +17,11 @@
 UIKIT_EXTERN NSString *const UIApplicationDidMockOpenURLNotification;
 
 /*!
+ @abstract When mocking @c -canOpenURL:, this notification is posted.
+ */
+UIKIT_EXTERN NSString *const UIApplicationDidMockCanOpenURLNotification;
+
+/*!
  @abstract The key for the opened URL in the @c UIApplicationDidMockOpenURLNotification notification.
  */
 UIKIT_EXTERN NSString *const UIApplicationOpenedURLKey;

--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -28,6 +28,7 @@ static BOOL _KIF_UIApplicationMockOpenURL_returnValue = NO;
 @end
 
 NSString *const UIApplicationDidMockOpenURLNotification = @"UIApplicationDidMockOpenURLNotification";
+NSString *const UIApplicationDidMockCanOpenURLNotification = @"UIApplicationDidMockCanOpenURLNotification";
 NSString *const UIApplicationOpenedURLKey = @"UIApplicationOpenedURL";
 static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
 
@@ -220,6 +221,16 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
     }
 }
 
+- (BOOL)KIF_canOpenURL:(NSURL *)URL;
+{
+    if (_KIF_UIApplicationMockOpenURL) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidMockCanOpenURLNotification object:self userInfo:@{UIApplicationOpenedURLKey: URL}];
+        return _KIF_UIApplicationMockOpenURL_returnValue;
+    } else {
+        return [self KIF_canOpenURL:URL];
+    }
+}
+
 static inline void Swizzle(Class c, SEL orig, SEL new)
 {
     Method origMethod = class_getInstanceMethod(c, orig);
@@ -248,6 +259,7 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         Swizzle(self, @selector(openURL:), @selector(KIF_openURL:));
+        Swizzle(self, @selector(canOpenURL:), @selector(KIF_canOpenURL:));
     });
 
     _KIF_UIApplicationMockOpenURL = YES;

--- a/KIF Tests/SystemTests.m
+++ b/KIF Tests/SystemTests.m
@@ -78,27 +78,43 @@
 
 - (void)testMockingOpenURL
 {
-    __block BOOL returnValue;
+    __block BOOL openURLReturnValue;
+    __block BOOL canOpenURLReturnValue;
     [system waitForApplicationToOpenURL:@"test123://" whileExecutingBlock:^{
-        returnValue = [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"test123://"]];
+        NSURL *uninstalledAppURL = [NSURL URLWithString:@"test123://"];
+        openURLReturnValue = [[UIApplication sharedApplication] canOpenURL:uninstalledAppURL];
+        canOpenURLReturnValue = [[UIApplication sharedApplication] openURL:uninstalledAppURL];
     } returning:NO];
-    KIFAssertEqual(NO, returnValue, @"openURL: should have returned NO");
+    KIFAssertEqual(NO, openURLReturnValue, @"openURL: should have returned NO");
+    KIFAssertEqual(NO, canOpenURLReturnValue, @"openURL: should have returned NO");
     
     [system waitForApplicationToOpenURL:@"test123://" whileExecutingBlock:^{
-        returnValue = [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"test123://"]];
+        NSURL *installedAppURL = [NSURL URLWithString:@"test123://"];
+        openURLReturnValue = [[UIApplication sharedApplication] canOpenURL:installedAppURL];
+        canOpenURLReturnValue = [[UIApplication sharedApplication] openURL:installedAppURL];
     } returning:YES];
-    KIFAssertEqual(YES, returnValue, @"openURL: should have returned YES");
+    KIFAssertEqual(YES, openURLReturnValue, @"openURL: should have returned YES");
+    KIFAssertEqual(YES, canOpenURLReturnValue, @"openURL: should have returned YES");
 
     [system waitForApplicationToOpenURLWithScheme:@"test123" whileExecutingBlock:^{
-        returnValue = [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"test123://"]];
+        NSURL *installedAppURL = [NSURL URLWithString:@"test123://some/path?query"];
+        openURLReturnValue = [[UIApplication sharedApplication] canOpenURL:installedAppURL];
+        canOpenURLReturnValue = [[UIApplication sharedApplication] openURL:installedAppURL];
     } returning:YES];
-    KIFAssertEqual(YES, returnValue, @"openURL: should have returned YES");
-    
+    KIFAssertEqual(YES, openURLReturnValue, @"openURL: should have returned YES");
+    KIFAssertEqual(YES, canOpenURLReturnValue, @"openURL: should have returned YES");
+
     [system waitForApplicationToOpenAnyURLWhileExecutingBlock:^{
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"423543523454://"]];
+        NSURL *someURL = [NSURL URLWithString:@"423543523454://"];
+        openURLReturnValue = [[UIApplication sharedApplication] canOpenURL:someURL];
+        canOpenURLReturnValue = [[UIApplication sharedApplication] openURL:someURL];
     } returning:YES];
-    
-    KIFAssertFalse([[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"this-is-a-fake-url://"]], @"Should no longer be mocking, reject bad URL.");
+    KIFAssertEqual(YES, openURLReturnValue, @"openURL: should have returned YES");
+    KIFAssertEqual(YES, canOpenURLReturnValue, @"openURL: should have returned YES");
+
+    NSURL *fakeURL = [NSURL URLWithString:@"this-is-a-fake-url://"];
+    KIFAssertFalse([[UIApplication sharedApplication] canOpenURL:fakeURL], @"Should no longer be mocking, reject bad URL.");
+    KIFAssertFalse([[UIApplication sharedApplication] openURL:fakeURL], @"Should no longer be mocking, reject bad URL.");
 }
 
 @end


### PR DESCRIPTION
This further enhances the behavior introduced in
https://github.com/kif-framework/KIF/pull/588

When mocking openURL:, it also makes sense to be able to call
canOpenURL: and receive consistent results.

For example:

```objectivec
[system waitForApplicationToOpenURL:@"test123://" whileExecutingBlock:^{
    NSURL *URL = [NSURL URLWithString:@"test123://"];
    NSAssert([[UIApplication sharedApplication] openURL:URL],
             @"You can open the URL");
    NSAssert([[UIApplication sharedApplication] canOpenURL:URL],
             @"You can also check the URL");
} returning:YES];
```

#### Implementation Notes
- Whenever openURL: is swizzled, also swizzle canOpenURL:
- When canOpenURL: is called, an NSNotification is posted
- The notification handler checks whether the URL matches,
  - possibly failing the test,
  - but leaving the openURL: mocking in place