### PR TITLE
Fixed: UIPanGestureRecognizer velocity value

### DIFF
--- a/Additions/UIEvent+KIFAdditions.m
+++ b/Additions/UIEvent+KIFAdditions.m
@@ -89,6 +89,7 @@ typedef struct __GSEvent * GSEventRef;
 @interface UIEvent (KIFAdditionsMorePrivateHeaders)
 - (void)_setGSEvent:(GSEventRef)event;
 - (void)_setHIDEvent:(IOHIDEventRef)event;
+- (void)_setTimestamp:(NSTimeInterval)timestemp;
 @end
 
 @implementation UIEvent (KIFAdditions)
@@ -122,6 +123,7 @@ typedef struct __GSEvent * GSEventRef;
     
     [self _setGSEvent:(GSEventRef)gsEventProxy];
     
+    [self _setTimestamp:(((UITouch*)touches[0]).timestamp)];
 }
 
 - (void)kif_setIOHIDEventWithTouches:(NSArray *)touches

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -485,6 +485,8 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
             }
             UIEvent *eventDown = [self eventWithTouches:[NSArray arrayWithArray:touches]];
             [[UIApplication sharedApplication] sendEvent:eventDown];
+            
+            CFRunLoopRunInMode(UIApplicationCurrentRunMode, DRAG_TOUCH_DELAY, false);
         }
         else
         {


### PR DESCRIPTION
This little fix is related to **UIPanGestureRecognizer**.
The main problem was that the _UIEvent_ object doesn\`t have a correct time stamp. That was always 0. If the time stamp is constant than the ```[panGestureRecognizer velocityInView:view]``` value remains always 0 on dragging the generated _UITouch_ objects from one point to another.

This fix synchronizes _UITouch_ and _UIEvent_ objects time stamp, and with this little change the system provides a valid velocity value when you call ```velocityInView:``` method.

Best regards,
LoGeN