### PR TITLE
Fixed static analysis error with uninitialized data

### DIFF
--- a/Additions/UIEvent+KIFAdditions.m
+++ b/Additions/UIEvent+KIFAdditions.m
@@ -127,7 +127,9 @@ typedef struct __GSEvent * GSEventRef;
 - (void)kif_setIOHIDEventWithTouches:(NSArray *)touches
 {
     uint64_t abTime = mach_absolute_time();
-    AbsoluteTime timeStamp = *(AbsoluteTime *) &abTime;
+    AbsoluteTime timeStamp;
+    timeStamp.hi = (UInt32)(abTime >> 32);
+    timeStamp.lo = (UInt32)(abTime);
     
     IOHIDEventRef handEvent = IOHIDEventCreateDigitizerEvent(kCFAllocatorDefault, timeStamp, kIOHIDDigitizerTransducerTypeHand, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     


### PR DESCRIPTION
The current implementation for the gesture `timeStamp` uses the `mach_absolute_time()`.  This poses a problem because the Static Analyzer can't correctly cast `mach_absolute_time` to `AbsoluteTime` resulting in a Static Analyzer Issue.

![screen shot 2015-04-05 at 10 29 50 am](https://cloud.githubusercontent.com/assets/1218847/6997801/5cda966e-db7f-11e4-8e54-8f7e1a6ccad0.png)


This solution replaces `AbsoluteTime` with with `CFAbsoluteTime` and then uses the  `CACurrentMediaTime` [which is also based off of the internal clock](http://nshipster.com/benchmarking/) to set the timeStamp.