### PR TITLE
Remove non-visible table view cells so that they don't stick around.

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -121,7 +121,12 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock;
 {
-    if (self.hidden) {
+    return [self accessibilityElementMatchingBlock:matchBlock notHidden:YES];
+}
+
+- (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock notHidden:(BOOL)notHidden;
+{
+    if (notHidden && self.hidden) {
         return nil;
     }
     
@@ -167,7 +172,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     while (elementStack.count) {
         UIAccessibilityElement *element = [elementStack lastObject];
         [elementStack removeLastObject];
-
+        
         BOOL elementMatches = matchBlock(element);
 
         if (elementMatches) {
@@ -193,46 +198,89 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
             UIAccessibilityElement *subelement = [element accessibilityElementAtIndex:accessibilityElementIndex];
             
             if (subelement) {
+                // Skip table view cell accessibility elements, they're handled below
+                if ([subelement isKindOfClass:NSClassFromString(@"UITableViewCellAccessibilityElement")]) {
+                    continue;
+                }
+                
                 [elementStack addObject:subelement];
             }
         }
     }
     
-    if (!matchingButOccludedElement && [self isKindOfClass:[UICollectionView class]]) {
-        UICollectionView *collectionView = (UICollectionView *)self;
-        
-        NSArray *indexPathsForVisibleItems = [collectionView indexPathsForVisibleItems];
-        
-        for (NSUInteger section = 0, numberOfSections = [collectionView numberOfSections]; section < numberOfSections; section++) {
-            for (NSUInteger item = 0, numberOfItems = [collectionView numberOfItemsInSection:section]; item < numberOfItems; item++) {
-                // Skip visible items because they are already handled
-                NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
-                if ([indexPathsForVisibleItems containsObject:indexPath]) {
-                    continue;
-                }
-                
-                @autoreleasepool {
-                    // Get the cell directly from the dataSource because UICollectionView will only vend visible cells
-                    UICollectionViewCell *cell = [collectionView.dataSource collectionView:collectionView cellForItemAtIndexPath:indexPath];
-                    
-                    UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock];
-                    
-                    // Remove the cell from the collection view so that it doesn't stick around
-                    [cell removeFromSuperview];
-                    
-                    // Skip this cell if it isn't the one we're looking for
-                    // Sometimes we get cells with no size here which can cause an endless loop, so we ignore those
-                    if (!element || CGSizeEqualToSize(cell.frame.size, CGSizeZero)) {
+    if (!matchingButOccludedElement) {
+        if ([self isKindOfClass:[UITableView class]]) {
+            UITableView *tableView = (UITableView *)self;
+            
+            NSArray *indexPathsForVisibleRows = [tableView indexPathsForVisibleRows];
+            
+            for (NSUInteger section = 0, numberOfSections = [tableView numberOfSections]; section < numberOfSections; section++) {
+                for (NSUInteger row = 0, numberOfRows = [tableView numberOfRowsInSection:section]; row < numberOfRows; row++) {
+                    // Skip visible rows because they are already handled
+                    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:row inSection:section];
+                    if ([indexPathsForVisibleRows containsObject:indexPath]) {
                         continue;
                     }
+                    
+                    @autoreleasepool {
+                        // Get the cell directly from the dataSource because UITableView will only vend visible cells
+                        UITableViewCell *cell = [tableView.dataSource tableView:tableView cellForRowAtIndexPath:indexPath];
+                        
+                        UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock notHidden:NO];
+                        
+                        // Remove the cell from the table view so that it doesn't stick around
+                        [cell removeFromSuperview];
+                        
+                        // Skip this cell if it isn't the one we're looking for
+                        if (!element) {
+                            continue;
+                        }
+                    }
+                    
+                    // Scroll to the cell and wait for the animation to complete
+                    [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:YES];
+                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.5, false);
+                    
+                    // Now try finding the element again
+                    return [self accessibilityElementMatchingBlock:matchBlock];
                 }
-                
-                // Scroll to the cell and wait for the animation to complete
-                [collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionNone animated:YES];
-                CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.5, false);
-                
-                // Now try finding the element again
-                return [self accessibilityElementMatchingBlock:matchBlock];
+            }
+        } else if ([self isKindOfClass:[UICollectionView class]]) {
+            UICollectionView *collectionView = (UICollectionView *)self;
+            
+            NSArray *indexPathsForVisibleItems = [collectionView indexPathsForVisibleItems];
+            
+            for (NSUInteger section = 0, numberOfSections = [collectionView numberOfSections]; section < numberOfSections; section++) {
+                for (NSUInteger item = 0, numberOfItems = [collectionView numberOfItemsInSection:section]; item < numberOfItems; item++) {
+                    // Skip visible items because they are already handled
+                    NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
+                    if ([indexPathsForVisibleItems containsObject:indexPath]) {
+                        continue;
+                    }
+                    
+                    @autoreleasepool {
+                        // Get the cell directly from the dataSource because UICollectionView will only vend visible cells
+                        UICollectionViewCell *cell = [collectionView.dataSource collectionView:collectionView cellForItemAtIndexPath:indexPath];
+                        
+                        UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock notHidden:NO];
+                        
+                        // Remove the cell from the collection view so that it doesn't stick around
+                        [cell removeFromSuperview];
+                        
+                        // Skip this cell if it isn't the one we're looking for
+                        // Sometimes we get cells with no size here which can cause an endless loop, so we ignore those
+                        if (!element || CGSizeEqualToSize(cell.frame.size, CGSizeZero)) {
+                            continue;
+                        }
+                    }
+                    
+                    // Scroll to the cell and wait for the animation to complete
+                    [collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionNone animated:YES];
+                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.5, false);
+                    
+                    // Now try finding the element again
+                    return [self accessibilityElementMatchingBlock:matchBlock];
+                }
             }
         }
     }

--- a/KIF Tests/TableViewTests.m
+++ b/KIF Tests/TableViewTests.m
@@ -127,22 +127,20 @@
 
 - (void)testButtonAbsentAfterRemoveFromSuperview
 {
-    [tester waitForViewWithAccessibilityLabel:@"Button"];
-    UIAccessibilityElement *element = [[UIApplication sharedApplication] accessibilityElementWithLabel:@"Button" accessibilityValue:nil traits:0];
-
-    [[(id)element view] removeFromSuperview];
+    UIView *view = [tester waitForViewWithAccessibilityLabel:@"Button"];
+    
+    [view removeFromSuperview];
     [tester waitForAbsenceOfViewWithAccessibilityLabel:@"Button"];
 }
 
 - (void)testButtonAbsentAfterSetHidden
 {
-    [tester waitForViewWithAccessibilityLabel:@"Button"];
-    UIAccessibilityElement *element = [[UIApplication sharedApplication] accessibilityElementWithLabel:@"Button" accessibilityValue:nil traits:0];
-
-    [[(id)element view] setHidden:YES];
+    UIView *view = [tester waitForViewWithAccessibilityLabel:@"Button"];
+    
+    [view setHidden:YES];
     [tester waitForAbsenceOfViewWithAccessibilityLabel:@"Button"];
 
-    [[(id)element view] setHidden:NO];
+    [view setHidden:NO];
     [tester waitForViewWithAccessibilityLabel:@"Button"];
 }
 


### PR DESCRIPTION
The implict approach to finding accessibility elements in a table view
results in cells being instantiated and added as subviews of the table
view, despite not being visible. When the table view has many rows
with heavyweight cells this can cause severe memory pressure. This
commit uses a direct approach to find accessibility elements in table
views, which allows for proper removal of non-visible cells. It also
has the benefit of returning actual views instead of accessibility
elements.