### PR TITLE
Print the correct UIAccessibilityElement (sub)class name

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -987,7 +987,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                 printf("|\t");
             }
             UIAccessibilityElement *e = [(UIAccessibilityElement*)self accessibilityElementAtIndex:i];
-            printf("UIAccessibilityElement, label: %s", e.accessibilityLabel.UTF8String);
+            printf("%s, label: %s", NSStringFromClass([e class]).UTF8String, e.accessibilityLabel.UTF8String);
             if(e.accessibilityValue && e.accessibilityValue.length > 0) {
                 printf(", value: %s", e.accessibilityValue.UTF8String);
             }


### PR DESCRIPTION
I added a small change to the printViewHierarchy method so it prints out the proper class name for an accessibility element. 