### PR TITLE
Move sys alert simulator macro to implementation

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -406,13 +406,11 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
  */
 - (void)tapItemAtIndexPath:(NSIndexPath *)indexPath inCollectionViewWithAccessibilityIdentifier:(NSString *)identifier;
 
-#if TARGET_IPHONE_SIMULATOR
 /*!
  @abstract If present, dismisses a system alert with the last button, usually 'Allow'.
  @discussion Use this to dissmiss a location services authorization dialog or a photos access dialog by tapping the 'Allow' button. No action is taken if no alert is present.
  */
 - (void)acknowledgeSystemAlert;
-#endif
 
 /*!
  @abstract Swipes a particular view in the view hierarchy in the given direction.

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -760,7 +760,9 @@
 }
 
 - (void)acknowledgeSystemAlert {
+    #if TARGET_IPHONE_SIMULATOR
     [UIAutomationHelper acknowledgeSystemAlert];
+    #endif
 }
 
 - (void)tapItemAtIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView


### PR DESCRIPTION
So it doesn't affect the client code.

Otherwise in the tests we have to write

```
#if TARGET_IPHONE_SIMULATOR
tester().acknowledgeSystemAlert()
#endif
```

to make it build for the device.
