### PR TITLE
Add swipeViewWithAccessibilityIdentifier method

### DIFF
--- a/IdentifierTests/KIFUITestActor-IdentifierTests.h
+++ b/IdentifierTests/KIFUITestActor-IdentifierTests.h
@@ -77,4 +77,12 @@
  */
 - (BOOL) tryFindingViewWithAccessibilityIdentifier:(NSString *) accessibilityIdentifier;
 
+/*!
+ @abstract Swipes a particular view in the view hierarchy in the given direction.
+ @discussion This step will get the view with the specified accessibility identifier and swipe the screen in the given direction from the view's center.
+ @param identifier The accessibility identifier of the view to swipe.
+ @param direction The direction in which to swipe.
+ */
+- (void)swipeViewWithAccessibilityIdentifier:(NSString *)identifier inDirection:(KIFSwipeDirection)direction;
+
 @end

--- a/IdentifierTests/KIFUITestActor-IdentifierTests.m
+++ b/IdentifierTests/KIFUITestActor-IdentifierTests.m
@@ -202,5 +202,14 @@
     return [UIAccessibilityElement accessibilityElement:nil view:nil withElementMatchingPredicate:predicate tappable:NO error:nil];
 }
 
+- (void)swipeViewWithAccessibilityIdentifier:(NSString *)identifier inDirection:(KIFSwipeDirection)direction
+{
+    UIView *viewToSwipe = nil;
+    UIAccessibilityElement *element = nil;
+
+    [self waitForAccessibilityElement: &element view:&viewToSwipe withIdentifier:identifier tappable:NO];
+
+    [self swipeAccessibilityElement:element inView:viewToSwipe inDirection:direction];
+}
 
 @end

--- a/KIF Tests/GestureTests.m
+++ b/KIF Tests/GestureTests.m
@@ -8,6 +8,7 @@
 
 #import <KIF/KIF.h>
 #import <KIF/KIFTestStepValidation.h>
+#import <KIF/KIFUITestActor-IdentifierTests.h>
 
 @interface GestureTests : KIFTestCase
 @end
@@ -80,6 +81,30 @@
 - (void)testMissingSwipeableElementWithTraits
 {
     KIFExpectFailure([[tester usingTimeout:0.25] swipeViewWithAccessibilityLabel:@"Unknown" value:nil traits:UIAccessibilityTraitStaticText inDirection:KIFSwipeDirectionDown]);
+}
+
+- (void)testSwipingLeftWithIdentifier
+{
+    [tester swipeViewWithAccessibilityIdentifier:@"gestures.swipeMe" inDirection:KIFSwipeDirectionLeft];
+    [tester waitForViewWithAccessibilityLabel:@"Left"];
+}
+
+- (void)testSwipingRightWithIdentifier
+{
+    [tester swipeViewWithAccessibilityIdentifier:@"gestures.swipeMe" inDirection:KIFSwipeDirectionRight];
+    [tester waitForViewWithAccessibilityLabel:@"Right"];
+}
+
+- (void)testSwipingUpWithIdentifier
+{
+    [tester swipeViewWithAccessibilityIdentifier:@"gestures.swipeMe" inDirection:KIFSwipeDirectionUp];
+    [tester waitForViewWithAccessibilityLabel:@"Up"];
+}
+
+- (void)testSwipingDownWithIdentifier
+{
+    [tester swipeViewWithAccessibilityIdentifier:@"gestures.swipeMe" inDirection:KIFSwipeDirectionDown];
+    [tester waitForViewWithAccessibilityLabel:@"Down"];
 }
 
 - (void)testScrolling

--- a/Test Host/en.lproj/MainStoryboard.storyboard
+++ b/Test Host/en.lproj/MainStoryboard.storyboard
@@ -1198,6 +1198,9 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="gestures.swipeMe"/>
+                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <outletCollection property="gestureRecognizers" destination="sWb-g6-Zbn" appends="YES" id="MEn-RE-WeD"/>
                                     <outletCollection property="gestureRecognizers" destination="lsG-Xj-9Cs" appends="YES" id="pne-b0-ZJx"/>


### PR DESCRIPTION
Test cases are also added for swipe up, down, left, right.
view identification takes place on the accessibility identifier
rather than the accessibilityLabel attribute.