### PR TITLE
Added unit test for row swiping

### DIFF
--- a/KIF Tests/TableViewTests.m
+++ b/KIF Tests/TableViewTests.m
@@ -151,4 +151,24 @@
     [tester enterText:@"Test-Driven Development" intoViewWithAccessibilityLabel:@"TextField"];
 }
 
+// Delete first and last rows in table view
+- (void)testSwipingRows {
+    
+    UITableView *tableView;
+    [tester waitForAccessibilityElement:NULL view:&tableView withIdentifier:@"TableView Tests Table" tappable:NO];
+    
+    // First row
+    [tester swipeRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inTableView:tableView inDirection:KIFSwipeDirectionLeft];
+    [tester tapViewWithAccessibilityLabel:@"Delete"];
+    
+    __KIFAssertEqualObjects([tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
+    
+    // Last row
+    [tester swipeRowAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:2] inTableView:tableView inDirection:KIFSwipeDirectionLeft];
+    [tester tapViewWithAccessibilityLabel:@"Delete"];
+    
+    __KIFAssertEqualObjects([tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:2] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
+    
+}
+
 @end

--- a/Test Host/TableViewController.m
+++ b/Test Host/TableViewController.m
@@ -24,4 +24,32 @@
     // Do nothing, this method is needed to activate reordering in edit mode
 }
 
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+
+    return YES;
+    
+}
+
+- (UITableViewCellEditingStyle)tableView:(UITableView *)tableView editingStyleForRowAtIndexPath:(NSIndexPath *)indexPath {
+    
+    return UITableViewCellEditingStyleDelete;
+    
+}
+
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
+    
+    if (editingStyle == UITableViewCellEditingStyleDelete) {
+        // Since the table view uses static cells, it is not possible to remove the row,
+        // so let's just change the label to have something to check in unit tests
+        UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:indexPath];
+        cell.textLabel.text = @"Deleted";
+        [self.tableView setEditing:NO animated:YES];
+        
+        // NOTE: These don't work very well
+        // [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+        // [self.tableView reloadData];
+    }
+    
+}
+
 @end


### PR DESCRIPTION
Added canEditRowAtIndexPath, editingStyleForRowAtIndexPath and commitEditingStyle methods to
TableViewController in order to support line editing.
Added unit test that swipes and deletes the first and last rows in the table view.