### PR TITLE
Disable iOS 7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ osx_image: xcode61
 sudo: false
 
 script:
-- xcodebuild -scheme KIF -destination 'platform=iOS Simulator,name=iPhone Retina (4-inch),OS=7.1' -destination 'platform=iOS Simulator,name=iPhone 6,OS=8.1' test
+- xcodebuild -scheme KIF -destination 'platform=iOS Simulator,name=iPhone 6,OS=8.1' test


### PR DESCRIPTION
Travis has been flakey lately. Disabling iOS 7 support to make things easier to debug and test. Will likely re-enable soon.