### PR TITLE
Use [UITableView visibleCells] instead of indexPathsForVisibleRows

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -215,7 +215,15 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
         if ([self isKindOfClass:[UITableView class]]) {
             UITableView *tableView = (UITableView *)self;
             
-            NSArray *indexPathsForVisibleRows = [tableView indexPathsForVisibleRows];
+            // Because of a bug in [UITableView indexPathsForVisibleRows] http://openradar.appspot.com/radar?id=5191284490764288
+            // We use [UITableView visibleCells] to determine the index path of the visible cells
+            NSMutableArray *indexPathsForVisibleRows = [[NSMutableArray alloc] init];
+            [[tableView visibleCells] enumerateObjectsUsingBlock:^(UITableViewCell *cell, NSUInteger idx, BOOL *stop) {
+                NSIndexPath *indexPath = [tableView indexPathForCell:cell];
+                if (indexPath) {
+                    [indexPathsForVisibleRows addObject:indexPath];
+                }
+            }];
             
             for (NSUInteger section = 0, numberOfSections = [tableView numberOfSections]; section < numberOfSections; section++) {
                 for (NSUInteger row = 0, numberOfRows = [tableView numberOfRowsInSection:section]; row < numberOfRows; row++) {


### PR DESCRIPTION
I bumped into a rare problem while trying to update to KIF 3.2.3

[UITableView indexPathsForVisibleRows] seems to return index paths for
non visible cells if screen folds on the tableview header.
I opened a radar with Apple. See http://openradar.appspot.com/radar?id=5191284490764288
To avoid this bug, we are now using the visibleCells method which
doesn't suffer from the same problem.

It won't be as fast as before since enumerating through the visible cells is necessary to get all the index paths but correctness is definitely the priority.
Let me know what you think. Thx