### PR TITLE
Update CGGeometry-KIFAdditions.h

### DIFF
--- a/Additions/CGGeometry-KIFAdditions.h
+++ b/Additions/CGGeometry-KIFAdditions.h
@@ -14,5 +14,5 @@ CG_INLINE CGPoint CGPointCenteredInRect(CGRect bounds) {
 }
 
 CG_INLINE CGPoint CGPointMidPoint(CGPoint point1, CGPoint point2) {
-    return CGPointMake((point1.x + point2.x) / 2.0, (point1.y + point2.y) / 2.0);
+    return CGPointMake((point1.x + point2.x) / 2.0f, (point1.y + point2.y) / 2.0f);
 }


### PR DESCRIPTION
Fixes "Implicit conversion loses floating-point precision: 'double' to 'CGFloat' (aka 'float')" warning