### PR TITLE
Added null pointer check

### DIFF
--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -147,7 +147,9 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
 
     NSError *directoryCreationError = nil;
     if (![[NSFileManager defaultManager] createDirectoryAtPath:outputPath withIntermediateDirectories:YES attributes:nil error:&directoryCreationError]) {
-        *error = [NSError KIFErrorWithFormat:@"Couldn't create directory at path %@ (details: %@)", outputPath, directoryCreationError];
+        if (error) {
+            *error = [NSError KIFErrorWithFormat:@"Couldn't create directory at path %@ (details: %@)", outputPath, directoryCreationError];
+        }
         return NO;
     }
 


### PR DESCRIPTION
When NULL is passed for the error pointer, this was causing a crash because there was no null pointer check.