### PR TITLE
add Xcode 7 compatibility

### DIFF
--- a/Additions/UITouch-KIFAdditions.m
+++ b/Additions/UITouch-KIFAdditions.m
@@ -26,10 +26,10 @@ typedef struct {
 @property(assign) BOOL isTap;
 @property(assign) NSUInteger tapCount;
 @property(assign) UITouchPhase phase;
-@property(retain) UIView *view;
-@property(retain) UIWindow *window;
 @property(assign) NSTimeInterval timestamp;
 
+- (void)setWindow:(UIWindow *)window;
+- (void)setView:(UIView *)view;
 - (void)setGestureView:(UIView *)view;
 - (void)_setLocationInWindow:(CGPoint)location resetPrevious:(BOOL)resetPrevious;
 - (void)_setIsFirstTouchForView:(BOOL)firstTouchForView;


### PR DESCRIPTION
Xcode 7 wants
```
@property(strong) UIView *view;		
@property(strong) UIWindow *window;
```

Xcode 6 wants
```
@property(retain) UIView *view;		
@property(retain) UIWindow *window;
```

`strong` isn't valid in Xcode 6 so best is to just declare setters instead making it work with Xcode 6 and 7
