### PR TITLE
Add getter/setter for default animationWaitingTimeout

### DIFF
--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -105,6 +105,19 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 - (BOOL)tryRunningBlock:(KIFTestExecutionBlock)executionBlock complete:(KIFTestCompletionBlock)completionBlock timeout:(NSTimeInterval)timeout error:(out NSError **)error;
 
 /*!
+ @method defaultAnimationWaitingTimeout
+ @abstract The default amount of time to wait for an animation to complete.
+ @discussion To change the default value of the timeout property, call +setDefaultAnimationWaitingTimeout: with a different value.
+ */
++ (NSTimeInterval)defaultAnimationWaitingTimeout;
+
+/*!
+ @method setDefaultAnimationWaitingTimeout:
+ @abstract Sets the default amount of time to wait for an animation to complete.
+ */
++ (void)setDefaultAnimationWaitingTimeout:(NSTimeInterval)newDefaultAnimationWaitingTimeout;
+
+/*!
  @method defaultTimeout
  @abstract The default amount of time to assign to execution blocks before assuming they failed.
  @discussion To change the default value of the timeout property, call +setDefaultTimeout: with a different value.

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -64,7 +64,7 @@
         _line = line;
         _delegate = delegate;
         _executionBlockTimeout = [[self class] defaultTimeout];
-        _animationWaitingTimeout = 0.5f;
+        _animationWaitingTimeout = [[self class] defaultAnimationWaitingTimeout];
     }
     return self;
 }
@@ -132,8 +132,19 @@
 
 #pragma mark Class Methods
 
+static NSTimeInterval KIFTestStepDefaultAnimationWaitingTimeout = 0.5;
 static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
 static NSTimeInterval KIFTestStepDelay = 0.1;
+
++ (NSTimeInterval)defaultAnimationWaitingTimeout
+{
+    return KIFTestStepDefaultAnimationWaitingTimeout;
+}
+
++ (void)setDefaultAnimationWaitingTimeout:(NSTimeInterval)newDefaultAnimationWaitingTimeout;
+{
+    KIFTestStepDefaultAnimationWaitingTimeout = newDefaultAnimationWaitingTimeout;
+}
 
 + (NSTimeInterval)defaultTimeout;
 {


### PR DESCRIPTION
Hi,

I'd like to introduce a new getter and setter for the `animationWaitingTimeout` property. In our KIF test suite we do something like this in `application:didFinishLaunchingWithOptions:`:

```objc
#ifdef EBK_DISABLE_ANIMATIONS
    [UIView setAnimationsEnabled:NO];
#endif
```

This already decreased the execution time of our test suite dramatically. Without anymations enabled, we don't really need `animationWaitingTimeout = 0.5f`. If we could configure this from the outside, it would decrease the execution time even more.

Thanks,
plu