### PR TITLE
Possible fix for NSInvalidArgumentException

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -192,7 +192,10 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
         
         // If the view is an accessibility container, and we didn't find a matching subview,
         // then check the actual accessibility elements
-        NSInteger accessibilityElementCount = element.accessibilityElementCount;
+	if (! element.isAccessibilityElement) {
+		continue;
+	}
+	NSInteger accessibilityElementCount = element.accessibilityElementCount;
         if (accessibilityElementCount == 0 || accessibilityElementCount == NSNotFound) {
             continue;
         }


### PR DESCRIPTION
Sometimes some stale UI leaks (think long test run) and you get
an invalid pointer.

refer to:
https://github.com/kif-framework/KIF/issues/683