### PR TITLE
Fix for issue 679. Crash taking screenshot.

### DIFF
--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -134,6 +134,11 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
     
     UIGraphicsBeginImageContextWithOptions([[windows objectAtIndex:0] bounds].size, YES, 0);
     for (UIWindow *window in windows) {
+		//avoid https://github.com/kif-framework/KIF/issues/679
+		if (window.hidden) {
+			continue;
+		}
+
         if ([window respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {
             [window drawViewHierarchyInRect:window.bounds afterScreenUpdates:YES];
         } else {


### PR DESCRIPTION
Some keywindows can be hidden in weird application implementations.
This fix attempts to avoid the crash.
https://github.com/kif-framework/KIF/issues/679