### PR TITLE
UIAutomationHelper.m: fix acknowledgeSystemAlert to close all alerts …

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -435,10 +435,10 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 
 #if TARGET_IPHONE_SIMULATOR
 /*!
- @abstract If present, dismisses a system alert with the last button, usually 'Allow'.
+ @abstract If present, dismisses a system alert with the last button, usually 'Allow'. Returns YES if a dialog was dismissed, NO otherwise.
  @discussion Use this to dissmiss a location services authorization dialog or a photos access dialog by tapping the 'Allow' button. No action is taken if no alert is present.
  */
-- (void)acknowledgeSystemAlert;
+- (BOOL)acknowledgeSystemAlert;
 #endif
 
 /*!

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -774,8 +774,8 @@
     [self tapItemAtIndexPath:indexPath inCollectionView:collectionView];
 }
 
-- (void)acknowledgeSystemAlert {
-    [UIAutomationHelper acknowledgeSystemAlert];
+- (BOOL)acknowledgeSystemAlert {
+    return [UIAutomationHelper acknowledgeSystemAlert];
 }
 
 - (void)tapItemAtIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView

--- a/Classes/UIAutomationHelper.h
+++ b/Classes/UIAutomationHelper.h
@@ -12,7 +12,7 @@
 
 @interface UIAutomationHelper : NSObject
 
-+ (void)acknowledgeSystemAlert;
++ (BOOL)acknowledgeSystemAlert;
 
 + (void)deactivateAppForDuration:(NSNumber *)duration;
 

--- a/Classes/UIAutomationHelper.m
+++ b/Classes/UIAutomationHelper.m
@@ -8,6 +8,7 @@
 
 #import "UIAutomationHelper.h"
 #include <dlfcn.h>
+#import <UIView-KIFAdditions.h>
 
 @interface UIAElement : NSObject <NSCopying>
 - (void)tap;
@@ -15,6 +16,8 @@
 
 @interface UIAAlert : UIAElement
 - (NSArray *)buttons;
+- (BOOL)isValid;
+- (BOOL)isVisible;
 @end
 
 @interface UIAApplication : UIAElement
@@ -44,22 +47,23 @@
     return sharedHelper;
 }
 
-+ (void)acknowledgeSystemAlert {
-    [[self sharedHelper] acknowledgeSystemAlert];
++ (BOOL)acknowledgeSystemAlert {
+    return [[self sharedHelper] acknowledgeSystemAlert];
 }
 
 + (void)deactivateAppForDuration:(NSNumber *)duration {
     [[self sharedHelper] deactivateAppForDuration:duration];
 }
-
-- (void)acknowledgeSystemAlert {
+- (BOOL)acknowledgeSystemAlert {
     UIAApplication *application = [[self target] frontMostApp];
-    UIAAlert *alert = application.alert;
-
-    if (![alert isKindOfClass:[self nilElementClass]]) {
-        [[alert.buttons lastObject] tap];
-        while (![application.alert isKindOfClass:[self nilElementClass]]) { }
-    }
+	UIAAlert* alert = application.alert;
+	if (![alert isKindOfClass:[self nilElementClass]]) {
+		[[alert.buttons lastObject] tap];
+		while ([alert isValid] && [alert isVisible]) {
+		}
+		return YES;
+	}
+    return NO;
 }
 
 - (void)deactivateAppForDuration:(NSNumber *)duration {

--- a/KIF Tests/SystemAlertTests.m
+++ b/KIF Tests/SystemAlertTests.m
@@ -24,20 +24,17 @@
     [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
 }
 
-- (void)testAuthorizingLocationServices {
-    [tester tapViewWithAccessibilityLabel:@"Location Services"];
-    [tester acknowledgeSystemAlert];
+- (void)testAuthorizingLocationServicesAndNotificationsScheduling {
+    [tester tapViewWithAccessibilityLabel:@"Location Services and Notifications"];
+    XCTAssertTrue([tester acknowledgeSystemAlert]);
+	XCTAssertTrue([tester acknowledgeSystemAlert]);
+	XCTAssertFalse([tester acknowledgeSystemAlert]);
 }
 
 - (void)testAuthorizingPhotosAccess {
     [tester tapViewWithAccessibilityLabel:@"Photos"];
     [tester acknowledgeSystemAlert];
     [tester tapViewWithAccessibilityLabel:@"Cancel"];
-}
-
-- (void)testNotificationScheduling {
-    [tester tapViewWithAccessibilityLabel:@"Notifications"];
-    [tester acknowledgeSystemAlert];
 }
 
 @end

--- a/Test Host/SystemAlertViewController.m
+++ b/Test Host/SystemAlertViewController.m
@@ -39,4 +39,9 @@
     }
 }
 
+- (IBAction)requestLocationServicesAndNotificicationsSchedulingAccesses {
+	[self requestLocationServicesAccess];
+	[self requestNotificationScheduling];
+}
+
 @end

--- a/Test Host/en.lproj/MainStoryboard.storyboard
+++ b/Test Host/en.lproj/MainStoryboard.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" variant="6xAndEarlier" propertyAccessControl="none" initialViewController="3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" variant="6xAndEarlier" propertyAccessControl="none" initialViewController="3">
     <dependencies>
         <deployment identifier="iOS"/>
         <development version="4600" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
@@ -1853,6 +1853,21 @@ Line Break
                                 </state>
                                 <connections>
                                     <action selector="requestNotificationScheduling" destination="k4d-l4-aKf" eventType="touchUpInside" id="iWn-UO-XJV"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="NYu-v0-8ac">
+                                <rect key="frame" x="24" y="182" width="273" height="44"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <state key="normal" title="Location Services and Notifications">
+                                    <color key="titleColor" red="0.19607843137254902" green="0.30980392156862746" blue="0.52156862745098043" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <state key="highlighted">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="requestLocationServicesAndNotificicationsSchedulingAccesses" destination="k4d-l4-aKf" eventType="touchUpInside" id="up3-fx-DyS"/>
                                 </connections>
                             </button>
                         </subviews>


### PR DESCRIPTION
…and not hang infinitely in case of multiple alerts

In my case, I have 2 notifications one above the other. The current script is looping indefinitely since `application.alert` is never nil after dismissing the first one.

I changed behavior so that all applications are closed; if you want to keep closing only the first alert, maybe you should consider changing return type to `bool` and returns `TRUE` if a popup was dismissed so that we can iterate until it returns `FALSE`?