### PR TITLE
Fix bad display for particular accessibilityLabel on error

### DIFF
--- a/Additions/NSException-KIFAdditions.h
+++ b/Additions/NSException-KIFAdditions.h
@@ -10,6 +10,7 @@
 
 @interface NSException (KIFAdditions)
 
-+ (NSException *)failureInFile:(NSString *)file atLine:(NSInteger)line withDescription:(NSString *)formatString, ...;
++ (NSException *)failureInFile:(NSString *)file atLine:(NSInteger)line withDescriptionFormat:(NSString *)formatString, ...;
++ (NSException *)failureInFile:(NSString *)file atLine:(NSInteger)line withDescription:(NSString *)string;
 
 @end

--- a/Additions/NSException-KIFAdditions.m
+++ b/Additions/NSException-KIFAdditions.m
@@ -10,7 +10,7 @@
 
 @implementation NSException (KIFAdditions)
 
-+ (NSException *)failureInFile:(NSString *)file atLine:(NSInteger)line withDescription:(NSString *)formatString, ...
++ (NSException *)failureInFile:(NSString *)file atLine:(NSInteger)line withDescriptionFormat:(NSString *)formatString, ...
 {
     va_list argumentList;
     va_start(argumentList, formatString);
@@ -19,8 +19,13 @@
 
     va_end(argumentList);
 
+    return [NSException failureInFile:file atLine:line withDescription:reason];
+}
+
++ (NSException *)failureInFile:(NSString *)file atLine:(NSInteger)line withDescription:(NSString *)string
+{
     return [NSException exceptionWithName:@"KIFFailureException"
-                                   reason: reason
+                                   reason: string
                                  userInfo:@{@"SenTestFilenameKey": file,
                                             @"SenTestLineNumberKey": @(line)}];
 }

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -202,7 +202,7 @@ static NSTimeInterval KIFTestStepDelay = 0.1;
 - (void)failWithExceptions:(NSArray *)exceptions stopTest:(BOOL)stop
 {
     NSException *firstException = [exceptions objectAtIndex:0];
-    NSException *newException = [NSException failureInFile:self.file atLine:(int)self.line withDescription:@"Failure in child step: %@", firstException.description];
+    NSException *newException = [NSException failureInFile:self.file atLine:(int)self.line withDescriptionFormat:@"Failure in child step: %@", firstException.description];
 
     [self.delegate failWithExceptions:[exceptions arrayByAddingObject:newException] stopTest:stop];
 }


### PR DESCRIPTION
I fixed #688 by adding an other failureInFile which not interpret the description.
For the test
```
waitForViewWithAccessibilityLabel("foobar%")
```
If you didn't define the accessibilityLabel "foobar%" in your project; failureInFile function was call with "foobar%" as formatString parameter hence the string was interpreted and the '%' deleted...