### PR TITLE
Enable Accessibility on both Xcode iOS 8 and 9 regardless of Xcode version

### DIFF
--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -60,25 +60,17 @@
         }
     }
     
-    // Enabling the Accessibility Inspector is necessary on iOS 9 because
-    // accessibilityLabel of UI elements will not return a value unless
-    // a feature using accessibility (like VoiceOver, Switch control or the Accessibility inspector) is running
-    NSOperatingSystemVersion iOS9 = {9, 0, 0};
-    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)]
-        && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS9]) {
-        NSString* accessibilitySettingsBundleLocation = @"/System/Library/PreferenceBundles/AccessibilitySettings.bundle/AccessibilitySettings";
-        if (simulatorRoot) {
-            accessibilitySettingsBundleLocation = [simulatorRoot stringByAppendingString:accessibilitySettingsBundleLocation];
-        }
-        const char *accessibilitySettingsBundlePath = [accessibilitySettingsBundleLocation fileSystemRepresentation];
-        void* accessibilitySettingsBundle = dlopen(accessibilitySettingsBundlePath, RTLD_LAZY);
-        if (accessibilitySettingsBundle) {
-            Class axSettingsPrefControllerClass = NSClassFromString(@"AccessibilitySettingsController");
-            id axSettingPrefController = [[axSettingsPrefControllerClass alloc] init];
-            [axSettingPrefController setAXInspectorEnabled:@(YES) specifier:nil];
-        }
+    NSString* accessibilitySettingsBundleLocation = @"/System/Library/PreferenceBundles/AccessibilitySettings.bundle/AccessibilitySettings";
+    if (simulatorRoot) {
+        accessibilitySettingsBundleLocation = [simulatorRoot stringByAppendingString:accessibilitySettingsBundleLocation];
     }
-    
+    const char *accessibilitySettingsBundlePath = [accessibilitySettingsBundleLocation fileSystemRepresentation];
+    void* accessibilitySettingsBundle = dlopen(accessibilitySettingsBundlePath, RTLD_LAZY);
+    if (accessibilitySettingsBundle) {
+        Class axSettingsPrefControllerClass = NSClassFromString(@"AccessibilitySettingsController");
+        id axSettingPrefController = [[axSettingsPrefControllerClass alloc] init];
+        [axSettingPrefController setAXInspectorEnabled:@(YES) specifier:nil];
+    }
 }
 
 - (instancetype)initWithFile:(NSString *)file line:(NSInteger)line delegate:(id<KIFTestActorDelegate>)delegate


### PR DESCRIPTION
@phatmann it looks like my testing skills are lacking and my previous PR is not 100% complete.
At the moment running tests from Xcode 7 in a ios 8 simulator doesn't work because accessibility labels are not enabled/accessible.

After more testing I realized the solution in this PR allows to simplify the [KIFTestActor _enableAccessibility] method by not checking if it is running in iOS 9 sim while being compatible with both Xcode 6 and Xcode 7 (and both iOS 8 and 9 simulators)

I have tested sucessfully: 
- Xcode 6.4 / iOS 8.4 sim
- Xcode 7b4 / iOS 8.4 sim
- Xcode 7b4 / iOS 9.0 sim (ignoring the 3 failures already documented)
- Xcode 7b5 / iOS 9.0 sim (ignoring the 3 failures already documented)

I could not run the test with Xcode 7b5 and iOS 8 sim since running non iOS 9 sim with beta 5 seems to [be busted](https://forums.developer.apple.com/message/39708#39708)

Let me know if you have any question