### PR TITLE
README Missing Info for Swift: add missing import of KIF framework to use in swift projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ If you want to write your test cases in Swift, you'll need to keep two things in
 2. The `tester` and `system` keywords are C preprocessor macros which aren't available in Swift. You can easily write a small extension to `XCTestCase` or any other class to access them:
 
 ```swift
+import KIF
+ 
 extension XCTestCase {
     func tester(_ file : String = __FILE__, _ line : Int = __LINE__) -> KIFUITestActor {
         return KIFUITestActor(inFile: file, atLine: line, delegate: self)


### PR DESCRIPTION
without the import KIF statement I was not able to build the project, despite the import in the bridging header