### PR TITLE
KIFUITestActor.m: fix enterText method to support unicode characters such as Emojis

### DIFF
--- a/KIF Tests/TypingTests.m
+++ b/KIF Tests/TypingTests.m
@@ -75,6 +75,14 @@
     [tester enterText:@", world\n" intoViewWithAccessibilityLabel:@"Greeting" traits:UIAccessibilityTraitNone expectedResult:@"Hello, world"];
 }
 
+- (void)testEnteringEmijoCharacterIntoViewWithAccessibilityLabel
+{
+	NSString *text = @" 😓He😤ll👿o";
+	[tester clearTextFromAndThenEnterText:text intoViewWithAccessibilityLabel:@"Greeting"];
+	UITextField * tf = (UITextField*)[tester waitForViewWithAccessibilityLabel:@"Greeting"];
+	XCTAssertTrue([tf.text isEqualToString:text]);
+}
+
 - (void)testClearingALongTextField
 {
     [tester clearTextFromAndThenEnterText:@"A man, a plan, a canal, Panama.  Able was I, ere I saw Elba." intoViewWithAccessibilityLabel:@"Greeting"];


### PR DESCRIPTION
Previous method was not working properly when entering unicode characters such as Emojis; see screenshot 1 (old) vs 2 (new) to see the wrong rendering. I could not manage to reproduce it with a unit test in KIF project (but it is on linphone-iphone...), but at least it renders correctly now.
![old](https://cloud.githubusercontent.com/assets/1451988/9658160/865af5bc-5247-11e5-8d65-0b13e56c2c96.png) old vs new ![new](https://cloud.githubusercontent.com/assets/1451988/9658162/8783bbea-5247-11e5-8263-a51cc70d4988.png)
 