### PR TITLE
Workaround broken `deactivateAppForDuration:` in iOS 9

### DIFF
--- a/KIF Tests/BackgroundTests.m
+++ b/KIF Tests/BackgroundTests.m
@@ -22,7 +22,6 @@
     [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
 }
 
-//TODO: Fail on iOS 9 (crash on UITarget.deactivateAppForDuration) and iOS 7
 - (void)testBackgroundApp {
     [tester waitForViewWithAccessibilityLabel:@"Start"];
     [tester deactivateAppForDuration:5];


### PR DESCRIPTION
-[UIATarget reactivateApp] was not rewritten for the new iOS 9 app switcher so we use a horrible hack to get the correct accessibility element.

There also seems to be an issue with the UIAApplication object returned by the `frontMostApp` method which has a nil name.

These hacks heavily rely on implementation detail of -[UIATarget deactivateApp] and -[UIATarget reactivateApp] and might break anytime.

Fixes #703