### PR TITLE
Improve testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 language: objective-c
-osx_image: xcode61
-sudo: false
+osx_image: xcode7
+env:
+  matrix:
+    - 'DESTINATION="platform=iOS Simulator,name=iPhone 6,OS=8.4"'
+    - 'DESTINATION="platform=iOS Simulator,name=iPhone 6,OS=9.0"'
 
+before_install:
+  - xcrun simctl list
+  - brew update
+install:
+  - brew install coreutils
+  - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 script:
-- xcodebuild -scheme KIF -destination 'platform=iOS Simulator,name=iPhone 6,OS=8.1' test
+  - open -b com.apple.iphonesimulator # Workaround https://github.com/travis-ci/travis-ci/issues/3040
+  - gstdbuf -o 0 xcodebuild test -scheme KIF -destination "${DESTINATION}" | xcpretty -c && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
* Use latest OS X image (Xcode 7)
* Run tests on multiple iOS versions (8.1, 8.2, 8,3, 8.4 and 9.0)
* Use xcpretty for a readable output
* Use gstdbuf for live output of test results