### PR TITLE
Add method for waiting for the absence of a view identified through a predicate

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -205,6 +205,13 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable;
 
 /*!
+ @abstract Waits until an accessibility element is no longer present.
+ @discussion The accessibility element matching the given predicate is found in the view hierarchy. If the element is found, then the step will attempt to wait until it isn't. Note that the associated view does not necessarily have to be visible on the screen, and may be behind another view or offscreen. Views with their hidden property set to YES are considered absent.
+ @param predicate The predicate to match.
+ */
+- (void)waitForAbsenceOfViewWithElementMatchingPredicate:(NSPredicate *)predicate;
+
+/*!
  @abstract Tries to guess if there are any unfinished animations and waits for a certain amount of time to let them finish.
  */
 - (void)waitForAnimationsToFinish;

--- a/IdentifierTests/KIFUITestActor-IdentifierTests.m
+++ b/IdentifierTests/KIFUITestActor-IdentifierTests.m
@@ -36,29 +36,8 @@
 
 - (void)waitForAbsenceOfViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
-    [self runBlock:^KIFTestStepResult(NSError **error) {
-        // If the app is ignoring interaction events, then wait before doing our analysis
-        KIFTestWaitCondition(![[UIApplication sharedApplication] isIgnoringInteractionEvents], error, @"Application is ignoring interaction events.");
-        
-        // If the element can't be found, then we're done
-        
-        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", accessibilityIdentifier];
-        UIAccessibilityElement *element = nil;
-        
-        if (![UIAccessibilityElement accessibilityElement:&element view:NULL withElementMatchingPredicate:predicate tappable:NO error:NULL]) {
-            return KIFTestStepResultSuccess;
-        }
-        
-        UIView *view = [UIAccessibilityElement viewContainingAccessibilityElement:element];
-        
-        // If we found an element, but it's not associated with a view, then something's wrong. Wait it out and try again.
-        KIFTestWaitCondition(view, error, @"Cannot find view containing accessibility element with the identifier \"%@\"", accessibilityIdentifier);
-        
-        // Hidden views count as absent
-        KIFTestWaitCondition([view isHidden] || [view superview] == nil, error, @"Accessibility element with identifier \"%@\" is visible and not hidden.", accessibilityIdentifier);
-        
-        return KIFTestStepResultSuccess;
-    }];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", accessibilityIdentifier];
+    [self waitForAbsenceOfViewWithElementMatchingPredicate:predicate];
 }
 
 - (UIView *)waitForViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier tappable:(BOOL)mustBeTappable


### PR DESCRIPTION
This commit adds a few convenience methods for cases in which an element only has an accessibility hint but no label or identifier. I'd like to get some early feedback on whether or not something like this would be appreciated. I think for clients it's more handy to use these methods instead of fiddling with `NSPredicate`.

The commit also adds a generic `waitForAbsenceOfViewWithElementMatchingPredicate` method which did not exist before.