### PR TITLE
Fix accessibility enabler not activating on iOS version < 9

### DIFF
--- a/Classes/KIFAccessibilityEnabler.m
+++ b/Classes/KIFAccessibilityEnabler.m
@@ -44,6 +44,8 @@
         if ([XCTestObservationCenter respondsToSelector:@selector(sharedTestObservationCenter)]) {
             XCTestObservationCenter *observationCenter = [XCTestObservationCenter sharedTestObservationCenter];
             [observationCenter addTestObserver:[self sharedAccessibilityEnabler]];
+        } else {
+            [[self sharedAccessibilityEnabler] _enableAccessibility];
         }
     }
 }


### PR DESCRIPTION
The following commits have regressed some accessibility issues for iOS < 9.
https://github.com/kif-framework/KIF/commit/927050d0a3e4178182570c560f646fa8a257bc52
https://github.com/kif-framework/KIF/commit/17a1bc86be31440d144902b1719ae549b173db03

Relevant discussion can be found: https://github.com/kif-framework/KIF/issues/596

ModalViewTests appear to be failing on master on both Xcode 6.3.2, iPad 2, iOS 8.1. and Xcode 7.1, iPad 2, iOS 9.1.

