### PR TITLE
3D Touch Support (Work in Progress)

### DIFF
--- a/Additions/UITableView-KIFAdditions.m
+++ b/Additions/UITableView-KIFAdditions.m
@@ -43,7 +43,7 @@
     CGPoint destinationPoint = CGPointMake(sourcePoint.x, CGPointCenteredInRect([self rectForRowAtIndexPath:indexPath]).y);
     
     // Create the touch (there should only be one touch object for the whole drag)
-    UITouch *touch = [[UITouch alloc] initAtPoint:sourcePoint inView:self];
+    UITouch *touch = [[UITouch alloc] initAtPoint:sourcePoint inView:self withForce:0.0f];
     [touch setPhaseAndUpdateTimestamp:UITouchPhaseBegan];
     
     UIEvent *eventDown = [self eventWithTouch:touch];

--- a/Additions/UITouch-KIFAdditions.h
+++ b/Additions/UITouch-KIFAdditions.h
@@ -13,7 +13,7 @@
 @interface UITouch (KIFAdditions)
 
 - (id)initInView:(UIView *)view;
-- (id)initAtPoint:(CGPoint)point inView:(UIView *)view;
+- (id)initAtPoint:(CGPoint)point inView:(UIView *)view withForce:(float)force;
 
 - (void)setLocationInWindow:(CGPoint)location;
 - (void)setPhaseAndUpdateTimestamp:(UITouchPhase)phase;

--- a/Additions/UITouch-KIFAdditions.m
+++ b/Additions/UITouch-KIFAdditions.m
@@ -39,6 +39,8 @@ typedef struct {
 - (void)_setPressure:(float)arg1 resetPrevious:(BOOL)arg2;
 - (void)_setNeedsForceUpdate:(BOOL)arg1;
 
+- (float)_pressure;
+
 @end
 
 @implementation UITouch (KIFAdditions)

--- a/Additions/UITouch-KIFAdditions.m
+++ b/Additions/UITouch-KIFAdditions.m
@@ -36,6 +36,8 @@ typedef struct {
 - (void)_setIsFirstTouchForView:(BOOL)firstTouchForView;
 
 - (void)_setHidEvent:(IOHIDEventRef)event;
+- (void)_setPressure:(float)arg1 resetPrevious:(BOOL)arg2;
+- (void)_setNeedsForceUpdate:(BOOL)arg1;
 
 @end
 
@@ -45,10 +47,10 @@ typedef struct {
 {
     CGRect frame = view.frame;    
     CGPoint centerPoint = CGPointMake(frame.size.width * 0.5f, frame.size.height * 0.5f);
-    return [self initAtPoint:centerPoint inView:view];
+    return [self initAtPoint:centerPoint inView:view withForce:0.0f];
 }
 
-- (id)initAtPoint:(CGPoint)point inWindow:(UIWindow *)window;
+- (id)initAtPoint:(CGPoint)point inWindow:(UIWindow *)window withForce:(float)force
 {
 	self = [super init];
 	if (self == nil) {
@@ -77,14 +79,16 @@ typedef struct {
     NSOperatingSystemVersion iOS9 = {9, 0, 0};
     if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS9]) {
         [self kif_setHidEvent];
+        [self _setNeedsForceUpdate:YES];
+        [self _setPressure:force resetPrevious:YES];
     }
     
 	return self;
 }
 
-- (id)initAtPoint:(CGPoint)point inView:(UIView *)view;
+- (id)initAtPoint:(CGPoint)point inView:(UIView *)view withForce:(float)force
 {
-    return [self initAtPoint:[view.window convertPoint:point fromView:view] inWindow:view.window];
+    return [self initAtPoint:[view.window convertPoint:point fromView:view] inWindow:view.window withForce:force];
 }
 
 //

--- a/Additions/UIView-KIFAdditions.h
+++ b/Additions/UIView-KIFAdditions.h
@@ -39,8 +39,11 @@ typedef CGPoint KIFDisplacement;
 - (void)flash;
 - (void)tap;
 - (void)tapAtPoint:(CGPoint)point;
+- (void)tapAtPoint:(CGPoint)point withForce:(float)force;
 - (void)twoFingerTapAtPoint:(CGPoint)point;
 - (void)longPressAtPoint:(CGPoint)point duration:(NSTimeInterval)duration;
+- (void)longPressAtPoint:(CGPoint)point duration:(NSTimeInterval)duration withForce:(float)force;
+
 
 /*!
  @method dragFromPoint:toPoint:

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -395,7 +395,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     [self tapAtPoint:centerPoint];
 }
 
-- (void)tapAtPoint:(CGPoint)point;
+- (void)tapAtPoint:(CGPoint)point withForce:(float)force;
 {
     // Web views don't handle touches in a normal fashion, but they do have a method we can call to tap them
     // This may not be necessary anymore. We didn't properly support controls that used gesture recognizers
@@ -415,7 +415,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     }
     
     // Handle touches in the normal way for other views
-    UITouch *touch = [[UITouch alloc] initAtPoint:point inView:self];
+    UITouch *touch = [[UITouch alloc] initAtPoint:point inView:self withForce:force];
     [touch setPhaseAndUpdateTimestamp:UITouchPhaseBegan];
     
     UIEvent *event = [self eventWithTouch:touch];
@@ -435,8 +435,8 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 - (void)twoFingerTapAtPoint:(CGPoint)point {
     CGPoint finger1 = CGPointMake(point.x - kTwoFingerConstantWidth, point.y - kTwoFingerConstantWidth);
     CGPoint finger2 = CGPointMake(point.x + kTwoFingerConstantWidth, point.y + kTwoFingerConstantWidth);
-    UITouch *touch1 = [[UITouch alloc] initAtPoint:finger1 inView:self];
-    UITouch *touch2 = [[UITouch alloc] initAtPoint:finger2 inView:self];
+    UITouch *touch1 = [[UITouch alloc] initAtPoint:finger1 inView:self withForce:0.0f];
+    UITouch *touch2 = [[UITouch alloc] initAtPoint:finger2 inView:self withForce:0.0f];
     [touch1 setPhaseAndUpdateTimestamp:UITouchPhaseBegan];
     [touch2 setPhaseAndUpdateTimestamp:UITouchPhaseBegan];
 
@@ -451,9 +451,9 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 
 #define DRAG_TOUCH_DELAY 0.01
 
-- (void)longPressAtPoint:(CGPoint)point duration:(NSTimeInterval)duration
+- (void)longPressAtPoint:(CGPoint)point duration:(NSTimeInterval)duration withForce:(float)force
 {
-    UITouch *touch = [[UITouch alloc] initAtPoint:point inView:self];
+    UITouch *touch = [[UITouch alloc] initAtPoint:point inView:self withForce:force];
     [touch setPhaseAndUpdateTimestamp:UITouchPhaseBegan];
     
     UIEvent *eventDown = [self eventWithTouch:touch];
@@ -538,7 +538,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
             for (NSArray *path in arrayOfPaths)
             {
                 CGPoint point = [path[pointIndex] CGPointValue];
-                UITouch *touch = [[UITouch alloc] initAtPoint:point inView:self];
+                UITouch *touch = [[UITouch alloc] initAtPoint:point inView:self withForce:0.0f];
                 [touch setPhaseAndUpdateTimestamp:UITouchPhaseBegan];
                 [touches addObject:touch];
             }

--- a/Classes/IOHIDEvent+KIF.m
+++ b/Classes/IOHIDEvent+KIF.m
@@ -21,6 +21,12 @@ typedef uint32_t IOHIDDigitizerTransducerType;
 typedef uint32_t IOHIDEventField;
 typedef uint32_t IOHIDEventType;
 
+@interface UITouch ()
+
+- (float)_pressure;
+
+@end
+
 void IOHIDEventAppendEvent(IOHIDEventRef event, IOHIDEventRef childEvent);
 void IOHIDEventSetIntegerValue(IOHIDEventRef event, IOHIDEventField field, int value);
 void IOHIDEventSetSenderID(IOHIDEventRef event, uint64_t sender);
@@ -168,7 +174,7 @@ IOHIDEventRef kif_IOHIDEventWithTouches(NSArray *touches) {
                                                                                     (IOHIDFloat)touchLocation.x, // x
                                                                                     (IOHIDFloat)touchLocation.y, // y
                                                                                     0.0, // z
-                                                                                    0, // tipPressure
+                                                                                    [touch _pressure], // tipPressure
                                                                                     0, // twist
                                                                                     5.0, // minor radius
                                                                                     5.0, // major radius

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -238,16 +238,18 @@ static inline KIFDisplacement KIFDisplacementForSwipingInDirection(KIFSwipeDirec
  @param label The accessibility label of the element to tap.
  @param value The accessibility value of the element to tap.
  @param traits The accessibility traits of the element to tap. Elements that do not include at least these traits are ignored.
+ @param force The amount of force that is to be exerted on the screen.
  */
-- (void)tapViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits;
+- (void)tapViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits force:(float)force;
 
 /*!
  @abstract Taps a particular view in the view heirarchy.
  @discussion Unlike the -tapViewWithAccessibilityLabel: family of methods, this method allows you to tap an arbitrary element.  Combined with -waitForAccessibilityElement:view:withLabel:value:traits:tappable: or +[UIAccessibilityElement accessibilityElement:view:withLabel:value:traits:tappable:error:] this provides an opportunity for more complex logic.
  @param element The accessibility element to tap.
  @param view The view containing the accessibility element.
+ @param force The amount of force that is to be exerted on the screen.
  */
-- (void)tapAccessibilityElement:(UIAccessibilityElement *)element inView:(UIView *)view;
+- (void)tapAccessibilityElement:(UIAccessibilityElement *)element inView:(UIView *)view withForce:(float)force;
 
 /*!
  @abstract Taps the increment|decrement button of a UIStepper view in the view heirarchy.

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -168,25 +168,25 @@
 
 - (void)tapViewWithAccessibilityLabel:(NSString *)label
 {
-    [self tapViewWithAccessibilityLabel:label value:nil traits:UIAccessibilityTraitNone];
+    [self tapViewWithAccessibilityLabel:label value:nil traits:UIAccessibilityTraitNone force:0.0f];
 }
 
 - (void)tapViewWithAccessibilityLabel:(NSString *)label traits:(UIAccessibilityTraits)traits
 {
-    [self tapViewWithAccessibilityLabel:label value:nil traits:traits];
+    [self tapViewWithAccessibilityLabel:label value:nil traits:traits force:0.0f];
 }
 
-- (void)tapViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits
+- (void)tapViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits force:(float)force
 {
     @autoreleasepool {
         UIView *view = nil;
         UIAccessibilityElement *element = nil;
         [self waitForAccessibilityElement:&element view:&view withLabel:label value:value traits:traits tappable:YES];
-        [self tapAccessibilityElement:element inView:view];
+        [self tapAccessibilityElement:element inView:view withForce:force];
     }
 }
 
-- (void)tapAccessibilityElement:(UIAccessibilityElement *)element inView:(UIView *)view
+- (void)tapAccessibilityElement:(UIAccessibilityElement *)element inView:(UIView *)view withForce:(float)force
 {
     [self runBlock:^KIFTestStepResult(NSError **error) {
         
@@ -208,9 +208,9 @@
         NSOperatingSystemVersion iOS9 = {9, 0, 0};
         BOOL isOperatingSystemAtLeastVersion9 = [NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS9];
         if (isOperatingSystemAtLeastVersion9 && [NSStringFromClass([view class]) isEqualToString:@"_UIAlertControllerActionView"]) {
-            [view longPressAtPoint:tappablePointInElement duration:0.1];
+          [view longPressAtPoint:tappablePointInElement duration:0.1 withForce:force];
         } else {
-            [view tapAtPoint:tappablePointInElement];
+          [view tapAtPoint:tappablePointInElement withForce:force];
         }
 
         KIFTestCondition(![view canBecomeFirstResponder] || [view isDescendantOfFirstResponder], error, @"Failed to make the view into the first responder: %@", view);
@@ -370,7 +370,7 @@
     UIAccessibilityElement *element = nil;
     
     [self waitForAccessibilityElement:&element view:&view withLabel:label value:nil traits:traits tappable:YES];
-    [self tapAccessibilityElement:element inView:view];
+    [self tapAccessibilityElement:element inView:view withForce:0.0f];
     [self waitForTimeInterval:0.25];
     [self enterTextIntoCurrentFirstResponder:text fallbackView:view];
     [self expectView:view toContainText:expectedResult ?: text];
@@ -424,7 +424,7 @@
 
 - (void)clearTextFromElement:(UIAccessibilityElement*)element inView:(UIView*)view
 {
-    [self tapAccessibilityElement:element inView:view];
+    [self tapAccessibilityElement:element inView:view withForce:0.0f];
 
     // Per issue #294, the tap occurs in the center of the text view.  If the text is too long, this means not all text gets cleared.  To address this for most cases, we can check if the selected view conforms to UITextInput and select the whole text range.
     if ([view conformsToProtocol:@protocol(UITextInput)]) {
@@ -627,7 +627,7 @@
         return;
     }
     
-    [self tapAccessibilityElement:element inView:view];
+    [self tapAccessibilityElement:element inView:view withForce:0.0f];
     
     // If we succeeded, stop the test.
     if (switchView.isOn == switchIsOn) {
@@ -1068,7 +1068,7 @@
         [self failWithError:[NSError KIFErrorWithFormat: @"Could not find the status bar"] stopTest:YES];
     }
     
-    [self tapAccessibilityElement:statusBars[0] inView:statusBars[0]];
+    [self tapAccessibilityElement:statusBars[0] inView:statusBars[0] withForce:0.0f];
 }
 
 - (void)moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath inTableViewWithAccessibilityIdentifier:(NSString *)identifier


### PR DESCRIPTION
I created a new method which passes a force value to be initialized with a UITouch for triggering a 3d touch on a specified view. This force value is used in the creation of an IOHIDEvent which is also attached to a UITouch. This should theoretically trigger a 3D touch given the addition of these new pressure/force properties in the iOS 9+ runtime headers as well as my research of the structure of the IOHIDEvent struct. However, the end result of calling this method with any float value is that it synthesizes a touch that does not seem to trigger 3D touch. If anyone could help me figure out how to get this working I would greatly appreciate it. Thanks! 
