### PR TITLE
Optional line number on screenshot file name

### DIFF
--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -132,6 +132,13 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
         return NO;
     }
     
+    if (!filename.length) {
+        if (error) {
+            *error = [NSError KIFErrorWithFormat:@"Missing screenshot filename."];
+        }
+        return NO;
+    }
+    
     UIGraphicsBeginImageContextWithOptions([[windows objectAtIndex:0] bounds].size, YES, 0);
     for (UIWindow *window in windows) {
 		//avoid https://github.com/kif-framework/KIF/issues/679
@@ -158,11 +165,8 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
         return NO;
     }
 
-    NSString *imageName = [NSString stringWithFormat:@"%@, line %lu", [filename lastPathComponent], (unsigned long)lineNumber];
-    if (description) {
-        imageName = [imageName stringByAppendingFormat:@", %@", description];
-    }
-
+    NSString *imageName = [self imageNameForFile:filename lineNumber:lineNumber description:description];
+    
     outputPath = [outputPath stringByAppendingPathComponent:imageName];
     outputPath = [outputPath stringByAppendingPathExtension:@"png"];
 
@@ -174,6 +178,24 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
     }
     
     return YES;
+}
+
+- (NSString *)imageNameForFile:(NSString *)filename lineNumber:(NSUInteger)lineNumber description:(NSString *)description {
+    if (!filename.length) {
+        return nil;
+    }
+    
+    NSString *imageName = [filename lastPathComponent];
+    
+    if (lineNumber > 0) {
+        imageName = [imageName stringByAppendingFormat:@", line %lu", (unsigned long)lineNumber];
+    }
+    
+    if (description.length) {
+        imageName = [imageName stringByAppendingFormat:@", %@", description];
+    }
+
+    return imageName;
 }
 
 #pragma mark - Run loop monitoring

--- a/KIF Tests/UIApplicationKIFAdditionsTests.m
+++ b/KIF Tests/UIApplicationKIFAdditionsTests.m
@@ -1,0 +1,75 @@
+//
+//  UIApplicationKIFAdditionsTests.m
+//  KIF
+//
+//  Created by Lucien Constantino on 10/12/15.
+//
+//
+
+#import <KIF/KIF.h>
+#import "UIApplication-KIFAdditions.h"
+
+@interface UIApplication ()
+- (NSString *)imageNameForFile:(NSString *)filename lineNumber:(NSUInteger)lineNumber description:(NSString *)description;
+@end
+
+@interface UIApplicationKIFAdditionsTests : KIFTestCase
+
+@end
+
+@implementation UIApplicationKIFAdditionsTests
+
+- (void)setUp {
+    [super setUp];
+    XCTAssertTrue([UIApplication instancesRespondToSelector:@selector(imageNameForFile:lineNumber:description:)]);
+}
+
+- (void)testScreenshotImageName {
+    
+    NSString *filename1 = @"screenshots/KIF";
+    NSUInteger lineNumber1 = 123;
+    NSString *description1 = @"a screenshot";
+    
+    NSString *imageName1 = [[UIApplication sharedApplication] imageNameForFile:filename1
+                                                                    lineNumber:lineNumber1
+                                                                   description:description1];
+    XCTAssertEqualObjects(imageName1, @"KIF, line 123, a screenshot");
+    
+    NSString *filename2 = @"screenshots/KIF";
+    NSUInteger lineNumber2 = 123;
+    NSString *description2 = nil;
+    
+    NSString *imageName2 = [[UIApplication sharedApplication] imageNameForFile:filename2
+                                                                    lineNumber:lineNumber2
+                                                                   description:description2];
+    XCTAssertEqualObjects(imageName2, @"KIF, line 123");
+    
+    NSString *filename3 = @"screenshots/KIF";
+    NSUInteger lineNumber3 = 0;
+    NSString *description3 = nil;
+    
+    NSString *imageName3 = [[UIApplication sharedApplication] imageNameForFile:filename3
+                                                                    lineNumber:lineNumber3
+                                                                   description:description3];
+    XCTAssertEqualObjects(imageName3, @"KIF");
+    
+    NSString *filename4 = @"screenshots/KIF";
+    NSUInteger lineNumber4 = 0;
+    NSString *description4 = @"a screenshot";
+    
+    NSString *imageName4 = [[UIApplication sharedApplication] imageNameForFile:filename4
+                                                                    lineNumber:lineNumber4
+                                                                   description:description4];
+    XCTAssertEqualObjects(imageName4, @"KIF, a screenshot");
+    
+    NSString *filename5 = nil;
+    NSUInteger lineNumber5 = 123;
+    NSString *description5 = @"a screenshot";
+    
+    NSString *imageName5 = [[UIApplication sharedApplication] imageNameForFile:filename5
+                                                                    lineNumber:lineNumber5
+                                                                   description:description5];
+    XCTAssertNil(imageName5);
+}
+
+@end

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		5C877DD01B057E13006A3AC6 /* KIFUITestActor-IdentifierTests.h in Headers */ = {isa = PBXBuildFile; fileRef = EB1A44D31A0C3268004A3F61 /* KIFUITestActor-IdentifierTests.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5C877DD11B0A8B8F006A3AC6 /* UIView-Debugging.h in Headers */ = {isa = PBXBuildFile; fileRef = 3ADD26484C6C438B71DC15C5 /* UIView-Debugging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5C877DD21B0A8B93006A3AC6 /* UIView-Debugging.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ADD2160096BE41C780FBD95 /* UIView-Debugging.m */; };
+		5F6A1B381C191F9600F20F22 /* UIApplicationKIFAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F6A1B371C191F9600F20F22 /* UIApplicationKIFAdditionsTests.m */; };
 		84D293AD1A2C84F700C10944 /* SystemAlertViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 84D293AC1A2C84F700C10944 /* SystemAlertViewController.m */; };
 		84D293AF1A2C867300C10944 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84D293AE1A2C867300C10944 /* CoreLocation.framework */; };
 		84D293B11A2C891700C10944 /* SystemAlertTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 84D293B01A2C891700C10944 /* SystemAlertTests.m */; };
@@ -211,6 +212,7 @@
 		4A48107A19708CAB0003A32E /* ExistTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExistTests.m; sourceTree = "<group>"; };
 		5A62B0AB1BB2043B00A3F480 /* AccessibilityIdentifierPullToRefreshTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccessibilityIdentifierPullToRefreshTests.m; sourceTree = "<group>"; };
 		5A62B0AD1BB205CA00A3F480 /* PullToRefreshTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PullToRefreshTests.m; sourceTree = "<group>"; };
+		5F6A1B371C191F9600F20F22 /* UIApplicationKIFAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIApplicationKIFAdditionsTests.m; sourceTree = "<group>"; };
 		84D293AC1A2C84F700C10944 /* SystemAlertViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SystemAlertViewController.m; sourceTree = "<group>"; };
 		84D293AE1A2C867300C10944 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		84D293B01A2C891700C10944 /* SystemAlertTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SystemAlertTests.m; sourceTree = "<group>"; };
@@ -608,6 +610,7 @@
 				84D293B01A2C891700C10944 /* SystemAlertTests.m */,
 				97E8A5D01B0A63D100124E3B /* BackgroundTests.m */,
 				5A62B0AD1BB205CA00A3F480 /* PullToRefreshTests.m */,
+				5F6A1B371C191F9600F20F22 /* UIApplicationKIFAdditionsTests.m */,
 				EB60ECF0177F8DB3005A041A /* Supporting Files */,
 			);
 			path = "KIF Tests";
@@ -932,6 +935,7 @@
 				4A48107B19708CAB0003A32E /* ExistTests.m in Sources */,
 				EA4655881905B92500B2C60E /* PickerTests.m in Sources */,
 				3812FB631A12188700335733 /* WaitForAnimationTests.m in Sources */,
+				5F6A1B381C191F9600F20F22 /* UIApplicationKIFAdditionsTests.m in Sources */,
 				EB1A44DA1A0C33AD004A3F61 /* AccessibilityIdentifierTests.m in Sources */,
 				EABD46B41857A0F300A5F081 /* LongPressTests.m in Sources */,
 				EABD46B51857A0F300A5F081 /* ModalViewTests.m in Sources */,


### PR DESCRIPTION
The line number appended to the saved screenshot file name should be optional. Specify `0` or negative values to hide the appendage "`, line %lu`".

Added unit test.