### PR TITLE
Fixed IOHIDEvent memory leak

### DIFF
--- a/Additions/UIEvent+KIFAdditions.m
+++ b/Additions/UIEvent+KIFAdditions.m
@@ -85,6 +85,7 @@ typedef struct __GSEvent * GSEventRef;
 {
     IOHIDEventRef event = kif_IOHIDEventWithTouches(touches);
     [self _setHIDEvent:event];
+    CFRelease(event);
 }
 
 @end

--- a/Additions/UITouch-KIFAdditions.m
+++ b/Additions/UITouch-KIFAdditions.m
@@ -107,6 +107,7 @@ typedef struct {
 - (void)kif_setHidEvent {
     IOHIDEventRef event = kif_IOHIDEventWithTouches(@[self]);
     [self _setHidEvent:event];
+    CFRelease(event);
 }
 
 @end

--- a/Classes/IOHIDEvent+KIF.h
+++ b/Classes/IOHIDEvent+KIF.h
@@ -7,5 +7,5 @@
 //
 
 typedef struct __IOHIDEvent * IOHIDEventRef;
-IOHIDEventRef kif_IOHIDEventWithTouches(NSArray *touches);
+IOHIDEventRef kif_IOHIDEventWithTouches(NSArray *touches) CF_RETURNS_RETAINED;
 


### PR DESCRIPTION
I also added the CF_RETURNS_RETAINED annotation, and then the static analyzer called out all of the leaks.