### PR TITLE
Fix tableview tests (causing Travis to be red)

### DIFF
--- a/KIF Tests/TableViewTests.m
+++ b/KIF Tests/TableViewTests.m
@@ -25,7 +25,6 @@
     [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
 }
 
-//TODO: Fail on iOS 9 (UITableViewCell accessibilityTraits is incorrect when selected)
 - (void)testTappingRows
 {
     [tester tapRowAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:2] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"];
@@ -34,7 +33,6 @@
     [tester waitForViewWithAccessibilityLabel:@"First Cell" traits:UIAccessibilityTraitSelected];
 }
 
-//TODO: Fail on iOS 9 (UITableViewCell accessibilityTraits is incorrect when selected)
 - (void)testTappingLastRowAndSection
 {
     [tester tapRowAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:-1] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"];

--- a/Test Host/TableViewController.m
+++ b/Test Host/TableViewController.m
@@ -6,7 +6,7 @@
 //
 //
 
-@interface TableViewController : UITableViewController
+@interface TableViewController : UITableViewController <UITableViewDelegate>
 
 @end
 
@@ -27,7 +27,27 @@
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
 
     return YES;
+}
+
+// Work around a bug on iOS9 that accessibility trait Selected doesn't get set
+- (nullable NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath;
+{
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] == NSOrderedSame) {
+        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+        [cell setAccessibilityTraits:cell.accessibilityTraits | UIAccessibilityTraitSelected];
+    }
+
+    return indexPath;
+}
+
+- (nullable NSIndexPath *)tableView:(UITableView *)tableView willDeselectRowAtIndexPath:(NSIndexPath *)indexPath;
+{
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] == NSOrderedSame) {
+        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+        [cell setAccessibilityTraits:cell.accessibilityTraits ^ UIAccessibilityTraitSelected];
+    }
     
+    return indexPath;
 }
 
 - (UITableViewCellEditingStyle)tableView:(UITableView *)tableView editingStyleForRowAtIndexPath:(NSIndexPath *)indexPath {


### PR DESCRIPTION
It looks like the accessibility behavior on iOS 9.0 had a bug. I tried locally and could reproduce against the 9.0 simulator, but not against the 9.1 or 9.2 simulator. I've adjusted the app behavior to account for the platform bug.