### PR TITLE
Don't run acknowledgeSystemAlert tests on iOS7, it doesn't work

### DIFF
--- a/KIF Tests/SpecificControlTests.m
+++ b/KIF Tests/SpecificControlTests.m
@@ -43,17 +43,19 @@
     [tester waitForViewWithAccessibilityLabel:@"Slider" value:@"5" traits:UIAccessibilityTraitNone];
 }
 
-- (void)testPickingAPhoto {
+- (void)testPickingAPhoto
+{
+    // 'acknowledgeSystemAlert' can't be used on iOS7
+    // The console shows a message "AX Lookup problem! 22 com.apple.iphone.axserver:-1"
+    if ([UIDevice.currentDevice.systemVersion compare:@"8.0" options:NSNumericSearch] < 0) {
+        return;
+    }
+
     [tester tapViewWithAccessibilityLabel:@"Photos"];
     [tester acknowledgeSystemAlert];
     [tester waitForTimeInterval:0.5f]; // Wait for view to stabilize
 
-    NSOperatingSystemVersion iOS8 = {8, 0, 0};
-    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS8]) {
-        [tester choosePhotoInAlbum:@"Camera Roll" atRow:1 column:2];
-    } else {
-        [tester choosePhotoInAlbum:@"Saved Photos" atRow:1 column:2];
-    }
+    [tester choosePhotoInAlbum:@"Camera Roll" atRow:1 column:2];
     [tester waitForViewWithAccessibilityLabel:@"UIImage"];
 }
 

--- a/KIF Tests/SystemAlertTests.m
+++ b/KIF Tests/SystemAlertTests.m
@@ -14,6 +14,17 @@
 
 @implementation SystemAlertTests
 
++ (XCTestSuite *)defaultTestSuite
+{
+    // 'acknowledgeSystemAlert' can't be used on iOS7
+    // The console shows a message "AX Lookup problem! 22 com.apple.iphone.axserver:-1"
+    if ([UIDevice.currentDevice.systemVersion compare:@"8.0" options:NSNumericSearch] < 0) {
+        return nil;
+    }
+
+    return [super defaultTestSuite];
+}
+
 - (void)beforeEach
 {
     [tester tapViewWithAccessibilityLabel:@"System Alerts"];


### PR DESCRIPTION
I see the console logs with "AX Lookup problem! 22 com.apple.iphone.axserver:-1" against the iOS7 simulator. I'm running Xcode 6.4 on Yosemite against the 7.1 simulator.

Did this ever work on iOS7 simulators? Maybe we should do something to prevent it from being used on iOS7, like assert in that method itself? Would that make the contract more clear?