### PR TITLE
Make gesture tests more reliable

### DIFF
--- a/KIF Tests/GestureTests.m
+++ b/KIF Tests/GestureTests.m
@@ -28,6 +28,9 @@
 - (void)beforeAll
 {
     [tester tapViewWithAccessibilityLabel:@"Gestures"];
+
+    // Wait for the push animation to complete before trying to interact with the view
+    [tester waitForTimeInterval:.25];
 }
 
 - (void)afterAll
@@ -192,9 +195,10 @@
 
 - (void)testScrolling
 {
-    [tester scrollViewWithAccessibilityIdentifier:@"Scroll View" byFractionOfSizeHorizontal:-0.9 vertical:-0.9];
+    // Needs to be offset from the edge to prevent the navigation controller's interactivePopGestureRecognizer from triggering
+    [tester scrollViewWithAccessibilityIdentifier:@"Scroll View" byFractionOfSizeHorizontal:-0.80 vertical:-0.80];
     [tester waitForTappableViewWithAccessibilityLabel:@"Bottom Right"];
-    [tester scrollViewWithAccessibilityIdentifier:@"Scroll View" byFractionOfSizeHorizontal:0.9 vertical:0.9];
+    [tester scrollViewWithAccessibilityIdentifier:@"Scroll View" byFractionOfSizeHorizontal:0.80 vertical:0.80];
     [tester waitForTappableViewWithAccessibilityLabel:@"Top Left"];
 }
 


### PR DESCRIPTION
Some tests would fail when run individually (when the navigation controller push animation is still happening), fixed that with a sleep in the beforeAll.

Also, `testScrolling` was failing consistently on the iPhone 6 Plus. It was dragging from the left edge of the screen which was triggering the navigation controller's `interactivePopGestureRecognizer`. The edge swipe region seems significantly bigger on iPhone 6 Plus.