### PR TITLE
Add a convenience method for logging an error

### DIFF
--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -151,6 +151,8 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 
 - (void)failWithError:(NSError *)error stopTest:(BOOL)stopTest;
 
+- (void)failWithMessage:(NSString *)message, ...;
+
 /*!
  @abstract Waits for a certain amount of time before returning.
  @discussion In general when waiting for the app to get into a known state, it's better to use -waitForTappableViewWithAccessibilityLabel:, however this step may be useful in some situations as well.

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -145,6 +145,16 @@ static NSTimeInterval KIFTestStepDelay = 0.1;
     }];
 }
 
+- (void)failWithMessage:(NSString *)message, ...;
+{
+    va_list args;
+    va_start(args, message);
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
+    NSError *error = [NSError errorWithDomain:@"KIFTest" code:KIFTestStepResultFailure userInfo:[NSDictionary dictionaryWithObjectsAndKeys:formattedMessage, NSLocalizedDescriptionKey, nil]];
+    [self failWithError:error stopTest:YES];
+    va_end(args);
+}
+
 - (void)failWithError:(NSError *)error stopTest:(BOOL)stopTest
 {
     [self.delegate failWithException:[NSException failureInFile:self.file atLine:(int)self.line withDescription:error.localizedDescription] stopTest:stopTest];


### PR DESCRIPTION
We're using this as a convenience method to generate screenshots when test cases fail. It seemed like something that was reasonable to push upstream, but happy to keep it in our code if it wouldn't be useful for others.