### PR TITLE
Setting first responder on an accessibility element may be delayed

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -212,11 +212,16 @@
         } else {
             [view tapAtPoint:tappablePointInElement];
         }
-
-        KIFTestCondition(![view canBecomeFirstResponder] || [view isDescendantOfFirstResponder], error, @"Failed to make the view into the first responder: %@", view);
         
         return KIFTestStepResultSuccess;
     }];
+
+    // Controls might not synchronously become first-responders. Sometimes custom controls
+    // may need to spin the runloop before reporting as the first responder.
+    [self runBlock:^KIFTestStepResult(NSError *__autoreleasing *error) {
+        KIFTestWaitCondition(![view canBecomeFirstResponder] || [view isDescendantOfFirstResponder], error, @"Failed to make the view into the first responder: %@", view);
+        return KIFTestStepResultSuccess;
+    } timeout:0.5];
 
     [self waitForAnimationsToFinish];
 }


### PR DESCRIPTION
We had a case where we're tapping an element that displays a popover control, and it doesn't report as being firstResponder until after the popover has been displayed (on the next runloop cycle). Using KIFTestCondition here meant that we'd fail the immediate check, despite the element becoming first responder shortly thereafter.

The fix here is to allow the element to become first responder shortly after being tapped. This will make failures take a little longer (I limited it to a half second) if the element is tapped and doesn't ever become first responder.