### PR TITLE
Don't compile acknowledgeSystemAlert for device builds

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -792,9 +792,14 @@
     [self tapItemAtIndexPath:indexPath inCollectionView:collectionView];
 }
 
-- (BOOL)acknowledgeSystemAlert {
+#if TARGET_IPHONE_SIMULATOR
+
+- (BOOL)acknowledgeSystemAlert
+{
     return [UIAutomationHelper acknowledgeSystemAlert];
 }
+
+#endif
 
 - (void)tapItemAtIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView
 {


### PR DESCRIPTION
We were hitting build errors when building for device. This is already not exposed in the header, so we're just also not compiling it in the source file on the same conditional.