### PR TITLE
UIControl isUserInteractionEnabled check.

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -829,6 +829,20 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
         }
     }
     
+    // Somtimes views are inside a UIControl and don't have user interaction enabled.
+    // Walk up the hierarchary evaluating the parent UIControl subclass and use that instead.
+    if (!isUserInteractionEnabled && [self.superview isKindOfClass:[UIControl class]]) {
+        // If this view is inside a UIControl, and it is enabled, then consider the view enabled
+        UIControl *control = (UIControl *)[self superview];
+        while (control && [control isKindOfClass:[UIControl class]]) {
+            if (control.isUserInteractionEnabled) {
+                isUserInteractionEnabled = YES;
+                break;
+            }
+            control = (UIControl *)[control superview];
+        }
+    }
+    
     return isUserInteractionEnabled;
 }
 


### PR DESCRIPTION
Added a fallthrough to allow UIControl subclasses to contain views with userInteractionEnabled == NO

We already have two specific special cases (which we should retain) but this one is more generic and will help with custom UIControls.

The logic is slightly different. Since we cant guarantee that a view of a given class is inside a UIControl, rather than walking to the top and evaluating that view, this will walk up the chain and evaluate every step along the way. 

