### PR TITLE
Fixing acknowledgeSystemAlert for dirty simulators.

### DIFF
--- a/Classes/UIAutomationHelper.h
+++ b/Classes/UIAutomationHelper.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
+
 @class KIFTestActor;
 
 @interface UIAutomationHelper : NSObject

--- a/KIF Tests/SystemAlertTests.m
+++ b/KIF Tests/SystemAlertTests.m
@@ -37,9 +37,14 @@
 
 - (void)testAuthorizingLocationServicesAndNotificationsScheduling {
     [tester tapViewWithAccessibilityLabel:@"Location Services and Notifications"];
-    XCTAssertTrue([tester acknowledgeSystemAlert]);
-	XCTAssertTrue([tester acknowledgeSystemAlert]);
-	XCTAssertFalse([tester acknowledgeSystemAlert]);
+
+    // In a clean state this will pop two alerts, but in a dirty state it will pop one or none.
+    // Call acknowledgeSystemAlert 2x without checking the return value (as the alerts might not be there).
+    // Finally check that the final attempt is indeed false and no alerts remain on screen.
+    
+    [tester acknowledgeSystemAlert];
+    [tester acknowledgeSystemAlert];
+    XCTAssertFalse([tester acknowledgeSystemAlert]);
 }
 
 - (void)testAuthorizingPhotosAccess {


### PR DESCRIPTION
Because the system will only pop the system alerts once per simulator, we cant assert that they will pop on every test run. This PR fixes acknowledgeSystemAlert to ensure the alert is valid before we attempt to tap the dismissal button (avoiding a crasher), and updates the associated tests to only assert that the _final_ alert dismissal returns NO. 