### PR TITLE
Updated README for compatibility with Xcode 7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,21 +250,21 @@ If you want to write your test cases in Swift, you'll need to keep two things in
 import KIF
  
 extension XCTestCase {
-    func tester(file : String = __FILE__, _ line : Int = __LINE__) -> KIFUITestActor {
+    func tester(file : String = #file, _ line : Int = #line) -> KIFUITestActor {
         return KIFUITestActor(inFile: file, atLine: line, delegate: self)
     }
 
-    func system(file : String = __FILE__, _ line : Int = __LINE__) -> KIFSystemTestActor {
+    func system(file : String = #file, _ line : Int = #line) -> KIFSystemTestActor {
         return KIFSystemTestActor(inFile: file, atLine: line, delegate: self)
     }
 }
 
 extension KIFTestActor {
-    func tester(file : String = __FILE__, _ line : Int = __LINE__) -> KIFUITestActor {
+    func tester(file : String = #file, _ line : Int = #line) -> KIFUITestActor {
         return KIFUITestActor(inFile: file, atLine: line, delegate: self)
     }
 
-    func system(file : String = __FILE__, _ line : Int = __LINE__) -> KIFSystemTestActor {
+    func system(file : String = #file, _ line : Int = #line) -> KIFSystemTestActor {
         return KIFSystemTestActor(inFile: file, atLine: line, delegate: self)
     }
 }


### PR DESCRIPTION
Deprecation warnings were showing after upgrade to Xcode 7.3:

<img width="321" alt="deprecation warnings" src="https://cloud.githubusercontent.com/assets/337963/13966057/1ff549a0-f047-11e5-8325-6606fc36f3f0.png">


As such, replaced `__LINE__` with `#line` and `__FILE__` with `#file`.

