### PR TITLE
Add fix for a case where accessibility element frame was zero

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -954,7 +954,14 @@
 
     // Within this method, all geometry is done in the coordinate system of the view to scroll.
 
-    CGRect elementFrame = [viewToScroll.windowOrIdentityWindow convertRect:element.accessibilityFrame toView:viewToScroll];
+    // PSPDFKit: This broke in a recent KIF update,
+    // for some reason accessibilityFrame is empty.
+    CGRect frame = element.accessibilityFrame;
+    if (CGRectIsEmpty(frame) && [element respondsToSelector:@selector(frame)]) {
+        frame = ((UIView *)element).frame;
+    }
+
+    CGRect elementFrame = [viewToScroll.windowOrIdentityWindow convertRect:frame toView:viewToScroll];
 
     KIFDisplacement scrollDisplacement = CGPointMake(elementFrame.size.width * horizontalFraction, elementFrame.size.height * verticalFraction);
 


### PR DESCRIPTION
We ran into this and I wanted to open a PR in case anyone else sees this.

Probably misses a KIF test case and more details - ping me if you see or know about a similar issue.
