### PR TITLE
Speed up wait time if layer speed is increased

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -144,7 +144,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
             }
             
             // Give the scroll view a small amount of time to perform the scroll.
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.3, false);
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.3 / UIApplication.sharedApplication.keyWindow.layer.speed, false);
         }
         
         superview = superview.superview;

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -449,7 +449,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     [[UIApplication sharedApplication] sendEvent:event];
 }
 
-#define DRAG_TOUCH_DELAY 0.01
+#define DRAG_TOUCH_DELAY (0.01 / UIApplication.sharedApplication.keyWindow.layer.speed)
 
 - (void)longPressAtPoint:(CGPoint)point duration:(NSTimeInterval)duration
 {

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -158,8 +158,10 @@
 }
 
 - (void)waitForAnimationsToFinishWithTimeout:(NSTimeInterval)timeout {
-    static const CGFloat kStabilizationWait = 0.5f;
-    
+    const CGFloat layerSpeed = UIApplication.sharedApplication.keyWindow.layer.speed;
+    timeout /= layerSpeed;
+    const CGFloat kStabilizationWait = 0.5f / layerSpeed;
+
     NSTimeInterval maximumWaitingTimeInterval = timeout;
     if (maximumWaitingTimeInterval <= kStabilizationWait) {
         if(maximumWaitingTimeInterval >= 0) {
@@ -321,7 +323,7 @@
     }];
 
     // Wait for view to settle.
-    [self waitForTimeInterval:0.5];
+    [self waitForTimeInterval:0.5 / UIApplication.sharedApplication.keyWindow.layer.speed];
 }
 
 - (void)waitForKeyboard
@@ -416,7 +418,7 @@
     // In iOS7, tapping a field that is already first responder moves the cursor to the front of the field
     if (view.window.firstResponder != view) {
         [self tapAccessibilityElement:element inView:view];
-        [self waitForTimeInterval:0.25];
+        [self waitForTimeInterval:0.25 / UIApplication.sharedApplication.keyWindow.layer.speed];
     }
 
     [self enterTextIntoCurrentFirstResponder:text fallbackView:view];


### PR DESCRIPTION
At PSPDFKit our UI tests start to get to a size where waiting for the KIF tests becomes impractical, so we investigated ways to make them run faster.

We had great success with increasing the layer speed on the key window:

```
UIApplication.sharedApplication.keyWindow.layer.speed = speed;
```

This might cause trouble for (very unusual) multi-window setups, but it's still entirely optional to use.
The default value here is 1, so no timeouts are changed by default.

Are there any other important spots where we should divide based on layer speed?