### PR TITLE
Use scrollRectToVisible instead of scrollToItemAtIndexPath

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -286,7 +286,8 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                     }
                     
                     // Scroll to the cell and wait for the animation to complete
-                    [collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionNone animated:YES];
+                    CGRect frame = [collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath].frame;
+                    [collectionView scrollRectToVisible:frame animated:YES];
                     CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.5, false);
                     
                     // Now try finding the element again


### PR DESCRIPTION
Currently, when scrolling to an offscreen collection view element that has not yet been created, KIF calls `scrollToItemAtIndexPath:atScrollPosition:` with position `UICollectionViewScrollPositionNone`.  According to [Apple's documentation](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UICollectionView_class/#//apple_ref/doc/uid/TP40012177-CH1-SW60), `UICollectionViewScrollPositionNone` means "Do not scroll the item into view", and indeed what actually happens in my project is that the collection view scrolls to the top and doesn't show the view.  This leads to an endless loop in `accessibilityElementMatchingBlock:`.

None of the other `UICollectionViewScrollPosition` constants are really suitable, so instead I get the element's frame from the collection view's layout and then use `scrollRectToVisible:` which does scroll the collection view appropriately.