### PR TITLE
Mark -[KIFTestActor init] unavailable.

### DIFF
--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -82,6 +82,8 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 
 @interface KIFTestActor : NSObject
 
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 + (instancetype)actorInFile:(NSString *)file atLine:(NSInteger)line delegate:(id<KIFTestActorDelegate>)delegate;
 
 @property (strong, nonatomic, readonly) NSString *file;

--- a/Classes/KIFTestCase.m
+++ b/Classes/KIFTestCase.m
@@ -125,7 +125,7 @@ NSComparisonResult selectorSort(NSInvocation *invocOne, NSInvocation *invocTwo, 
         NSLog(@"Fatal failure encountered: %@", exception.description);
         NSLog(@"Stopping tests since stopTestsOnFirstBigFailure = YES");
         
-        KIFTestActor *waiter = [[KIFTestActor alloc] init];
+        KIFTestActor *waiter = KIFActorWithClass(KIFTestActor);
         [waiter waitForTimeInterval:[[NSDate distantFuture] timeIntervalSinceNow]];
         
         return;

--- a/KIF Tests/AccessibilityIdentifierTests.m
+++ b/KIF Tests/AccessibilityIdentifierTests.m
@@ -93,7 +93,7 @@
 	[tester waitForTimeInterval:0.5f];
 	uiLabel = (UILabel *)[tester waitForViewWithAccessibilityIdentifier:@"tapViewController.stepperValue"];
 	NSInteger newValue = [[uiLabel text] integerValue];
-	if (! newValue == (originalValue + 1))
+	if (newValue != (originalValue + 1))
 	{
 		NSException *exception = [NSException exceptionWithName:@"Unexpected test failure"
 														 reason:[NSString stringWithFormat: @"newValue was expected to be +1 of originalValue. Original Value was %ld while newValue is %ld", (long)originalValue, (long)newValue] userInfo:nil];
@@ -111,7 +111,7 @@
 	[tester waitForTimeInterval:0.5f];
 	uiLabel = (UILabel *)[tester waitForViewWithAccessibilityIdentifier:@"tapViewController.stepperValue"];
 	NSInteger newValue = [[uiLabel text] integerValue];
-	if (! newValue == (originalValue -1))
+	if (newValue != (originalValue -1))
 	{
 		NSException *exception = [NSException exceptionWithName:@"Unexpected test failure"
 														 reason:[NSString stringWithFormat: @"newValue was expected to be -1 of originalValue. Original Value was %ld while newValue is %ld", (long)originalValue, (long)newValue] userInfo:nil];


### PR DESCRIPTION
Ran into a problem where we created a KIFTestActor without a line or file, and then when it ran into a test failure it would try and insert a `nil` for `self.file` into the exception user info in NSException+KIFAdditions and crash.

Elected to change KIFTestActor to simply not allow the user to create a KIFTestActor without a file path in the first place (this also works really well with Swift). 

An alternative solution is to perform a nil check before creating the dictionary in the NSException category.