### PR TITLE
Additional speedups relative to animation speed

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -144,7 +144,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
             }
             
             // Give the scroll view a small amount of time to perform the scroll.
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.3 / UIApplication.sharedApplication.keyWindow.layer.speed, false);
+            KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, 0.3, false);
         }
         
         superview = superview.superview;

--- a/Additions/UIApplication-KIFAdditions.h
+++ b/Additions/UIApplication-KIFAdditions.h
@@ -9,6 +9,7 @@
 
 #import <UIKit/UIKit.h>
 
+
 #define UIApplicationCurrentRunMode ([[UIApplication sharedApplication] currentRunLoopMode])
 
 /*!
@@ -25,6 +26,11 @@ UIKIT_EXTERN NSString *const UIApplicationDidMockCanOpenURLNotification;
  @abstract The key for the opened URL in the @c UIApplicationDidMockOpenURLNotification notification.
  */
 UIKIT_EXTERN NSString *const UIApplicationOpenedURLKey;
+
+/*!
+ @abstract A wrapper for CFRunLoopRunInMode that scales the seconds parameter relative to the animation speed.
+ */
+CF_EXPORT SInt32 KIFRunLoopRunInModeRelativeToAnimationSpeed(CFStringRef mode, CFTimeInterval seconds, Boolean returnAfterSourceHandled);
 
 @interface UIApplication (KIFAdditions)
 
@@ -68,6 +74,11 @@ UIKIT_EXTERN NSString *const UIApplicationOpenedURLKey;
  @returns All windows in the application, including the key window even if it does not appear in @c -windows.
  */
 - (NSArray *)windowsWithKeyWindow;
+
+/*!
+ The current Core Animation speed of the keyWindow's CALayer.
+ */
+@property (nonatomic, assign) float animationSpeed;
 
 /*!
  @abstract Writes a screenshot to disk.

--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -20,6 +20,12 @@ MAKE_CATEGORIES_LOADABLE(UIApplication_KIFAdditions)
 static BOOL _KIF_UIApplicationMockOpenURL = NO;
 static BOOL _KIF_UIApplicationMockOpenURL_returnValue = NO;
 
+SInt32 KIFRunLoopRunInModeRelativeToAnimationSpeed(CFStringRef mode, CFTimeInterval seconds, Boolean returnAfterSourceHandled)
+{
+    CFTimeInterval scaledSeconds = seconds / [UIApplication sharedApplication].animationSpeed;
+    return CFRunLoopRunInMode(mode, scaledSeconds, returnAfterSourceHandled);
+}
+
 @interface UIApplication (Undocumented)
 - (void)pushRunLoopMode:(id)arg1;
 - (void)pushRunLoopMode:(id)arg1 requester:(id)requester;
@@ -110,6 +116,19 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
         [windows addObject:keyWindow];
     }
     return windows;
+}
+
+- (float)animationSpeed
+{
+    if (!self.keyWindow) {
+        return 1.0f;
+    }
+    return self.keyWindow.layer.speed;
+}
+
+- (void)setAnimationSpeed:(float)animationSpeed
+{
+    self.keyWindow.layer.speed = animationSpeed;
 }
 
 #pragma mark - Screenshotting

--- a/Additions/UIScrollView-KIFAdditions.m
+++ b/Additions/UIScrollView-KIFAdditions.m
@@ -37,7 +37,7 @@ MAKE_CATEGORIES_LOADABLE(UIScrollView_KIFAdditions)
     
     if (!CGPointEqualToPoint(contentOffset, self.contentOffset)) {
         [self setContentOffset:contentOffset animated:animated];
-        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.2, false);
+        KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, 0.2, false);
     }
 }
 

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -250,6 +250,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                     
                     // Scroll to the cell and wait for the animation to complete
                     [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:YES];
+                    // Note: using KIFRunLoopRunInModeRelativeToAnimationSpeed here may cause tests to stall
                     CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.5, false);
                     
                     // Now try finding the element again
@@ -288,6 +289,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                     // Scroll to the cell and wait for the animation to complete
                     CGRect frame = [collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath].frame;
                     [collectionView scrollRectToVisible:frame animated:YES];
+                    // Note: using KIFRunLoopRunInModeRelativeToAnimationSpeed here may cause tests to stall
                     CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.5, false);
                     
                     // Now try finding the element again
@@ -450,7 +452,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     [[UIApplication sharedApplication] sendEvent:event];
 }
 
-#define DRAG_TOUCH_DELAY (0.01 / UIApplication.sharedApplication.keyWindow.layer.speed)
+#define DRAG_TOUCH_DELAY 0.01
 
 - (void)longPressAtPoint:(CGPoint)point duration:(NSTimeInterval)duration
 {

--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -158,7 +158,13 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
  */
 - (void)waitForTimeInterval:(NSTimeInterval)timeInterval;
 
-
+/*!
+ @abstract Waits for a certain amount of time before returning.  The time delay is optionally scaled relative to the current animation speed.
+ @discussion In general when waiting for the app to get into a known state, it's better to use -waitForTappableViewWithAccessibilityLabel:, however this step may be useful in some situations as well.
+ @param timeInterval The number of seconds to wait before returning.
+ @param scaleTime Whether to scale the timeInterval relative to the current animation speed
+ */
+- (void)waitForTimeInterval:(NSTimeInterval)timeInterval relativeToAnimationSpeed:(BOOL)scaleTime;
 
 @end
 

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -154,6 +154,15 @@ static NSTimeInterval KIFTestStepDelay = 0.1;
 
 - (void)waitForTimeInterval:(NSTimeInterval)timeInterval
 {
+    [self waitForTimeInterval:timeInterval relativeToAnimationSpeed:NO];
+}
+
+- (void)waitForTimeInterval:(NSTimeInterval)timeInterval relativeToAnimationSpeed:(BOOL)scaleTime
+{
+    if (scaleTime) {
+        timeInterval /= [UIApplication sharedApplication].animationSpeed;
+    }
+    
     NSTimeInterval startTime = [NSDate timeIntervalSinceReferenceDate];
     
     [self runBlock:^KIFTestStepResult(NSError **error) {

--- a/Classes/KIFTypist.m
+++ b/Classes/KIFTypist.m
@@ -89,7 +89,7 @@ static NSTimeInterval keystrokeDelay = 0.01f;
         [[UIKeyboardImpl sharedInstance] addInputString:characterString];
     }
     
-    CFRunLoopRunInMode(kCFRunLoopDefaultMode, keystrokeDelay, false);
+    KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, keystrokeDelay, false);
     return YES;
 }
 

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -158,21 +158,19 @@
 }
 
 - (void)waitForAnimationsToFinishWithTimeout:(NSTimeInterval)timeout {
-    const CGFloat layerSpeed = UIApplication.sharedApplication.keyWindow.layer.speed;
-    timeout /= layerSpeed;
-    const CGFloat kStabilizationWait = 0.5f / layerSpeed;
-
+    static const CGFloat kStabilizationWait = 0.5f;
+    
     NSTimeInterval maximumWaitingTimeInterval = timeout;
     if (maximumWaitingTimeInterval <= kStabilizationWait) {
         if(maximumWaitingTimeInterval >= 0) {
-            [self waitForTimeInterval:maximumWaitingTimeInterval];
+            [self waitForTimeInterval:maximumWaitingTimeInterval relativeToAnimationSpeed:YES];
         }
         
         return;
     }
     
     // Wait for the view to stabilize and give them a chance to start animations before we wait for them.
-    [self waitForTimeInterval:kStabilizationWait];
+    [self waitForTimeInterval:kStabilizationWait relativeToAnimationSpeed:YES];
     maximumWaitingTimeInterval -= kStabilizationWait;
     
     NSTimeInterval startTime = [NSDate timeIntervalSinceReferenceDate];
@@ -323,7 +321,7 @@
     }];
 
     // Wait for view to settle.
-    [self waitForTimeInterval:0.5 / UIApplication.sharedApplication.keyWindow.layer.speed];
+    [self waitForTimeInterval:0.5 relativeToAnimationSpeed:YES];
 }
 
 - (void)waitForKeyboard
@@ -418,7 +416,7 @@
     // In iOS7, tapping a field that is already first responder moves the cursor to the front of the field
     if (view.window.firstResponder != view) {
         [self tapAccessibilityElement:element inView:view];
-        [self waitForTimeInterval:0.25 / UIApplication.sharedApplication.keyWindow.layer.speed];
+        [self waitForTimeInterval:0.25 relativeToAnimationSpeed:YES];
     }
 
     [self enterTextIntoCurrentFirstResponder:text fallbackView:view];
@@ -480,7 +478,7 @@
         id<UITextInput> textInput = (id<UITextInput>)view;
         [textInput setSelectedTextRange:[textInput textRangeFromPosition:textInput.beginningOfDocument toPosition:textInput.endOfDocument]];
         
-        [self waitForTimeInterval:0.1];
+        [self waitForTimeInterval:0.1 relativeToAnimationSpeed:YES];
         [self enterTextIntoCurrentFirstResponder:@"\b" fallbackView:view];
     } else {
         NSUInteger numberOfCharacters = [view respondsToSelector:@selector(text)] ? [(UITextField *)view text].length : element.accessibilityValue.length;
@@ -619,11 +617,11 @@
                 }
                 else if ([rowTitle isEqual:pickerColumnValues[componentIndex]]) {
                     [pickerView selectRow:rowIndex inComponent:componentIndex animated:false];
-                    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
+                    KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, 1.0f, false);
                     
                     // Tap in the middle of the picker view to select the item
                     [pickerView tap];
-                    [self waitForTimeInterval:0.5];
+                    [self waitForTimeInterval:0.5 relativeToAnimationSpeed:YES];
                     
                     // The combination of selectRow:inComponent:animated: and tap does not consistently result in
                     // pickerView:didSelectRow:inComponent: being called on the delegate. We need to do it explicitly.
@@ -690,7 +688,7 @@
     NSLog(@"Faking turning switch %@", switchIsOn ? @"ON" : @"OFF");
     [switchView setOn:switchIsOn animated:YES];
     [switchView sendActionsForControlEvents:UIControlEventValueChanged];
-    [self waitForTimeInterval:0.5];
+    [self waitForTimeInterval:0.5 relativeToAnimationSpeed:YES];
 
     // We gave it our best shot.  Fail the test.
     if (switchView.isOn != switchIsOn) {
@@ -744,7 +742,7 @@
     }
     UIView *dimmingView = [[window subviewsWithClassNamePrefix:@"UIDimmingView"] lastObject];
     [dimmingView tapAtPoint:CGPointMake(50.0f, 50.0f)];
-    CFRunLoopRunInMode(kCFRunLoopDefaultMode, tapDelay, false);
+    KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, tapDelay, false);
 }
 
 - (void)choosePhotoInAlbum:(NSString *)albumName atRow:(NSInteger)row column:(NSInteger)column
@@ -778,7 +776,7 @@
     }];
 
     // Wait for media picker view controller to be pushed.
-    [self waitForTimeInterval:1];
+    [self waitForTimeInterval:1 relativeToAnimationSpeed:YES];
 
     // Tap the desired photo in the grid
     // TODO: This currently only works for the first page of photos. It should scroll appropriately at some point.
@@ -829,7 +827,7 @@
     [tableView dragFromPoint:swipeStart displacement:swipeDisplacement steps:kNumberOfPointsInSwipePath];
     
     // Wait for the view to stabilize.
-    [tester waitForTimeInterval:0.5];
+    [tester waitForTimeInterval:0.5 relativeToAnimationSpeed:YES];
     
 }
 
@@ -1044,7 +1042,7 @@
         return KIFTestStepResultSuccess;
     }];
 
-    [self waitForTimeInterval:0.1]; // Let things settle.
+    [self waitForTimeInterval:0.1 relativeToAnimationSpeed:YES]; // Let things settle.
 
 
     return cell;
@@ -1091,7 +1089,10 @@
                            atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally | UICollectionViewScrollPositionCenteredVertically
                                    animated:YES];
 
-    [self waitForAnimationsToFinish];
+    // waitForAnimationsToFinish doesn't allow collection view to settle when animations are sped up
+    // So use waitForTimeInterval instead
+    const NSTimeInterval animationWaitTime = 0.5f;
+    [self waitForTimeInterval:animationWaitTime relativeToAnimationSpeed:YES];
     UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
 
     //For big collection views with many cells the cell might not be ready yet. Relayout and try again.
@@ -1099,8 +1100,9 @@
         [collectionView layoutIfNeeded];
         [collectionView scrollToItemAtIndexPath:indexPath
                                atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally | UICollectionViewScrollPositionCenteredVertically
-                                       animated:YES];
-        [self waitForAnimationsToFinish];
+                                       animated:NO];
+        // waitForAnimationsToFinish doesn't allow collection view to settle when animations are sped up
+        [self waitForTimeInterval:animationWaitTime relativeToAnimationSpeed:YES];
         cell = [collectionView cellForItemAtIndexPath:indexPath];
     }
     

--- a/Classes/UIAutomationHelper.m
+++ b/Classes/UIAutomationHelper.m
@@ -115,10 +115,10 @@ static void FixReactivateApp(void)
             [[alert.buttons lastObject] tap];
             while ([self _alertIsValidAndVisible:alert]) {
                 // Wait for button press to complete.
-                CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.1, false);
+                KIFRunLoopRunInModeRelativeToAnimationSpeed(UIApplicationCurrentRunMode, 0.1, false);
             }
             // Wait for alert dismissial animation.
-            CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.4, false);
+            KIFRunLoopRunInModeRelativeToAnimationSpeed(UIApplicationCurrentRunMode, 0.4, false);
             return YES;
 	}
     return NO;

--- a/Test Host/AppDelegate.m
+++ b/Test Host/AppDelegate.m
@@ -19,4 +19,10 @@
     return YES;
 }
 
+- (void)applicationDidBecomeActive:(UIApplication *)application
+{
+    // Uncomment the following line to run the tests with animations 100x faster
+    //UIApplication.sharedApplication.keyWindow.layer.speed = 100;
+}
+
 @end


### PR DESCRIPTION
This builds on #840 and adds a more central way to scale animation wait times relative to animation speed.

- created `waitForTimeInterval:relativeToAnimationSpeed:` to make it explicit when times are scaled.
- created `KIFRunLoopRunInModeRelativeToAnimationSpeed` to do the same for `CFRunLoopRunInMode`
- added an `animationSpeed` property to UIApplication to simplify getting and setting the keyWindow animation speed (and add some safety to prevent divide by 0 errors)

All tests pass locally with the animation speed set to 100.  I left in the commented code I used to run the tests with fast animations for others to verify.  Ideally, I'd prefer to have a way to run the tests on Travis at fast animation speeds in addition to normal speed.  I'm open to suggestions for how best to implement that.