### PR TITLE
Fix for cell reuse causing wrong elements to be tapped

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -50,6 +50,13 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
         return NO;
     }
     
+    // viewContainingAccessibilityElement:.. can cause scrolling, which can cause cell reuse.
+    // If this happens, the element we kept a reference to might have been reconfigured, and a
+    // different element might be the one that matches.
+    if (![UIView accessibilityElement:element hasLabel:label accessibilityValue:value traits:traits]) {
+        return NO;
+    }
+    
     if (foundElement) { *foundElement = element; }
     if (foundView) { *foundView = view; }
     return YES;

--- a/Additions/UIView-KIFAdditions.h
+++ b/Additions/UIView-KIFAdditions.h
@@ -22,6 +22,7 @@ typedef CGPoint KIFDisplacement;
 - (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label;
 - (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label traits:(UIAccessibilityTraits)traits;
 - (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label accessibilityValue:(NSString *)value traits:(UIAccessibilityTraits)traits;
++ (BOOL)accessibilityElement:(UIAccessibilityElement *)element hasLabel:(NSString *)label accessibilityValue:(NSString *)value traits:(UIAccessibilityTraits)traits;
 
 /*!
  @method accessibilityElementMatchingBlock:

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -101,25 +101,31 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 {
     return [self accessibilityElementMatchingBlock:^(UIAccessibilityElement *element) {
         
-        // TODO: This is a temporary fix for an SDK defect.
-        NSString *accessibilityValue = nil;
-        @try {
-            accessibilityValue = element.accessibilityValue;
-        }
-        @catch (NSException *exception) {
-            NSLog(@"KIF: Unable to access accessibilityValue for element %@ because of exception: %@", element, exception.reason);
-        }
+        return [UIView accessibilityElement:element hasLabel:label accessibilityValue:value traits:traits];
         
-        if ([accessibilityValue isKindOfClass:[NSAttributedString class]]) {
-            accessibilityValue = [(NSAttributedString *)accessibilityValue string];
-        }
-        
-        BOOL labelsMatch = StringsMatchExceptLineBreaks(label, element.accessibilityLabel);
-        BOOL traitsMatch = ((element.accessibilityTraits) & traits) == traits;
-        BOOL valuesMatch = !value || [value isEqual:accessibilityValue];
-
-        return (BOOL)(labelsMatch && traitsMatch && valuesMatch);
     }];
+}
+
++ (BOOL)accessibilityElement:(UIAccessibilityElement *)element hasLabel:(NSString *)label accessibilityValue:(NSString *)value traits:(UIAccessibilityTraits)traits
+{
+    // TODO: This is a temporary fix for an SDK defect.
+    NSString *accessibilityValue = nil;
+    @try {
+        accessibilityValue = element.accessibilityValue;
+    }
+    @catch (NSException *exception) {
+        NSLog(@"KIF: Unable to access accessibilityValue for element %@ because of exception: %@", element, exception.reason);
+    }
+    
+    if ([accessibilityValue isKindOfClass:[NSAttributedString class]]) {
+        accessibilityValue = [(NSAttributedString *)accessibilityValue string];
+    }
+    
+    BOOL labelsMatch = StringsMatchExceptLineBreaks(label, element.accessibilityLabel);
+    BOOL traitsMatch = ((element.accessibilityTraits) & traits) == traits;
+    BOOL valuesMatch = !value || [value isEqual:accessibilityValue];
+    
+    return (BOOL)(labelsMatch && traitsMatch && valuesMatch);
 }
 
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock;


### PR DESCRIPTION
In our tests, we had a step which tapped a cell in a collection view, identified by its accessibility label.  When the test ran, the collection view was initially offscreen, and while it was being scrolled onto the screen the collection view decided to recycle its cells.  KIF had kept a reference to the original cell which it then used to send the tap event.  As a result, the wrong cell in the collection view was tapped, and the test failed.

This PR addresses the problem by re-checking the accessibility element after calling the method which can cause scrolling.  <s>The logic for identifying accessibility elements which was in the view category has been moved into the accessibility element category so that it can be used in both places.</s>