### PR TITLE
Added KIFAccessibilityEnabler.h to KIFFramework

### DIFF
--- a/KIFFramework/KIF.h
+++ b/KIFFramework/KIF.h
@@ -20,6 +20,7 @@ FOUNDATION_EXPORT const unsigned char KIFVersionString[];
 
 #import <KIF/KIFTestActor.h>
 #import <KIF/KIFTestCase.h>
+#import <KIF/KIFAccessibilityEnabler.h>
 #import <KIF/KIFSystemTestActor.h>
 #import <KIF/KIFUITestActor.h>
 #import <KIF/KIFUITestActor-ConditionalTests.h>


### PR DESCRIPTION
This is to allow use of KIFAccessibilityEnabler in other testing frameworks/or when not using KIFTestCase.