### PR TITLE
Use scroll view delegate to reliably wait for scrolling to finish

### DIFF
--- a/Classes/KIFConstants.h
+++ b/Classes/KIFConstants.h
@@ -1,0 +1,13 @@
+//
+//  KIFConstants.h
+//  KIF
+//
+//  Created by Ashit Gandhi on 7/27/15.
+//
+//
+
+// The amount of time (in seconds) to wait for an event before terminating tests
+#define KIF_WAIT_TIMEOUT_INTERVAL   (30.0)
+
+// The amount of time (in seconds) to run the thread's runlooop before checking state again
+#define KIF_RUNLOOP_INTERVAL        (0.01)

--- a/Classes/KIFProxyDelegate.h
+++ b/Classes/KIFProxyDelegate.h
@@ -1,0 +1,22 @@
+//
+//  KIFProxyDelegate.h
+//  KIF
+//
+//
+
+#import <Foundation/Foundation.h>
+
+/*!
+ * @abstract @c KIFProxyDelegate serves as a proxy delegate between the @c original and @c replacement
+ * @discussion This class lets the @c replacement delegate intercept and act on all messages sent to this object, before @c original gets them. 
+ 
+   @c KIFProxyDelegate @b does @b not retain the delegates, so ensure the object representing the delegate is retain long enough for your use case.
+ */
+@interface KIFProxyDelegate : NSProxy
+
+@property (nonatomic, weak, readonly) id original;
+
+- (instancetype)initWithOriginalDelegate:(id)original
+                     replacementDelegate:(id)replacement;
+
+@end

--- a/Classes/KIFProxyDelegate.m
+++ b/Classes/KIFProxyDelegate.m
@@ -1,0 +1,51 @@
+//
+//  KIFProxyDelegate.m
+//  KIF
+//
+//  Created by Ashit Gandhi on 7/24/15.
+//
+//
+
+#import "KIFProxyDelegate.h"
+
+@interface KIFProxyDelegate ()
+@property (nonatomic, weak, readonly) id replacement;
+@end
+
+@implementation KIFProxyDelegate
+
+- (instancetype)initWithOriginalDelegate:(NSObject *)original
+                     replacementDelegate:(NSObject *)replacement
+{
+    _original = original;
+    _replacement = replacement;
+    return self;
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    if ([self.replacement respondsToSelector:anInvocation.selector]) {
+        [anInvocation invokeWithTarget:self.replacement];
+    }
+
+    if ([self.original respondsToSelector:anInvocation.selector]) {
+        [anInvocation invokeWithTarget:self.original];
+    }
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    if (self.original != nil && [self.original respondsToSelector:aSelector]) {
+        return [self.original methodSignatureForSelector:aSelector];
+    } else {
+        return [self.replacement methodSignatureForSelector:aSelector];
+    }
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    return [self.original respondsToSelector:aSelector] ||
+           [self.replacement respondsToSelector:aSelector];
+}
+
+@end

--- a/Classes/KIFScrollViewDelegates.h
+++ b/Classes/KIFScrollViewDelegates.h
@@ -1,0 +1,47 @@
+//
+//  KIFScrollViewDelegates.h
+//  KIF
+//
+//  Created by Ashit Gandhi on 7/24/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+/*!
+ * @abstract @c Generic scroll view delegate that allows to reliably wait for scrolling to complete.
+ * @discussion Objects of this class can serve a scroll view delegate. 
+               Note that scrolling has to start for the @c waitForScrollComplete* methods to be called.
+ */
+@interface KIFScrollViewDelegate : NSObject<UIScrollViewDelegate>
+
+/*!
+ * @abstract Resets scroll completion state if you want to reuse the same delegate object.
+ */
+- (void)reset;
+
+/*!
+ * @abstract Scrolling wait function for generic scroll views.
+ */
+- (BOOL)waitForScrollCompleteOnView:(UIView *)view inScrollView:(UIScrollView *)scrollView;
+
+@end
+
+@interface KIFCollectionViewDelegate : KIFScrollViewDelegate<UICollectionViewDelegate>
+
+/*!
+ * @abstract Scrolling wait function using collection view cell visibility logic.
+ */
+- (BOOL)waitForScrollCompleteToIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView;
+
+@end
+
+@interface KIFTableViewDelegate : KIFScrollViewDelegate<UITableViewDelegate>
+
+/*!
+ * @abstract Scrolling wait function using table views cell visibility logic.
+ */
+- (BOOL)waitForScrollCompleteToIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView;
+
+@end

--- a/Classes/KIFScrollViewDelegates.m
+++ b/Classes/KIFScrollViewDelegates.m
@@ -1,0 +1,180 @@
+//
+//  KIFScrollViewDelegates.m
+//  KIF
+//
+//  Created by Ashit Gandhi on 7/24/15.
+//
+//
+
+#import "KIFScrollViewDelegates.h"
+#import "KIFConstants.h"
+
+@interface KIFScrollViewDelegate ()
+@property (nonatomic, assign) BOOL scrollViewDidEndScrollingAnimation;
+@end
+
+typedef BOOL (^VisibilityTestBlock)();
+
+@implementation KIFScrollViewDelegate
+
+// UIScrollViewDelegate scrollViewDidScroll
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+    // This ensures that scrollViewDidEndScrollingAnimation is always called,
+    // whether the scrollview is animated or not,
+    // and that it's always called after scrollViewDidScroll,
+    // which could fire synchronously from within the scroll method, thus
+    // completing before any waits have started
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                                             selector:@selector(scrollViewDidEndScrollingAnimation:)
+                                               object:nil];
+    [self performSelector:@selector(scrollViewDidEndScrollingAnimation:)
+               withObject:nil
+               afterDelay:0.1f];
+}
+
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
+{
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                                             selector:@selector(scrollViewDidEndScrollingAnimation:)
+                                               object:nil];
+    self.scrollViewDidEndScrollingAnimation = YES;
+}
+
+- (void)reset
+{
+    self.scrollViewDidEndScrollingAnimation = NO;
+}
+
+- (BOOL)waitForScrollCompleteOnView:(UIView *)view inScrollView:(UIScrollView *)scrollView
+{
+    // The UITableViewWrapperView (introduced in iOS7) gets in the way.
+    // It doesn't update its content offset, so we cannot use it to judge if the cell is in view
+    if ([NSStringFromClass([scrollView class]) isEqualToString:@"UITableViewWrapperView"] &&
+        [scrollView.superview isKindOfClass:[UIScrollView class]]) {
+        scrollView = (UIScrollView *)scrollView.superview;
+    }
+
+    return [self waitForScrollViewDidEndScrollingAnimationOnView:^BOOL {
+        CGRect elementFrame = [view.window convertRect:view.accessibilityFrame
+                                                toView:scrollView];
+        CGRect visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y,
+                                        CGRectGetWidth(scrollView.bounds), CGRectGetHeight(scrollView.bounds));
+
+        return CGRectContainsRect(visibleRect, elementFrame);
+    }];
+}
+
+- (BOOL)waitForScrollViewDidEndScrollingAnimationOnView:(UIView *)view inScrollView:(UIScrollView *)scrollView
+{
+    @autoreleasepool {
+        NSDate *date;
+        NSDate *timeout = [NSDate dateWithTimeIntervalSinceNow:KIF_WAIT_TIMEOUT_INTERVAL]; // max wait timeout
+        CGRect viewFrame;
+        CGRect visibleRect;
+        do {
+            viewFrame = [view.window convertRect:view.frame toView:scrollView];
+            visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y,
+                                     CGRectGetWidth(scrollView.bounds), CGRectGetHeight(scrollView.bounds));
+
+            date = [NSDate dateWithTimeIntervalSinceNow:KIF_RUNLOOP_INTERVAL];
+            [[NSRunLoop currentRunLoop] runUntilDate:date];
+            if ([date compare:timeout] == NSOrderedDescending) {
+                return NO;
+            }
+        } while (!self.scrollViewDidEndScrollingAnimation || !CGRectContainsRect(visibleRect, viewFrame));
+        return YES;
+    }
+}
+
+- (BOOL)waitForScrollViewDidEndScrollingAnimationOnView:(VisibilityTestBlock)isVisibleBlock
+{
+    @autoreleasepool {
+        NSDate *date;
+        NSDate *timeout = [NSDate dateWithTimeIntervalSinceNow:KIF_WAIT_TIMEOUT_INTERVAL]; // max wait
+
+        // Ensure that we pump the runloop at least once before bailing
+        do {
+            date = [NSDate dateWithTimeIntervalSinceNow:KIF_RUNLOOP_INTERVAL];
+            [[NSRunLoop currentRunLoop] runUntilDate:date];
+            if ([date compare:timeout] == NSOrderedDescending) {
+                return NO;
+            }
+        } while (!self.scrollViewDidEndScrollingAnimation && !isVisibleBlock());
+        return YES;
+    }
+}
+
+@end
+
+@implementation KIFCollectionViewDelegate
+
+- (BOOL)waitForScrollCompleteToIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView
+{
+    return [self waitForScrollViewDidEndScrollingAnimationOnView:^BOOL {
+        return [KIFCollectionViewDelegate isItemAtIndexPath:indexPath alreadyVisibleIn:collectionView];
+    }];
+}
+
++ (BOOL)isItemAtIndexPath:(NSIndexPath *)indexPath alreadyVisibleIn:(UICollectionView *)collectionView
+{
+    for (UICollectionViewCell * testCell in [collectionView visibleCells]) {
+        NSIndexPath * itemIndexPath = [collectionView indexPathForCell:testCell];
+        if (itemIndexPath.section == indexPath.section && itemIndexPath.item == indexPath.item) {
+            CGRect itemRect = [testCell convertRect:testCell.frame toView:testCell.superview];
+            itemRect = [collectionView convertRect:itemRect toView:collectionView.superview];
+            CGRect collectionViewFrame = CGRectMake(collectionView.contentOffset.x, collectionView.contentOffset.y,
+                                                    collectionView.bounds.size.width, collectionView.bounds.size.height);
+
+            // Check the simplest contained case -- this works only if the item is visible without having to scroll at all
+            BOOL contained = CGRectContainsRect(collectionView.bounds, testCell.frame);
+            if (contained) {
+                return YES;
+            }
+
+            // If the itemRect is larger than the CV or is positioned so that it can never be fully within the VC, only verify if its midpoint is within the CV
+            if (itemRect.size.width > (collectionView.contentOffset.x + collectionViewFrame.size.width) ||
+                itemRect.size.height > (collectionView.contentOffset.y + collectionViewFrame.size.height)) {
+                return CGRectContainsPoint(collectionViewFrame,
+                                           CGPointMake(itemRect.origin.x + (itemRect.size.width/2),
+                                           itemRect.origin.y + (itemRect.size.height/2)));
+            }
+
+            // This does not work if the itemRect is larger than the collection view
+            return CGRectContainsRect(collectionViewFrame, itemRect);
+        }
+    }
+    return NO;
+}
+
+@end
+
+@implementation KIFTableViewDelegate
+
++ (BOOL)isRowAtIndexPath:(NSIndexPath *)indexPath alreadyVisibleIn:(UITableView *)tableView
+{
+    CGRect rowRect = [tableView rectForRowAtIndexPath:indexPath];
+    rowRect = [tableView convertRect:rowRect toView:tableView.superview];
+
+    // If the row's size (in any dimension) is > the table view's size,
+    // then we should return true if the row's midpoint is visible
+    if (rowRect.size.width > (tableView.contentOffset.x + tableView.frame.size.width) ||
+        rowRect.size.height > (tableView.contentOffset.y + tableView.frame.size.height)) {
+        return CGRectContainsPoint(tableView.frame,
+                                   CGPointMake(rowRect.origin.x + (rowRect.size.width/2),
+                                   rowRect.origin.y + (rowRect.size.height/2)));
+    }
+
+    // Otherwise, check if the full rect is contained
+    // This does not work if the rowRect is larger than the table view
+    return CGRectContainsRect(tableView.frame, rowRect);
+}
+
+- (BOOL)waitForScrollCompleteToIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView
+{
+    return [self waitForScrollViewDidEndScrollingAnimationOnView:^BOOL {
+        return [KIFTableViewDelegate isRowAtIndexPath:indexPath alreadyVisibleIn:tableView];
+    }];
+}
+
+@end

--- a/KIF Tests/ProxyDelegateTests.m
+++ b/KIF Tests/ProxyDelegateTests.m
@@ -1,0 +1,145 @@
+//
+//  ProxyDelegateTests.m
+//  KIF
+//
+//  Created by Jacek Suliga on 5/23/16.
+//
+//
+
+#import "KIFProxyDelegate.h"
+
+// Helper class for the original delegate
+@interface ProxyTestHelperOrg: NSObject
+
+@property (copy) dispatch_block_t functionAblock;
+@property (copy) dispatch_block_t functionBblock;
+@property (copy) dispatch_block_t functionCblock;
+
+@end
+
+@implementation ProxyTestHelperOrg
+
+-(void)sampleFunctionA
+{
+    if (self.functionAblock) {
+        self.functionAblock();
+    }
+}
+
+-(void)sampleFunctionB:(id)someObject
+{
+    if (self.functionBblock) {
+        self.functionBblock();
+    }
+}
+
+-(void)sampleFunctionC
+{
+    if (self.functionCblock) {
+        self.functionCblock();
+    }
+}
+
+@end
+
+// Helper class for the replacement delegate
+@interface ProxyTestHelperRepl: NSObject
+
+@property (copy) dispatch_block_t functionAblock;
+@property (copy) dispatch_block_t functionBblock;
+@property (copy) dispatch_block_t functionDblock;
+
+@end
+
+@implementation ProxyTestHelperRepl
+
+-(void)sampleFunctionA
+{
+    if (self.functionAblock) {
+        self.functionAblock();
+    }
+}
+
+-(void)sampleFunctionB:(id)someObject
+{
+    if (self.functionBblock) {
+        self.functionBblock();
+    }
+}
+
+-(void)sampleFunctionD
+{
+    if (self.functionDblock) {
+        self.functionDblock();
+    }
+}
+
+@end
+
+
+@interface ProxyDelegateTests: XCTestCase
+@end
+
+@implementation ProxyDelegateTests
+
+-(void)testDelegate {
+    // Configure original "delegate"
+    ProxyTestHelperOrg * original = [ProxyTestHelperOrg new];
+
+    __block BOOL originalAcalled = NO;
+    __block BOOL originalBcalled = NO;
+    __block BOOL originalCcalled = NO;
+
+    original.functionAblock = ^{
+        originalAcalled = YES;
+    };
+    original.functionBblock = ^{
+        originalBcalled = YES;
+    };
+    original.functionCblock = ^{
+        originalCcalled = YES;
+    };
+
+    // Configure replacement "delegate"
+    ProxyTestHelperRepl * replacement = [ProxyTestHelperRepl new];
+
+    __block BOOL replacementAcalled = NO;
+    __block BOOL replacementBcalled = NO;
+    __block BOOL replacementDcalled = NO;
+
+    replacement.functionAblock = ^{
+        replacementAcalled = YES;
+    };
+    replacement.functionBblock = ^{
+        replacementBcalled = YES;
+    };
+    replacement.functionDblock = ^{
+        replacementDcalled = YES;
+    };
+
+    KIFProxyDelegate * proxyDelegate = [[KIFProxyDelegate alloc] initWithOriginalDelegate:original replacementDelegate:replacement];
+
+    // Calling function A on proxyDelegate should call function A on the replacement and original as well
+    [proxyDelegate performSelector:@selector(sampleFunctionA)];
+    XCTAssert(replacementAcalled && originalAcalled, @"Replacement not called, or original not called!");
+
+    // Calling function B on proxyDelegate should call function B on the replacement, and original as well
+    [proxyDelegate performSelector:@selector(sampleFunctionB:) withObject:self];
+    XCTAssert(replacementBcalled && originalBcalled, @"Replacement not called, or original not called!");
+
+    // Calling function C on proxyDelegate should call function C on the original, as replacement does not implement it
+    [proxyDelegate performSelector:@selector(sampleFunctionC)];
+    XCTAssert(originalCcalled, @"Original not called");
+
+    // Calling function D on proxyDelegate should call function D on the replacement, as only it implements it
+    [proxyDelegate performSelector:@selector(sampleFunctionD)];
+    XCTAssert(replacementDcalled, @"Replacement not called");
+
+    // Final state for the original delegate
+    XCTAssert(originalAcalled && originalBcalled && originalCcalled, @"Original not called");
+
+    // Final state for the replacement delegate
+    XCTAssert(replacementAcalled && replacementBcalled && replacementDcalled, @"Replacement not called");
+}
+
+@end

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		0EAA1C141B4B371700FFB2FB /* IOHIDEvent+KIF.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */; };
 		0EAA1C171B4B372700FFB2FB /* IOHIDEvent+KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EAA1C111B4B371700FFB2FB /* IOHIDEvent+KIF.h */; };
 		0EAA1C181B4B372700FFB2FB /* IOHIDEvent+KIF.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */; };
+		12C111261CF40B3700390595 /* KIFProxyDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 12C111241CF40B3700390595 /* KIFProxyDelegate.h */; };
+		12C111271CF40B3700390595 /* KIFProxyDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C111251CF40B3700390595 /* KIFProxyDelegate.m */; };
+		12C111291CF410F900390595 /* ProxyDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C111281CF410F900390595 /* ProxyDelegateTests.m */; };
+		12C1112C1CF4127900390595 /* KIFScrollViewDelegates.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C1112B1CF4127900390595 /* KIFScrollViewDelegates.m */; };
 		2CDEE1CB181DBED200DF6E63 /* PickerController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CDEE1CA181DBED200DF6E63 /* PickerController.m */; };
 		2EE12710198991920031D347 /* MultiFingerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EE1270F198991920031D347 /* MultiFingerTests.m */; };
 		3812FB611A1212A700335733 /* AnimationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3812FB601A1212A700335733 /* AnimationViewController.m */; };
@@ -267,6 +271,12 @@
 /* Begin PBXFileReference section */
 		0EAA1C111B4B371700FFB2FB /* IOHIDEvent+KIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IOHIDEvent+KIF.h"; sourceTree = "<group>"; };
 		0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IOHIDEvent+KIF.m"; sourceTree = "<group>"; };
+		12C111241CF40B3700390595 /* KIFProxyDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFProxyDelegate.h; sourceTree = "<group>"; };
+		12C111251CF40B3700390595 /* KIFProxyDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFProxyDelegate.m; sourceTree = "<group>"; };
+		12C111281CF410F900390595 /* ProxyDelegateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ProxyDelegateTests.m; sourceTree = "<group>"; };
+		12C1112A1CF4127900390595 /* KIFScrollViewDelegates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFScrollViewDelegates.h; sourceTree = "<group>"; };
+		12C1112B1CF4127900390595 /* KIFScrollViewDelegates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFScrollViewDelegates.m; sourceTree = "<group>"; };
+		12C1112D1CF4161000390595 /* KIFConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFConstants.h; sourceTree = "<group>"; };
 		2CDEE1CA181DBED200DF6E63 /* PickerController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PickerController.m; sourceTree = "<group>"; };
 		2CED883D181F5EE1005ABD20 /* PickerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PickerTests.m; sourceTree = "<group>"; };
 		2EE1270F198991920031D347 /* MultiFingerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultiFingerTests.m; sourceTree = "<group>"; };
@@ -608,6 +618,11 @@
 				BD6A1CA01BCE8DD000EF07D2 /* KIFAccessibilityEnabler.m */,
 				0EAA1C111B4B371700FFB2FB /* IOHIDEvent+KIF.h */,
 				0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */,
+				12C111241CF40B3700390595 /* KIFProxyDelegate.h */,
+				12C111251CF40B3700390595 /* KIFProxyDelegate.m */,
+				12C1112A1CF4127900390595 /* KIFScrollViewDelegates.h */,
+				12C1112B1CF4127900390595 /* KIFScrollViewDelegates.m */,
+				12C1112D1CF4161000390595 /* KIFConstants.h */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -772,6 +787,7 @@
 				5A62B0AD1BB205CA00A3F480 /* PullToRefreshTests.m */,
 				EB60ED0A177F90BA005A041A /* SystemTests.m */,
 				5F6A1B371C191F9600F20F22 /* UIApplicationKIFAdditionsTests.m */,
+				12C111281CF410F900390595 /* ProxyDelegateTests.m */,
 				EB60ECF0177F8DB3005A041A /* Supporting Files */,
 			);
 			path = "KIF Tests";
@@ -926,6 +942,7 @@
 				EABD46A01857A0C700A5F081 /* KIFUITestActor.h in Headers */,
 				EABD46A11857A0C700A5F081 /* NSBundle-KIFAdditions.h in Headers */,
 				EAC8096A1864F19C000E819F /* NSException-KIFAdditions.h in Headers */,
+				12C111261CF40B3700390595 /* KIFProxyDelegate.h in Headers */,
 				EABD46961857A0C700A5F081 /* XCTestCase-KIFAdditions.h in Headers */,
 				E977D1071AA4062B005645BF /* UIEvent+KIFAdditions.h in Headers */,
 				BD6A1CA11BCE8DD000EF07D2 /* KIFAccessibilityEnabler.h in Headers */,
@@ -1218,6 +1235,7 @@
 				EB1A44D61A0C3268004A3F61 /* KIFUITestActor-IdentifierTests.m in Sources */,
 				EB2526491981BF7A00DBC747 /* KIFUITestActor-ConditionalTests.m in Sources */,
 				E977D1081AA4062B005645BF /* UIEvent+KIFAdditions.m in Sources */,
+				12C111271CF40B3700390595 /* KIFProxyDelegate.m in Sources */,
 				85DB946F1C5A3E860025F83E /* CALayer-KIFAdditions.m in Sources */,
 				EABD46871857A0C700A5F081 /* KIFSystemTestActor.m in Sources */,
 				EAC8096B1864F19C000E819F /* NSException-KIFAdditions.m in Sources */,
@@ -1237,6 +1255,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				12C111291CF410F900390595 /* ProxyDelegateTests.m in Sources */,
 				FA8A3C591A771C5500206350 /* SearchFieldTests_ViewTestActor.m in Sources */,
 				FA8A3C551A77157F00206350 /* LongPressTests_ViewTestActor.m in Sources */,
 				FA49155E1A78206E00A78E57 /* CompositionTests_ViewTestActor.m in Sources */,
@@ -1289,6 +1308,7 @@
 				FA4915651A7827D000A78E57 /* PickerTests_ViewTestActor.m in Sources */,
 				84D293B11A2C891700C10944 /* SystemAlertTests.m in Sources */,
 				BFE470901C7F44F700580EF9 /* UIScreen+KIFAdditionsTests.m in Sources */,
+				12C1112C1CF4127900390595 /* KIFScrollViewDelegates.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -12,10 +12,17 @@
 		0EAA1C141B4B371700FFB2FB /* IOHIDEvent+KIF.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */; };
 		0EAA1C171B4B372700FFB2FB /* IOHIDEvent+KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EAA1C111B4B371700FFB2FB /* IOHIDEvent+KIF.h */; };
 		0EAA1C181B4B372700FFB2FB /* IOHIDEvent+KIF.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */; };
+		125D35281CF4DE0700A7F87F /* KIFProxyDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C111251CF40B3700390595 /* KIFProxyDelegate.m */; };
+		125D35291CF4DE1100A7F87F /* KIFScrollViewDelegates.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C1112B1CF4127900390595 /* KIFScrollViewDelegates.m */; };
+		125D352A1CF4DE1200A7F87F /* KIFScrollViewDelegates.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C1112B1CF4127900390595 /* KIFScrollViewDelegates.m */; };
+		125D352B1CF4DE5000A7F87F /* KIFProxyDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 12C111241CF40B3700390595 /* KIFProxyDelegate.h */; };
+		125D352C1CF4DE5500A7F87F /* KIFScrollViewDelegates.h in Headers */ = {isa = PBXBuildFile; fileRef = 12C1112A1CF4127900390595 /* KIFScrollViewDelegates.h */; };
+		125D352D1CF4DE5500A7F87F /* KIFScrollViewDelegates.h in Headers */ = {isa = PBXBuildFile; fileRef = 12C1112A1CF4127900390595 /* KIFScrollViewDelegates.h */; };
+		125D352E1CF4DE5900A7F87F /* KIFConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 12C1112D1CF4161000390595 /* KIFConstants.h */; };
+		125D352F1CF4DE5900A7F87F /* KIFConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 12C1112D1CF4161000390595 /* KIFConstants.h */; };
 		12C111261CF40B3700390595 /* KIFProxyDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 12C111241CF40B3700390595 /* KIFProxyDelegate.h */; };
 		12C111271CF40B3700390595 /* KIFProxyDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C111251CF40B3700390595 /* KIFProxyDelegate.m */; };
 		12C111291CF410F900390595 /* ProxyDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C111281CF410F900390595 /* ProxyDelegateTests.m */; };
-		12C1112C1CF4127900390595 /* KIFScrollViewDelegates.m in Sources */ = {isa = PBXBuildFile; fileRef = 12C1112B1CF4127900390595 /* KIFScrollViewDelegates.m */; };
 		2CDEE1CB181DBED200DF6E63 /* PickerController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CDEE1CA181DBED200DF6E63 /* PickerController.m */; };
 		2EE12710198991920031D347 /* MultiFingerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EE1270F198991920031D347 /* MultiFingerTests.m */; };
 		3812FB611A1212A700335733 /* AnimationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3812FB601A1212A700335733 /* AnimationViewController.m */; };
@@ -889,9 +896,11 @@
 				FAB89FB41CAAECBF00C6DFC1 /* KIFUIViewTestActor.h in Headers */,
 				9CC9677C1AD4B20700576D13 /* KIFTestActor.h in Headers */,
 				9CC9677F1AD4B20700576D13 /* KIFTypist.h in Headers */,
+				125D352C1CF4DE5500A7F87F /* KIFScrollViewDelegates.h in Headers */,
 				9CC967811AD4B20700576D13 /* KIFTestStepValidation.h in Headers */,
 				9CC967751AD4B1FF00576D13 /* KIFUITestActor.h in Headers */,
 				9CC967771AD4B1FF00576D13 /* KIFUITestActor-ConditionalTests.h in Headers */,
+				125D352B1CF4DE5000A7F87F /* KIFProxyDelegate.h in Headers */,
 				FAB89FB61CAAED4A00C6DFC1 /* NSPredicate+KIFAdditions.h in Headers */,
 				9CC967611AD4B1F100576D13 /* UITouch-KIFAdditions.h in Headers */,
 				9CC967631AD4B1F100576D13 /* UIView-KIFAdditions.h in Headers */,
@@ -905,6 +914,7 @@
 				9CC9676F1AD4B1F100576D13 /* NSException-KIFAdditions.h in Headers */,
 				9CC967711AD4B1F100576D13 /* UIEvent+KIFAdditions.h in Headers */,
 				9CC967841AD4B20700576D13 /* UIAutomationHelper.h in Headers */,
+				125D352E1CF4DE5900A7F87F /* KIFConstants.h in Headers */,
 				FAB89FBA1CAAED6800C6DFC1 /* KIFUIObject.h in Headers */,
 				FA7176951CAEE6120041FEEE /* CALayer-KIFAdditions.h in Headers */,
 			);
@@ -936,6 +946,7 @@
 				EABD469B1857A0C700A5F081 /* LoadableCategory.h in Headers */,
 				FA8BDCCD1A76B3A80042A989 /* KIFUIObject.h in Headers */,
 				EABD469C1857A0C700A5F081 /* KIFTypist.h in Headers */,
+				125D352D1CF4DE5500A7F87F /* KIFScrollViewDelegates.h in Headers */,
 				EABD469D1857A0C700A5F081 /* KIFTestActor.h in Headers */,
 				EABD469E1857A0C700A5F081 /* KIFTestCase.h in Headers */,
 				EABD469F1857A0C700A5F081 /* KIFSystemTestActor.h in Headers */,
@@ -944,6 +955,7 @@
 				EAC8096A1864F19C000E819F /* NSException-KIFAdditions.h in Headers */,
 				12C111261CF40B3700390595 /* KIFProxyDelegate.h in Headers */,
 				EABD46961857A0C700A5F081 /* XCTestCase-KIFAdditions.h in Headers */,
+				125D352F1CF4DE5900A7F87F /* KIFConstants.h in Headers */,
 				E977D1071AA4062B005645BF /* UIEvent+KIFAdditions.h in Headers */,
 				BD6A1CA11BCE8DD000EF07D2 /* KIFAccessibilityEnabler.h in Headers */,
 				EABD46A21857A0C700A5F081 /* NSError-KIFAdditions.h in Headers */,
@@ -1186,10 +1198,12 @@
 				9CC967D51AD4B5B900576D13 /* KIFUITestActor-IdentifierTests.m in Sources */,
 				9CC967CD1AD4B59A00576D13 /* KIFSystemTestActor.m in Sources */,
 				9CC967CE1AD4B59A00576D13 /* KIFUITestActor.m in Sources */,
+				125D35281CF4DE0700A7F87F /* KIFProxyDelegate.m in Sources */,
 				FAB89FB91CAAED6500C6DFC1 /* KIFUIObject.m in Sources */,
 				9CC967CF1AD4B59A00576D13 /* KIFUITestActor-ConditionalTests.m in Sources */,
 				9CC967BF1AD4B58C00576D13 /* CGGeometry-KIFAdditions.m in Sources */,
 				FAB89FB31CAAECB100C6DFC1 /* KIFUIViewTestActor.m in Sources */,
+				125D352A1CF4DE1200A7F87F /* KIFScrollViewDelegates.m in Sources */,
 				9CC967C01AD4B58C00576D13 /* NSFileManager-KIFAdditions.m in Sources */,
 				9CC967C11AD4B58C00576D13 /* UIAccessibilityElement-KIFAdditions.m in Sources */,
 				9CC967C21AD4B58C00576D13 /* UIApplication-KIFAdditions.m in Sources */,
@@ -1230,6 +1244,7 @@
 				D927B9E018F9E46400DAD036 /* UITableView-KIFAdditions.m in Sources */,
 				EABD46831857A0C700A5F081 /* KIFTypist.m in Sources */,
 				EABD46841857A0C700A5F081 /* KIFTestActor.m in Sources */,
+				125D35291CF4DE1100A7F87F /* KIFScrollViewDelegates.m in Sources */,
 				EABD46851857A0C700A5F081 /* KIFTestCase.m in Sources */,
 				EABD46861857A0C700A5F081 /* XCTestCase-KIFAdditions.m in Sources */,
 				EB1A44D61A0C3268004A3F61 /* KIFUITestActor-IdentifierTests.m in Sources */,
@@ -1308,7 +1323,6 @@
 				FA4915651A7827D000A78E57 /* PickerTests_ViewTestActor.m in Sources */,
 				84D293B11A2C891700C10944 /* SystemAlertTests.m in Sources */,
 				BFE470901C7F44F700580EF9 /* UIScreen+KIFAdditionsTests.m in Sources */,
-				12C1112C1CF4127900390595 /* KIFScrollViewDelegates.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Instead of hard coded arbitrary waits, use scroll view proxy delegate to wait for scrolling to finish.
This removes the need to wait for an arbitrary amount of time (which may not be enough for slower machines, or may be too long for faster ones).
On a relatively new machine, this improves performance for lookups in scroll views (table views and collection views) by 2x and more.
