### PR TITLE
Update Test cases for [hopefully] better travis results

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -465,7 +465,7 @@
         KIFTestWaitCondition([actual isEqualToString:expected], error, @"Failed to get text \"%@\" in field; instead, it was \"%@\"", expected, actual);
         
         return KIFTestStepResultSuccess;
-    } timeout:1.0];
+    } timeout:[KIFTestActor defaultTimeout]];
 }
 
 - (void)clearTextFromFirstResponder

--- a/Classes/KIFUIViewTestActor.h
+++ b/Classes/KIFUIViewTestActor.h
@@ -17,6 +17,15 @@
 @property (nonatomic, strong, readonly) UIAccessibilityElement *element;
 @property (nonatomic, strong, readonly) NSPredicate *predicate;
 
+
+/*!
+ @abstract a static string to use when typing into text fields.
+ @discussion Do not change this string to something that would be auto-corrected
+ For example, "string-to-test" might be auto-corrected to some other string
+ and hence cause a test to fail.
+ */
+extern NSString *const inputFieldTestString;
+
 #pragma mark - Searching for Accessibility Elements
 /*!
  These methods are used to build the tester's search predicate. they are intended to be chained together allowing for complex searches.

--- a/Classes/KIFUIViewTestActor.m
+++ b/Classes/KIFUIViewTestActor.m
@@ -23,6 +23,8 @@
 
 @implementation KIFUIViewTestActor
 
+NSString *const inputFieldTestString = @"Testing";
+
 #pragma mark - Initialization
 
 - (instancetype)usingPredicate:(NSPredicate *)predicate;

--- a/KIF Tests/MultiFingerTests.m
+++ b/KIF Tests/MultiFingerTests.m
@@ -42,8 +42,10 @@
     self.latestRotation = 0;
 }
 
-- (void)testTwoFingerTap {
+- (void)testTwoFingerTap
+{
     UIScrollView *scrollView = (UIScrollView *)[tester waitForViewWithAccessibilityLabel:@"Scroll View"];
+	[tester waitForAnimationsToFinish];
     UITapGestureRecognizer *twoFingerTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                                              action:@selector(twoFingerTapped)];
     twoFingerTapRecognizer.numberOfTouchesRequired = 2;
@@ -55,7 +57,8 @@
     [scrollView removeGestureRecognizer:twoFingerTapRecognizer];
 }
 
-- (void)twoFingerTapped {
+- (void)twoFingerTapped
+{
     self.twoFingerTapSuccess = YES;
 }
 
@@ -64,6 +67,7 @@
     CGFloat offset = 50.0;
 
     UIScrollView *scrollView = (UIScrollView *)[tester waitForViewWithAccessibilityLabel:@"Scroll View"];
+	[tester waitForAnimationsToFinish];
     UIPanGestureRecognizer *panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingerPanned:)];
     panGestureRecognizer.minimumNumberOfTouches = 2;
     [scrollView addGestureRecognizer:panGestureRecognizer];
@@ -88,6 +92,7 @@
     CGFloat distance = 50.0;
 
     UIScrollView *scrollView = (UIScrollView *)[tester waitForViewWithAccessibilityLabel:@"Scroll View"];
+	[tester waitForAnimationsToFinish];
     UIPinchGestureRecognizer *pinchRecognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self
                                                                                           action:@selector(zoomed:)];
 
@@ -114,6 +119,7 @@
 
 - (void)testRotate {
     UIScrollView *scrollView = (UIScrollView *)[tester waitForViewWithAccessibilityLabel:@"Scroll View"];
+	[tester waitForAnimationsToFinish];
     UIRotationGestureRecognizer *rotateRecognizer =
         [[UIRotationGestureRecognizer alloc] initWithTarget:self action:@selector(rotated:)];
 

--- a/KIF Tests/MultiFingerTests_ViewTestActor.m
+++ b/KIF Tests/MultiFingerTests_ViewTestActor.m
@@ -41,6 +41,7 @@
     CGFloat offset = 50.0;
 
     UIScrollView *scrollView = (UIScrollView *)[viewTester usingLabel:@"Scroll View"].view;
+	[tester waitForAnimationsToFinish];
     UIPanGestureRecognizer *panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingerPanned)];
     panGestureRecognizer.minimumNumberOfTouches = 2;
     [scrollView addGestureRecognizer:panGestureRecognizer];
@@ -62,6 +63,7 @@
     CGFloat distance = 50.0;
 
     UIScrollView *scrollView = (UIScrollView *)[viewTester usingLabel:@"Scroll View"].view;
+	[tester waitForAnimationsToFinish];
     UIPinchGestureRecognizer *pinchRecognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self
                                                                                           action:@selector(zoomed:)];
 

--- a/KIF Tests/TableViewTests.m
+++ b/KIF Tests/TableViewTests.m
@@ -146,7 +146,7 @@
 
 - (void)testEnteringTextIntoATextFieldInATableCell
 {
-    [tester enterText:@"Test-Driven Development" intoViewWithAccessibilityLabel:@"TextField"];
+    [tester enterText:inputFieldTestString intoViewWithAccessibilityLabel:@"TextField"];
 }
 
 // Delete first and last rows in table view
@@ -154,7 +154,7 @@
     
     UITableView *tableView;
     [tester waitForAccessibilityElement:NULL view:&tableView withIdentifier:@"TableView Tests Table" tappable:NO];
-    
+	[tester waitForAnimationsToFinish];
     // First row
     NSIndexPath *firstCellPath = [NSIndexPath indexPathForRow:0 inSection:0];
     [tester swipeRowAtIndexPath:firstCellPath inTableView:tableView inDirection:KIFSwipeDirectionLeft];

--- a/KIF Tests/TableViewTests_ViewTestActor.m
+++ b/KIF Tests/TableViewTests_ViewTestActor.m
@@ -109,6 +109,7 @@
     [[viewTester usingLabel:@"Edit"] tap];
 
     __KIFAssertEqualObjects([[viewTester usingIdentifier:@"TableView Tests Table"] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:-3 inSection:1]].textLabel.text, @"Cell 35", @"");
+	[viewTester waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:1]];
     __KIFAssertEqualObjects([[viewTester usingIdentifier:@"TableView Tests Table"] waitForCellInTableViewAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:1]].textLabel.text, @"Cell 37", @"");
 
     [[viewTester usingIdentifier:@"TableView Tests Table"] moveRowInTableViewAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:1] toIndexPath:[NSIndexPath indexPathForRow:-3 inSection:1]];
@@ -148,7 +149,7 @@
 
 - (void)testEnteringTextIntoATextFieldInATableCell
 {
-    [[viewTester usingLabel:@"TextField"] enterText:@"Test-Driven Development"];
+    [[viewTester usingLabel:@"TextField"] enterText:inputFieldTestString];
 }
 
 @end


### PR DESCRIPTION
After running the test cases locally on both hardware and sim
it was noticed that some tests needed a bit more waiting to run
reliably. Perhaps running too fast on robust platform?

Notably:
Tests that type into input fields:
* In "(void)expectView:(UIView *)view toContainText:(NSString *)expectedResult"
the timeout was set to 1.0. This bumps it up to 2.0. Seems to stabilize field tests.
The community will also benefit from this change.
* Predictive text was getting in the way of typing the string, "Test-Driven Development".
The text was getting auto-corrected.  This PR changes it to "Testing"

Tests that utilize gestures:
* MultiFinger and TableView Tests benefit from waitFor... method calls.