### PR TITLE
Added waitForDeleteStateForCell* methods to reliably wait for cell delete state changes

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -675,6 +675,18 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 */
 - (void)swipeRowAtIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView inDirection:(KIFSwipeDirection)direction;
 
+/*!
+ @abstract Waits for the given cell to transition to the delete state. Useful when swiping left on a cell for delete action.
+ @param cell Cell to wait for delete state on.
+ */
+- (void)waitForDeleteStateForCell:(UITableViewCell*)cell;
+
+/*!
+ @abstract Waits for the given cell to transition to the delete state. Useful when swiping left on a cell for delete action.
+ @param indexPath Index path of the row to wait for the delete state on.
+ @param tableView Table view to operate on.
+ */
+- (void)waitForDeleteStateForCellAtIndexPath:(NSIndexPath*)indexPath inTableView:(UITableView*)tableView;
 
 /*!
  @abstract Backgrounds app using UIAutomation command, simulating pressing the Home button

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -831,6 +831,19 @@
     
 }
 
+- (void)waitForDeleteStateForCellAtIndexPath:(NSIndexPath*)indexPath inTableView:(UITableView*)tableView {
+    UITableViewCell *cell = [self waitForCellAtIndexPath:indexPath inTableView:tableView];
+    [self waitForDeleteStateForCell:cell];
+}
+
+- (void)waitForDeleteStateForCell:(UITableViewCell*)cell {
+    [self runBlock:^KIFTestStepResult(NSError **error) {
+        KIFTestWaitCondition(cell.showingDeleteConfirmation, error,
+                             @"Expected cell to get in the delete confirmation state: %@", cell);
+        return KIFTestStepResultSuccess;
+    }];
+}
+
 - (void)tapItemAtIndexPath:(NSIndexPath *)indexPath inCollectionViewWithAccessibilityIdentifier:(NSString *)identifier
 {
     UICollectionView *collectionView;

--- a/KIF Tests/TableViewTests.m
+++ b/KIF Tests/TableViewTests.m
@@ -156,13 +156,17 @@
     [tester waitForAccessibilityElement:NULL view:&tableView withIdentifier:@"TableView Tests Table" tappable:NO];
     
     // First row
-    [tester swipeRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inTableView:tableView inDirection:KIFSwipeDirectionLeft];
+    NSIndexPath *firstCellPath = [NSIndexPath indexPathForRow:0 inSection:0];
+    [tester swipeRowAtIndexPath:firstCellPath inTableView:tableView inDirection:KIFSwipeDirectionLeft];
+    [tester waitForDeleteStateForCellAtIndexPath:firstCellPath inTableView:tableView];
     [tester tapViewWithAccessibilityLabel:@"Delete"];
     
     __KIFAssertEqualObjects([tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
     
     // Last row
-    [tester swipeRowAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:2] inTableView:tableView inDirection:KIFSwipeDirectionLeft];
+    NSIndexPath *lastCellPath = [NSIndexPath indexPathForRow:1 inSection:2];
+    [tester swipeRowAtIndexPath:lastCellPath inTableView:tableView inDirection:KIFSwipeDirectionLeft];
+    [tester waitForDeleteStateForCellAtIndexPath:lastCellPath inTableView:tableView];
     [tester tapViewWithAccessibilityLabel:@"Delete"];
     
     __KIFAssertEqualObjects([tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:2] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");

--- a/KIF Tests/TableViewTests.m
+++ b/KIF Tests/TableViewTests.m
@@ -161,7 +161,7 @@
     [tester waitForDeleteStateForCellAtIndexPath:firstCellPath inTableView:tableView];
     [tester tapViewWithAccessibilityLabel:@"Delete"];
     
-    __KIFAssertEqualObjects([tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
+    __KIFAssertEqualObjects([tester waitForCellAtIndexPath:firstCellPath inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
     
     // Last row
     NSIndexPath *lastCellPath = [NSIndexPath indexPathForRow:1 inSection:2];
@@ -169,8 +169,7 @@
     [tester waitForDeleteStateForCellAtIndexPath:lastCellPath inTableView:tableView];
     [tester tapViewWithAccessibilityLabel:@"Delete"];
     
-    __KIFAssertEqualObjects([tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:2] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
-    
+    __KIFAssertEqualObjects([tester waitForCellAtIndexPath:lastCellPath inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
 }
 
 @end


### PR DESCRIPTION
These APIs are useful to know when it's safe to perform delete operations when swiping left on table view cells in the edit mode.