### PR TITLE
Added "setText:intoViewWithAccessibilityIdentifier:" helper function

### DIFF
--- a/Additions/CAAnimation+KIFAdditions.h
+++ b/Additions/CAAnimation+KIFAdditions.h
@@ -1,0 +1,15 @@
+//
+//  CAAnimation+KIFAdditions.h
+//  Pods
+//
+//  Created by Justin Martin on 6/6/16.
+//
+
+#import <QuartzCore/QuartzCore.h>
+
+
+@interface CAAnimation (KIFAdditions)
+
+- (double)KIF_completionTime;
+
+@end

--- a/Additions/CAAnimation+KIFAdditions.m
+++ b/Additions/CAAnimation+KIFAdditions.m
@@ -1,0 +1,26 @@
+//
+//  CAAnimation+KIFAdditions.m
+//  Pods
+//
+//  Created by Justin Martin on 6/6/16.
+//
+
+#import "CAAnimation+KIFAdditions.h"
+
+
+@implementation CAAnimation (KIFAdditions)
+
+- (double)KIF_completionTime;
+{
+    if (self.repeatDuration > 0) {
+        return self.beginTime + self.repeatDuration;
+    } else if (self.repeatCount == HUGE_VALF) {
+        return HUGE_VALF;
+    } else if (self.repeatCount > 0) {
+        return self.beginTime + (self.repeatCount * self.duration);
+    } else {
+        return self.beginTime + self.duration;
+    }
+}
+
+@end

--- a/Additions/UIAccessibilityElement-KIFAdditions.h
+++ b/Additions/UIAccessibilityElement-KIFAdditions.h
@@ -35,6 +35,20 @@
 + (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits tappable:(BOOL)mustBeTappable error:(out NSError **)error;
 
 /*!
+ @abstract Finds an accessibility element and view with a matching label, value, and traits, optionally passing a tappability test.
+ @discussion This method combines @c +accessibilityElementWithLabel:value:traits:error: and @c +viewContainingAccessibilityElement:tappable:error: for convenience.
+ @param foundElement The found accessibility element or @c nil if the method returns @c NO.  Can be @c NULL.
+ @param foundView The first matching view for @c foundElement as determined by the accessibility API or @c nil if the view is hidden or fails the tappability test. Can be @c NULL.
+ @param label The accessibility label of the element to wait for.
+ @param value The accessibility value of the element to tap.
+ @param traits The accessibility traits of the element to wait for. Elements that do not include at least these traits are ignored.
+ @param fromView The root view to start looking for the accessibility element.
+ @param error A reference to an error object to be populated when no matching element or view is found.  Can be @c NULL.
+ @result @c YES if the element and view were found.  Otherwise @c NO.
+ */
++ (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError **)error;
+
+/*!
  @abstract Finds an accessibility element with a matching label, value, and traits.
  @discussion This functionality is identical to <tt>-[UIApplication accessibilityElementWithLabel:accessibilityValue:traits:]</tt> except that it detailed error messaging in the case where the element cannot be found.
  @param label The accessibility label of the element to wait for.
@@ -44,6 +58,29 @@
  @return The found accessibility element.  If @c nil see the @c error for a detailed reason.
  */
 + (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits error:(out NSError **)error;
+
+/*!
+ @abstract Finds an accessibility element with a matching label, value, and traits from specified root view.
+ @discussion This functionality is identical to <tt>-[UIApplication accessibilityElementWithLabel:accessibilityValue:traits:]</tt> except that it detailed error messaging in the case where the element cannot be found.
+ @param label The accessibility label of the element to wait for.
+ @param value The accessibility value of the element to tap.
+ @param traits The accessibility traits of the element to wait for. Elements that do not include at least these traits are ignored.
+ @param fromRootView The root view to start looking for the accessibility element.
+ @param error A reference to an error object to be populated when no element is found.  Can be @c NULL.
+ @return The found accessibility element.  If @c nil see the @c error for a detailed reason.
+ */
++ (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView error:(out NSError **)error;
+
+/*!
+ @abstract Finds an accessibility element and view from the specified root view where the element passes the predicate, optionally passing a tappability test.
+ @param foundElement The found accessibility element or @c nil if the method returns @c NO.  Can be @c NULL.
+ @param foundView The first matching view for @c foundElement as determined by the accessibility API or @c nil if the view is hidden or fails the tappability test. Can be @c NULL.
+ @param fromRootView The root view to start looking for the accessibility element.
+ @param predicate The predicate to test the accessibility element on.
+ @param error A reference to an error object to be populated when no matching element or view is found.  Can be @c NULL.
+ @result @c YES if the element and view were found.  Otherwise @c NO.
+ */
++ (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withElementMatchingPredicate:(NSPredicate *)predicate fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError **)error;
 
 /*!
  @abstract Finds an accessibility element and view where the element passes the predicate, optionally passing a tappability test.

--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -50,6 +50,13 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
         return NO;
     }
     
+    // viewContainingAccessibilityElement:.. can cause scrolling, which can cause cell reuse.
+    // If this happens, the element we kept a reference to might have been reconfigured, and a
+    // different element might be the one that matches.
+    if (![UIView accessibilityElement:element hasLabel:label accessibilityValue:value traits:traits]) {
+        return NO;
+    }
+    
     if (foundElement) { *foundElement = element; }
     if (foundView) { *foundView = view; }
     return YES;

--- a/Additions/UIView-KIFAdditions.h
+++ b/Additions/UIView-KIFAdditions.h
@@ -22,6 +22,7 @@ typedef CGPoint KIFDisplacement;
 - (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label;
 - (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label traits:(UIAccessibilityTraits)traits;
 - (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label accessibilityValue:(NSString *)value traits:(UIAccessibilityTraits)traits;
++ (BOOL)accessibilityElement:(UIAccessibilityElement *)element hasLabel:(NSString *)label accessibilityValue:(NSString *)value traits:(UIAccessibilityTraits)traits;
 
 /*!
  @method accessibilityElementMatchingBlock:

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -195,7 +195,13 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                 continue;
             }
         }
-        
+
+        // Avoid crash within accessibilityElementCount while traversing map subviews
+        // See https://github.com/kif-framework/KIF/issues/802
+        if ([element isKindOfClass:NSClassFromString(@"MKBasicMapView")]) {
+            continue;
+        }
+
         // If the view is an accessibility container, and we didn't find a matching subview,
         // then check the actual accessibility elements
         NSInteger accessibilityElementCount = element.accessibilityElementCount;

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -101,25 +101,31 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 {
     return [self accessibilityElementMatchingBlock:^(UIAccessibilityElement *element) {
         
-        // TODO: This is a temporary fix for an SDK defect.
-        NSString *accessibilityValue = nil;
-        @try {
-            accessibilityValue = element.accessibilityValue;
-        }
-        @catch (NSException *exception) {
-            NSLog(@"KIF: Unable to access accessibilityValue for element %@ because of exception: %@", element, exception.reason);
-        }
+        return [UIView accessibilityElement:element hasLabel:label accessibilityValue:value traits:traits];
         
-        if ([accessibilityValue isKindOfClass:[NSAttributedString class]]) {
-            accessibilityValue = [(NSAttributedString *)accessibilityValue string];
-        }
-        
-        BOOL labelsMatch = StringsMatchExceptLineBreaks(label, element.accessibilityLabel);
-        BOOL traitsMatch = ((element.accessibilityTraits) & traits) == traits;
-        BOOL valuesMatch = !value || [value isEqual:accessibilityValue];
-
-        return (BOOL)(labelsMatch && traitsMatch && valuesMatch);
     }];
+}
+
++ (BOOL)accessibilityElement:(UIAccessibilityElement *)element hasLabel:(NSString *)label accessibilityValue:(NSString *)value traits:(UIAccessibilityTraits)traits
+{
+    // TODO: This is a temporary fix for an SDK defect.
+    NSString *accessibilityValue = nil;
+    @try {
+        accessibilityValue = element.accessibilityValue;
+    }
+    @catch (NSException *exception) {
+        NSLog(@"KIF: Unable to access accessibilityValue for element %@ because of exception: %@", element, exception.reason);
+    }
+    
+    if ([accessibilityValue isKindOfClass:[NSAttributedString class]]) {
+        accessibilityValue = [(NSAttributedString *)accessibilityValue string];
+    }
+    
+    BOOL labelsMatch = StringsMatchExceptLineBreaks(label, element.accessibilityLabel);
+    BOOL traitsMatch = ((element.accessibilityTraits) & traits) == traits;
+    BOOL valuesMatch = !value || [value isEqual:accessibilityValue];
+    
+    return (BOOL)(labelsMatch && traitsMatch && valuesMatch);
 }
 
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock;

--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -91,6 +91,7 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 @property (weak, nonatomic, readonly) id<KIFTestActorDelegate> delegate;
 @property (nonatomic) NSTimeInterval executionBlockTimeout;
 @property (nonatomic) NSTimeInterval animationWaitingTimeout;
+@property (nonatomic) NSTimeInterval animationStabilizationTimeout;
 
 - (instancetype)usingTimeout:(NSTimeInterval)executionBlockTimeout;
 
@@ -116,6 +117,19 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
  @abstract Sets the default amount of time to wait for an animation to complete.
  */
 + (void)setDefaultAnimationWaitingTimeout:(NSTimeInterval)newDefaultAnimationWaitingTimeout;
+
+/*!
+ @method defaultAnimationStabilizationTimeout
+ @abstract The default amount of time to wait before starting to check for animations
+ @discussion To change the default value of the timeout property, call +setDefaultAnimationStabilizationTimeout: with a different value.
+ */
++ (NSTimeInterval)defaultAnimationStabilizationTimeout;
+
+/*!
+ @method setDefaultAnimationStabilizationTimeout:
+ @abstract Sets the amount of time to wait before starting to check for animations
+ */
++ (void)setDefaultAnimationStabilizationTimeout:(NSTimeInterval)newDefaultAnimationStabilizationTimeout;
 
 /*!
  @method defaultTimeout

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -27,6 +27,7 @@
         _delegate = delegate;
         _executionBlockTimeout = [[self class] defaultTimeout];
         _animationWaitingTimeout = [[self class] defaultAnimationWaitingTimeout];
+        _animationStabilizationTimeout = [[self class] defaultAnimationStabilizationTimeout];
     }
     return self;
 }
@@ -95,6 +96,7 @@
 #pragma mark Class Methods
 
 static NSTimeInterval KIFTestStepDefaultAnimationWaitingTimeout = 0.5;
+static NSTimeInterval KIFTestStepDefaultAnimationStabilizationTimeout = 0.5;
 static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
 static NSTimeInterval KIFTestStepDelay = 0.1;
 
@@ -106,6 +108,16 @@ static NSTimeInterval KIFTestStepDelay = 0.1;
 + (void)setDefaultAnimationWaitingTimeout:(NSTimeInterval)newDefaultAnimationWaitingTimeout;
 {
     KIFTestStepDefaultAnimationWaitingTimeout = newDefaultAnimationWaitingTimeout;
+}
+
++ (NSTimeInterval)defaultAnimationStabilizationTimeout
+{
+    return KIFTestStepDefaultAnimationStabilizationTimeout;
+}
+
++ (void)setDefaultAnimationStabilizationTimeout:(NSTimeInterval)newDefaultAnimationStabilizationTimeout;
+{
+    KIFTestStepDefaultAnimationStabilizationTimeout = newDefaultAnimationStabilizationTimeout;
 }
 
 + (NSTimeInterval)defaultTimeout;

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -356,6 +356,13 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 - (void)clearTextFromAndThenEnterText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label;
 - (void)clearTextFromAndThenEnterText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label traits:(UIAccessibilityTraits)traits expectedResult:(NSString *)expectedResult;
 
+/*!
+ @abstract Gets text from a given label/text field/text view
+ @param view The view to get the text from
+ @returns Text from the given label/text field/text view
+ */
+- (NSString *)textFromView:(UIView *)view;
+
 - (void)expectView:(UIView *)view toContainText:(NSString *)expectedResult;
 
 /*!

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -598,6 +598,7 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
  @abstract Scrolls a table view with the given identifier while waiting for the cell at the given indexPath to appear.
  @discussion This step will get the view with the specified accessibility identifier and then get the cell at the indexPath.
  
+ By default, scrolls to the middle of the cell. If you need to scroll to top/bottom, use the @c atPosition: variation.
  For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
  
  @param indexPath Index path of the cell.
@@ -607,9 +608,23 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 - (UITableViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inTableViewWithAccessibilityIdentifier:(NSString *)identifier;
 
 /*!
+ @abstract Scrolls a table view with the given identifier while waiting for the cell at the given indexPath to appear.
+ @discussion This step will get the view with the specified accessibility identifier and then get the cell at the indexPath.
+ 
+ For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+ 
+ @param indexPath Index path of the cell.
+ @param identifier Accessibility identifier of the table view.
+ @param position Table View scroll position to scroll to. Useful for tall cells when the content needed is in a specific location.
+ @result Table view cell at index path
+ */
+- (UITableViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inTableViewWithAccessibilityIdentifier:(NSString *)identifier atPosition:(UITableViewScrollPosition)position;
+
+/*!
  @abstract Scrolls a table view while waiting for the cell at the given indexPath to appear.
  @discussion This step will get the cell at the indexPath.
  
+ By default, scrolls to the middle of the cell. If you need to scroll to top/bottom, use the @c atPosition: variation.
  For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
  
  @param indexPath Index path of the cell.
@@ -617,6 +632,19 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
  @result Table view cell at index path
  */
 - (UITableViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView;
+
+/*!
+ @abstract Scrolls a table view while waiting for the cell at the given indexPath to appear.
+ @discussion This step will get the cell at the indexPath.
+ 
+ For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+ 
+ @param indexPath Index path of the cell.
+ @param tableView UITableView containing the cell.
+ @param position Table View scroll position to scroll to. Useful for tall cells when the content needed is in a specific location.
+ @result Table view cell at index path
+ */
+- (UITableViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView atPosition:(UITableViewScrollPosition)position;
 
 /*!
  @abstract Scrolls a collection view while waiting for the cell at the given indexPath to appear.

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -703,6 +703,18 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 */
 - (void)swipeRowAtIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView inDirection:(KIFSwipeDirection)direction;
 
+/*!
+ @abstract Waits for the given cell to transition to the delete state. Useful when swiping left on a cell for delete action.
+ @param cell Cell to wait for delete state on.
+ */
+- (void)waitForDeleteStateForCell:(UITableViewCell*)cell;
+
+/*!
+ @abstract Waits for the given cell to transition to the delete state. Useful when swiping left on a cell for delete action.
+ @param indexPath Index path of the row to wait for the delete state on.
+ @param tableView Table view to operate on.
+ */
+- (void)waitForDeleteStateForCellAtIndexPath:(NSIndexPath*)indexPath inTableView:(UITableView*)tableView;
 
 /*!
  @abstract Backgrounds app using UIAutomation command, simulating pressing the Home button

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -226,6 +226,13 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 - (void)waitForAnimationsToFinishWithTimeout:(NSTimeInterval)timeout;
 
 /*!
+ @abstract Tries to guess if there are any unfinished animations and waits for a certain amount of time to let them finish.
+ @param timeout The maximum duration the method waits to let the animations finish.
+ @param stabilizationTime The time we just sleep before attempting to detect animations
+ */
+- (void)waitForAnimationsToFinishWithTimeout:(NSTimeInterval)timeout stabilizationTime:(NSTimeInterval)stabilizationTime;
+
+/*!
  @abstract Taps a particular view in the view hierarchy.
  @discussion The view or accessibility element with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, a tap event is simulated in the center of the view or element.
  @param label The accessibility label of the element to tap.

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -369,6 +369,14 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 - (void)enterText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label;
 
 /*!
+ @abstract Sets text into a particular view in the view hierarchy. No animation nor typing simulation.
+ @discussion The view or accessibility element with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, then text is set on the view. Does not result in first responder changes. Does not perform expected result validation.
+ @param text The text to set.
+ @param label The accessibility label of the element to set the text on.
+ */
+- (void)setText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label;
+
+/*!
  @abstract Enters text into a particular view in the view hierarchy.
  @discussion The view or accessibility element with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, a tap event is simulated in the center of the view or element, then text is entered into the view by simulating taps on the appropriate keyboard keys.
  @param text The text to enter.

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -162,6 +162,19 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits tappable:(BOOL)mustBeTappable;
 
 /*!
+ @abstract Waits for an accessibility element and its containing view from specified root view based on a variety of criteria.
+ @discussion This method provides a more verbose API for achieving what is available in the waitForView/waitForTappableView family of methods, exposing both the found element and its containing view.  The results can be used in other methods such as @c tapAccessibilityElement:inView:
+ @param element To be populated with the matching accessibility element when found.  Can be NULL.
+ @param view To be populated with the matching view when found.  Can be NULL.
+ @param label The accessibility label of the element to wait for.
+ @param value The accessibility value of the element to tap.
+ @param traits The accessibility traits of the element to wait for. Elements that do not include at least these traits are ignored.
+ @param fromRootView The root view to start looking for accessibility element.
+ @param mustBeTappable If YES, only an element that can be tapped on will be returned.
+ */
+- (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable;
+
+/*!
  @abstract Waits for an accessibility element and its containing view based the accessibility identifier.
  @discussion This method provides a more verbose API for achieving what is available in the waitForView/waitForTappableView family of methods, exposing both the found element and its containing view.  The results can be used in other methods such as @c tapAccessibilityElement:inView:
  @param element To be populated with the matching accessibility element when found.  Can be NULL.
@@ -170,6 +183,17 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
  @param mustBeTappable If YES, only an element that can be tapped on will be returned.
  */
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withIdentifier:(NSString *)identifier tappable:(BOOL)mustBeTappable;
+
+/*!
+ @abstract Waits for an accessibility element and its containing view from specified root view based the accessibility identifier.
+ @discussion This method provides a more verbose API for achieving what is available in the waitForView/waitForTappableView family of methods, exposing both the found element and its containing view.  The results can be used in other methods such as @c tapAccessibilityElement:inView:
+ @param element To be populated with the matching accessibility element when found.  Can be NULL.
+ @param view To be populated with the matching view when found.  Can be NULL.
+ @param identifier The accessibility identifier of the element to wait for.
+ @param fromRootView The root view to start looking for accessibility element.
+ @param mustBeTappable If YES, only an element that can be tapped on will be returned.
+ */
+- (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withIdentifier:(NSString *)identifier fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable;
 
 /*!
  @abstract Waits for an accessibility element and its containing view based on a predicate.

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -997,12 +997,22 @@
 
 - (UITableViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inTableViewWithAccessibilityIdentifier:(NSString *)identifier
 {
+    return [self waitForCellAtIndexPath:indexPath inTableViewWithAccessibilityIdentifier:identifier atPosition:UITableViewScrollPositionMiddle];
+}
+
+- (UITableViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inTableViewWithAccessibilityIdentifier:(NSString *)identifier atPosition:(UITableViewScrollPosition)position
+{
     UITableView *tableView;
     [self waitForAccessibilityElement:NULL view:&tableView withIdentifier:identifier tappable:NO];
-    return [self waitForCellAtIndexPath:indexPath inTableView:tableView];
+    return [self waitForCellAtIndexPath:indexPath inTableView:tableView atPosition:position];
 }
 
 - (UITableViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView
+{
+    return [self waitForCellAtIndexPath:indexPath inTableView:tableView atPosition:UITableViewScrollPositionMiddle];
+}
+
+- (UITableViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inTableView:(UITableView *)tableView atPosition:(UITableViewScrollPosition)position
 {
     if (![tableView isKindOfClass:[UITableView class]]) {
         [self failWithError:[NSError KIFErrorWithFormat:@"View is not a table view"] stopTest:YES];
@@ -1030,7 +1040,7 @@
     __block UITableViewCell *cell = nil;
     __block CGFloat lastYOffset = CGFLOAT_MAX;
     [self runBlock:^KIFTestStepResult(NSError **error) {
-        [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionMiddle animated:YES];
+        [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:position animated:YES];
         cell = [tableView cellForRowAtIndexPath:indexPath];
         KIFTestWaitCondition(!!cell, error, @"Table view cell at index path %@ not found", indexPath);
         

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -510,6 +510,20 @@
     [self enterTextIntoCurrentFirstResponder:text];
 }
 
+- (NSString *)textFromView:(UIView *)view {
+    if ([view isKindOfClass:[UILabel class]]) {
+        UILabel *label = (UILabel *)view;
+        return label.text ? : @"";
+    } else if ([view isKindOfClass:[UITextField class]]) {
+        UITextField *textField = (UITextField *)view;
+        return [textField.text isEqual: @""] ? textField.placeholder : textField.text;
+    } else if ([view isKindOfClass:[UITextView class]]) {
+        UITextView *textView = (UITextView *)view;
+        return textView.text;
+    }
+    return @"";
+}
+
 - (void)selectDatePickerValue:(NSArray *)datePickerColumnValues
 {
     [self selectPickerValue:datePickerColumnValues pickerType:KIFUIDatePicker];

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -80,6 +80,13 @@
     }];
 }
 
+- (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable
+{
+    [self runBlock:^KIFTestStepResult(NSError **error) {
+        return [UIAccessibilityElement accessibilityElement:element view:view withLabel:label value:value traits:traits fromRootView:fromView tappable:mustBeTappable error:error];
+    }];
+}
+
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withIdentifier:(NSString *)identifier tappable:(BOOL)mustBeTappable
 {
     if (![UIAccessibilityElement instancesRespondToSelector:@selector(accessibilityIdentifier)]) {
@@ -87,6 +94,13 @@
     }
 
     [self waitForAccessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", identifier] tappable:mustBeTappable];
+}
+
+- (void)waitForAccessibilityElement:(UIAccessibilityElement *__autoreleasing *)element view:(out UIView *__autoreleasing *)view withIdentifier:(NSString *)identifier fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable
+{
+    [self runBlock:^KIFTestStepResult(NSError **error) {
+        return [UIAccessibilityElement accessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", identifier] fromRootView:fromView tappable:mustBeTappable error:error] ? KIFTestStepResultSuccess : KIFTestStepResultWait;
+    }];
 }
 
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -418,6 +418,17 @@
     return [self enterText:text intoViewWithAccessibilityLabel:label traits:UIAccessibilityTraitNone expectedResult:nil];
 }
 
+- (void)setText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label
+{
+    UIView *view = nil;
+    UIAccessibilityElement *element = nil;
+
+    [self waitForAccessibilityElement:&element view:&view withLabel:label value:nil traits:UIAccessibilityTraitNone tappable:YES];
+    if ([view respondsToSelector:@selector(setText:)]) {
+        [view performSelector:@selector(setText:) withObject:text];
+    }
+}
+
 - (void)enterText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label traits:(UIAccessibilityTraits)traits expectedResult:(NSString *)expectedResult
 {
     UIView *view = nil;

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -831,6 +831,19 @@
     
 }
 
+- (void)waitForDeleteStateForCellAtIndexPath:(NSIndexPath*)indexPath inTableView:(UITableView*)tableView {
+    UITableViewCell *cell = [self waitForCellAtIndexPath:indexPath inTableView:tableView];
+    [self waitForDeleteStateForCell:cell];
+}
+
+- (void)waitForDeleteStateForCell:(UITableViewCell*)cell {
+    [self runBlock:^KIFTestStepResult(NSError **error) {
+        KIFTestWaitCondition(cell.showingDeleteConfirmation, error,
+                             @"Expected cell to get in the delete confirmation state: %@", cell);
+        return KIFTestStepResultSuccess;
+    }];
+}
+
 - (void)tapItemAtIndexPath:(NSIndexPath *)indexPath inCollectionViewWithAccessibilityIdentifier:(NSString *)identifier
 {
     UICollectionView *collectionView;

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -234,16 +234,8 @@
     [self runBlock:^KIFTestStepResult(NSError **error) {
         
         KIFTestWaitCondition(view.isUserInteractionActuallyEnabled, error, @"View is not enabled for interaction: %@", view);
-        
-        // If the accessibilityFrame is not set, fallback to the view frame.
-        CGRect elementFrame;
-        if (CGRectEqualToRect(CGRectZero, element.accessibilityFrame)) {
-            elementFrame.origin = CGPointZero;
-            elementFrame.size = view.frame.size;
-        } else {
-            elementFrame = [view.windowOrIdentityWindow convertRect:element.accessibilityFrame toView:view];
-        }
-        CGPoint tappablePointInElement = [view tappablePointInRect:elementFrame];
+
+        CGPoint tappablePointInElement = [self tappablePointInElement:element andView:view];
         
         // This is mostly redundant of the test in _accessibilityElementWithLabel:
         KIFTestWaitCondition(!isnan(tappablePointInElement.x), error, @"View is not tappable: %@", view);
@@ -321,9 +313,8 @@
     [self runBlock:^KIFTestStepResult(NSError **error) {
         
         KIFTestWaitCondition(view.isUserInteractionActuallyEnabled, error, @"View is not enabled for interaction: %@", view);
-        
-        CGRect elementFrame = [view.windowOrIdentityWindow convertRect:element.accessibilityFrame toView:view];
-        CGPoint tappablePointInElement = [view tappablePointInRect:elementFrame];
+
+        CGPoint tappablePointInElement = [self tappablePointInElement:element andView:view];
         
         // This is mostly redundant of the test in _accessibilityElementWithLabel:
         KIFTestWaitCondition(!isnan(tappablePointInElement.x), error, @"View is not tappable: %@", view);
@@ -794,10 +785,8 @@
             }
             return KIFTestStepResultWait;
         }
-        
-        CGRect elementFrame = [view.windowOrIdentityWindow convertRect:element.accessibilityFrame toView:view];
-        CGPoint tappablePointInElement = [view tappablePointInRect:elementFrame];
-        
+
+        CGPoint tappablePointInElement = [self tappablePointInElement:element andView:view];
         [view tapAtPoint:tappablePointInElement];
         
         return KIFTestStepResultSuccess;
@@ -926,9 +915,10 @@
     const NSUInteger kNumberOfPointsInSwipePath = 20;
   
     // Within this method, all geometry is done in the coordinate system of the view to swipe.
-  
-    CGRect elementFrame = [viewToSwipe.windowOrIdentityWindow convertRect:element.accessibilityFrame toView:viewToSwipe];
+    CGRect elementFrame = [self elementFrameForElement:element andView:viewToSwipe];
+
     CGPoint swipeStart = CGPointCenteredInRect(elementFrame);
+
     KIFDisplacement swipeDisplacement = [self _displacementForSwipingInDirection:direction];
   
     [viewToSwipe dragFromPoint:swipeStart displacement:swipeDisplacement steps:kNumberOfPointsInSwipePath];
@@ -994,8 +984,7 @@
     const NSUInteger kNumberOfPointsInScrollPath = 5;
 
     // Within this method, all geometry is done in the coordinate system of the view to scroll.
-
-    CGRect elementFrame = [viewToScroll.windowOrIdentityWindow convertRect:element.accessibilityFrame toView:viewToScroll];
+    CGRect elementFrame = [self elementFrameForElement:element andView:viewToScroll];
 
     KIFDisplacement scrollDisplacement = CGPointMake(elementFrame.size.width * horizontalFraction, elementFrame.size.height * verticalFraction);
 
@@ -1219,16 +1208,7 @@
 
 		KIFTestWaitCondition(view.isUserInteractionActuallyEnabled, error, @"View is not enabled for interaction: %@", view);
 
-		// If the accessibilityFrame is not set, fallback to the view frame.
-		CGRect elementFrame;
-		if (CGRectEqualToRect(CGRectZero, element.accessibilityFrame)) {
-			elementFrame.origin = CGPointZero;
-			elementFrame.size = view.frame.size;
-		} else {
-			elementFrame = [view.windowOrIdentityWindow convertRect:element.accessibilityFrame toView:view];
-		}
-
-		CGPoint stepperPointToTap = [view tappablePointInRect:elementFrame];
+        CGPoint stepperPointToTap = [self tappablePointInElement:element andView:view];
 
 		switch (stepperDirection)
 		{
@@ -1250,6 +1230,28 @@
 	}];
 
 	[self waitForAnimationsToFinish];
+}
+
+- (CGRect) elementFrameForElement:(UIAccessibilityElement *)element andView:(UIView *)view
+{
+    CGRect elementFrame;
+
+    // If the accessibilityFrame is not set, fallback to the view frame.
+    if (CGRectEqualToRect(CGRectZero, element.accessibilityFrame)) {
+        elementFrame.origin = CGPointZero;
+        elementFrame.size = view.frame.size;
+    } else {
+        elementFrame = [view.windowOrIdentityWindow convertRect:element.accessibilityFrame toView:view];
+    }
+    return elementFrame;
+}
+
+- (CGPoint) tappablePointInElement:(UIAccessibilityElement *)element andView:(UIView *)view
+{
+    CGRect elementFrame = [self elementFrameForElement:element andView:view];
+    CGPoint tappablePoint = [view tappablePointInRect:elementFrame];
+
+    return tappablePoint;
 }
 
 - (KIFDisplacement)_displacementForSwipingInDirection:(KIFSwipeDirection)direction;

--- a/IdentifierTests/KIFUITestActor-IdentifierTests.h
+++ b/IdentifierTests/KIFUITestActor-IdentifierTests.h
@@ -32,6 +32,14 @@
 - (void)enterText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier;
 
 /*!
+ @abstract Sets text into a particular view in the view hierarchy. No animation nor typing simulation.
+ @discussion The view or accessibility element with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, then text is set on the view. Does not result in first responder changes. Does not perform expected result validation.
+ @param text The text to set.
+ @param accessibilityIdentifier The accessibility identifier of the element to set the text on.
+ */
+- (void)setText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier;
+
+/*!
  @abstract Enters text into a particular view in the view hierarchy.
  @discussion The view or accessibility element with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, a tap event is simulated in the center of the view or element, then text is entered into the view by simulating taps on the appropriate keyboard keys.
  @param text The text to enter.

--- a/IdentifierTests/KIFUITestActor-IdentifierTests.m
+++ b/IdentifierTests/KIFUITestActor-IdentifierTests.m
@@ -63,7 +63,17 @@
 - (void)enterText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
 	return [self enterText:text intoViewWithAccessibilityIdentifier:accessibilityIdentifier expectedResult:nil];
-	
+}
+
+- (void)setText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
+{
+    UIView *view = nil;
+    UIAccessibilityElement *element = nil;
+
+    [self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
+    if ([view respondsToSelector:@selector(setText:)]) {
+        [view performSelector:@selector(setText:) withObject:text];
+    }
 }
 
 - (void)enterText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier expectedResult:(NSString *)expectedResult

--- a/KIF Tests/AccessibilityIdentifierTests.m
+++ b/KIF Tests/AccessibilityIdentifierTests.m
@@ -59,6 +59,16 @@
 	[tester enterText:@"Yo" intoViewWithAccessibilityIdentifier:@"idGreeting"];
 }
 
+- (void)testSettingTextIntoViewWithAccessibilityIdentifier
+{
+    UIView *greetingView = [tester waitForViewWithAccessibilityIdentifier:@"idGreeting"];
+    [tester longPressViewWithAccessibilityIdentifier:@"idGreeting" duration:2];
+    [tester setText:@"Yo" intoViewWithAccessibilityIdentifier:@"idGreeting"];
+    [tester expectView:greetingView toContainText:@"Yo"];
+    [tester setText:@"Hello" intoViewWithAccessibilityIdentifier:@"idGreeting"];
+    [tester expectView:greetingView toContainText:@"Hello"];
+}
+
 - (void)testEnteringTextIntoViewWithAccessibilityIdentifierExpectingResults
 {
 	[tester enterText:@", world" intoViewWithAccessibilityIdentifier:@"idGreeting" expectedResult:@"Hello, world"];

--- a/KIF Tests/TableViewTests.m
+++ b/KIF Tests/TableViewTests.m
@@ -156,13 +156,17 @@
     [tester waitForAccessibilityElement:NULL view:&tableView withIdentifier:@"TableView Tests Table" tappable:NO];
     
     // First row
-    [tester swipeRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inTableView:tableView inDirection:KIFSwipeDirectionLeft];
+    NSIndexPath *firstCellPath = [NSIndexPath indexPathForRow:0 inSection:0];
+    [tester swipeRowAtIndexPath:firstCellPath inTableView:tableView inDirection:KIFSwipeDirectionLeft];
+    [tester waitForDeleteStateForCellAtIndexPath:firstCellPath inTableView:tableView];
     [tester tapViewWithAccessibilityLabel:@"Delete"];
     
     __KIFAssertEqualObjects([tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
     
     // Last row
-    [tester swipeRowAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:2] inTableView:tableView inDirection:KIFSwipeDirectionLeft];
+    NSIndexPath *lastCellPath = [NSIndexPath indexPathForRow:1 inSection:2];
+    [tester swipeRowAtIndexPath:lastCellPath inTableView:tableView inDirection:KIFSwipeDirectionLeft];
+    [tester waitForDeleteStateForCellAtIndexPath:lastCellPath inTableView:tableView];
     [tester tapViewWithAccessibilityLabel:@"Delete"];
     
     __KIFAssertEqualObjects([tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:2] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");

--- a/KIF Tests/TableViewTests.m
+++ b/KIF Tests/TableViewTests.m
@@ -161,7 +161,7 @@
     [tester waitForDeleteStateForCellAtIndexPath:firstCellPath inTableView:tableView];
     [tester tapViewWithAccessibilityLabel:@"Delete"];
     
-    __KIFAssertEqualObjects([tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
+    __KIFAssertEqualObjects([tester waitForCellAtIndexPath:firstCellPath inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
     
     // Last row
     NSIndexPath *lastCellPath = [NSIndexPath indexPathForRow:1 inSection:2];
@@ -169,8 +169,7 @@
     [tester waitForDeleteStateForCellAtIndexPath:lastCellPath inTableView:tableView];
     [tester tapViewWithAccessibilityLabel:@"Delete"];
     
-    __KIFAssertEqualObjects([tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:2] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
-    
+    __KIFAssertEqualObjects([tester waitForCellAtIndexPath:lastCellPath inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"].textLabel.text, @"Deleted", @"");
 }
 
 @end

--- a/KIF Tests/TappingTests.m
+++ b/KIF Tests/TappingTests.m
@@ -7,6 +7,7 @@
 //
 
 #import <KIF/KIF.h>
+#import <KIF/KIFUITestActor-IdentifierTests.h>
 
 @interface TappingTests : KIFTestCase
 @end
@@ -21,6 +22,18 @@
 - (void)afterEach
 {
     [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
+}
+
+- (void)testTappingViewFromSpecificView
+{
+    UIView *scrollView = [tester waitForViewWithAccessibilityIdentifier:@"TapViewController Inner ScrollView"];
+    UIView *buttonView;
+    UIAccessibilityElement *element;
+    [tester waitForAccessibilityElement:&element view:&buttonView withIdentifier:@"Inner Button" fromRootView:scrollView tappable:YES];
+    
+    if (buttonView != NULL) {
+        [tester tapAccessibilityElement:element inView:buttonView];
+    }
 }
 
 - (void)testTappingViewWithAccessibilityLabel

--- a/KIF Tests/TypingTests.m
+++ b/KIF Tests/TypingTests.m
@@ -100,6 +100,8 @@
 {
     [tester enterText:@"hi\bello" intoViewWithAccessibilityLabel:@"Other Text" traits:UIAccessibilityTraitNone expectedResult:@"hello"];
     [tester waitForViewWithAccessibilityLabel:@"Greeting" value:@"Deleted something." traits:UIAccessibilityTraitNone];
+    UIView *textView = [tester waitForViewWithAccessibilityLabel:@"Other Text"];
+    XCTAssertEqualObjects([tester textFromView:textView], @"hello");
 }
 
 @end

--- a/KIF Tests/TypingTests.m
+++ b/KIF Tests/TypingTests.m
@@ -57,6 +57,16 @@
     [tester waitForViewWithAccessibilityLabel:@"Greeting" value:@"Yo" traits:UIAccessibilityTraitNone];
 }
 
+- (void)testSettingTextIntoViewWithAccessibilityLabel
+{
+    UIView *greetingView = [tester waitForViewWithAccessibilityLabel:@"Greeting"];
+    [tester longPressViewWithAccessibilityLabel:@"Greeting" duration:2];
+    [tester setText:@"Yo" intoViewWithAccessibilityLabel:@"Greeting"];
+    [tester expectView:greetingView toContainText:@"Yo"];
+    [tester setText:@"Hello" intoViewWithAccessibilityLabel:@"Greeting"];
+    [tester expectView:greetingView toContainText:@"Hello"];
+}
+
 - (void)testEnteringTextIntoViewWithAccessibilityLabelExpectingResults
 {
     [tester enterText:@", world" intoViewWithAccessibilityLabel:@"Greeting" traits:UIAccessibilityTraitNone expectedResult:@"Hello, world"];

--- a/Test Host/en.lproj/MainStoryboard.storyboard
+++ b/Test Host/en.lproj/MainStoryboard.storyboard
@@ -1491,8 +1491,14 @@
                                         <state key="normal" title="Button">
                                             <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Inner Button"/>
+                                        </userDefinedRuntimeAttributes>
                                     </button>
                                 </subviews>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="TapViewController Inner ScrollView"/>
+                                </userDefinedRuntimeAttributes>
                             </scrollView>
                             <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label with Tap Gesture Recognizer" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="eKU-mb-iWm">
                                 <rect key="frame" x="27" y="288" width="267" height="21"/>
@@ -1760,12 +1766,18 @@ Line Break
                                 <state key="highlighted">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Inner Button"/>
+                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="requestLocationServicesAndNotificicationsSchedulingAccesses" destination="k4d-l4-aKf" eventType="touchUpInside" id="up3-fx-DyS"/>
                                 </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="TapViewController Inner ScrollView"/>
+                        </userDefinedRuntimeAttributes>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
                     <navigationItem key="navigationItem" id="fud-79-Dhj"/>


### PR DESCRIPTION
There are cases where text should be entered without typing simulation.
For example, cases where text is pasted, or where we do repeated text field inputs and want to have more performant tests.
This API sets the text explicitly on the view, without going through the Typist.