### PR TITLE
avoid crash when getting accessibility labels of MKMapView subviews

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -189,7 +189,14 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                 continue;
             }
         }
-        
+
+        // Avoid crash in accessibilityElementCount
+        // Some of MKMapView subviews are private classes that do not respond to accessibilityElementCount
+        // See https://github.com/kif-framework/KIF/issues/802
+        if (![element respondsToSelector:@selector(accessibilityElementCount)]) {
+            continue;
+        }
+
         // If the view is an accessibility container, and we didn't find a matching subview,
         // then check the actual accessibility elements
         NSInteger accessibilityElementCount = element.accessibilityElementCount;


### PR DESCRIPTION
Fixes https://github.com/kif-framework/KIF/issues/802

I've tried skipping all elements that are not UIAccessibilityElement, but that turned out to be to drastic, as it broke several of our project KIF tests.