### PR TITLE
Animation timeout improvements

### DIFF
--- a/Additions/CAAnimation+KIFAdditions.h
+++ b/Additions/CAAnimation+KIFAdditions.h
@@ -1,0 +1,15 @@
+//
+//  CAAnimation+KIFAdditions.h
+//  Pods
+//
+//  Created by Justin Martin on 6/6/16.
+//
+
+#import <QuartzCore/QuartzCore.h>
+
+
+@interface CAAnimation (KIFAdditions)
+
+- (double)KIF_completionTime;
+
+@end

--- a/Additions/CAAnimation+KIFAdditions.m
+++ b/Additions/CAAnimation+KIFAdditions.m
@@ -1,0 +1,26 @@
+//
+//  CAAnimation+KIFAdditions.m
+//  Pods
+//
+//  Created by Justin Martin on 6/6/16.
+//
+
+#import "CAAnimation+KIFAdditions.h"
+
+
+@implementation CAAnimation (KIFAdditions)
+
+- (double)KIF_completionTime;
+{
+    if (self.repeatDuration > 0) {
+        return self.beginTime + self.repeatDuration;
+    } else if (self.repeatCount == HUGE_VALF) {
+        return HUGE_VALF;
+    } else if (self.repeatCount > 0) {
+        return self.beginTime + (self.repeatCount * self.duration);
+    } else {
+        return self.beginTime + self.duration;
+    }
+}
+
+@end

--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -91,6 +91,7 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 @property (weak, nonatomic, readonly) id<KIFTestActorDelegate> delegate;
 @property (nonatomic) NSTimeInterval executionBlockTimeout;
 @property (nonatomic) NSTimeInterval animationWaitingTimeout;
+@property (nonatomic) NSTimeInterval animationStabilizationTimeout;
 
 - (instancetype)usingTimeout:(NSTimeInterval)executionBlockTimeout;
 
@@ -116,6 +117,19 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
  @abstract Sets the default amount of time to wait for an animation to complete.
  */
 + (void)setDefaultAnimationWaitingTimeout:(NSTimeInterval)newDefaultAnimationWaitingTimeout;
+
+/*!
+ @method defaultAnimationStabilizationTimeout
+ @abstract The default amount of time to wait before starting to check for animations
+ @discussion To change the default value of the timeout property, call +setDefaultAnimationStabilizationTimeout: with a different value.
+ */
++ (NSTimeInterval)defaultAnimationStabilizationTimeout;
+
+/*!
+ @method setDefaultAnimationStabilizationTimeout:
+ @abstract Sets the amount of time to wait before starting to check for animations
+ */
++ (void)setDefaultAnimationStabilizationTimeout:(NSTimeInterval)newDefaultAnimationStabilizationTimeout;
 
 /*!
  @method defaultTimeout

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -27,6 +27,7 @@
         _delegate = delegate;
         _executionBlockTimeout = [[self class] defaultTimeout];
         _animationWaitingTimeout = [[self class] defaultAnimationWaitingTimeout];
+        _animationStabilizationTimeout = [[self class] defaultAnimationStabilizationTimeout];
     }
     return self;
 }
@@ -95,6 +96,7 @@
 #pragma mark Class Methods
 
 static NSTimeInterval KIFTestStepDefaultAnimationWaitingTimeout = 0.5;
+static NSTimeInterval KIFTestStepDefaultAnimationStabilizationTimeout = 0.5;
 static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
 static NSTimeInterval KIFTestStepDelay = 0.1;
 
@@ -106,6 +108,16 @@ static NSTimeInterval KIFTestStepDelay = 0.1;
 + (void)setDefaultAnimationWaitingTimeout:(NSTimeInterval)newDefaultAnimationWaitingTimeout;
 {
     KIFTestStepDefaultAnimationWaitingTimeout = newDefaultAnimationWaitingTimeout;
+}
+
++ (NSTimeInterval)defaultAnimationStabilizationTimeout
+{
+    return KIFTestStepDefaultAnimationStabilizationTimeout;
+}
+
++ (void)setDefaultAnimationStabilizationTimeout:(NSTimeInterval)newDefaultAnimationStabilizationTimeout;
+{
+    KIFTestStepDefaultAnimationStabilizationTimeout = newDefaultAnimationStabilizationTimeout;
 }
 
 + (NSTimeInterval)defaultTimeout;

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -202,6 +202,13 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 - (void)waitForAnimationsToFinishWithTimeout:(NSTimeInterval)timeout;
 
 /*!
+ @abstract Tries to guess if there are any unfinished animations and waits for a certain amount of time to let them finish.
+ @param timeout The maximum duration the method waits to let the animations finish.
+ @param stabilizationTime The time we just sleep before attempting to detect animations
+ */
+- (void)waitForAnimationsToFinishWithTimeout:(NSTimeInterval)timeout stabilizationTime:(NSTimeInterval)stabilizationTime;
+
+/*!
  @abstract Taps a particular view in the view hierarchy.
  @discussion The view or accessibility element with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, a tap event is simulated in the center of the view or element.
  @param label The accessibility label of the element to tap.


### PR DESCRIPTION
Animation timeout improvements:
 * Expose out a `waitForAnimationsToFinish` method variant to control how long we sleep before starting to look for animations
 * Rather than taking the existence of an animation key as being sufficient knowledge of if it is complete, instead calculate when the animation should be completed and compare that against the current time.