### PR TITLE
Added "setText:..." helper functions

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -388,6 +388,14 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 - (void)clearTextFromAndThenEnterText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label traits:(UIAccessibilityTraits)traits expectedResult:(NSString *)expectedResult;
 
 /*!
+ @abstract Sets text into a particular view in the view hierarchy. No animation nor typing simulation.
+ @discussion The view or accessibility element with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, then text is set on the view. Does not result in first responder changes. Does not perform expected result validation.
+ @param text The text to set.
+ @param label The accessibility label of the element to set the text on.
+ */
+- (void)setText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label;
+
+/*!
  @abstract Gets text from a given label/text field/text view
  @param view The view to get the text from
  @returns Text from the given label/text field/text view

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -527,6 +527,17 @@
     [self enterTextIntoCurrentFirstResponder:text];
 }
 
+- (void)setText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label
+{
+    UIView *view = nil;
+    UIAccessibilityElement *element = nil;
+
+    [self waitForAccessibilityElement:&element view:&view withLabel:label value:nil traits:UIAccessibilityTraitNone tappable:YES];
+    if ([view respondsToSelector:@selector(setText:)]) {
+        [view performSelector:@selector(setText:) withObject:text];
+    }
+}
+
 - (NSString *)textFromView:(UIView *)view {
     if ([view isKindOfClass:[UILabel class]]) {
         UILabel *label = (UILabel *)view;

--- a/Classes/KIFUIViewTestActor.h
+++ b/Classes/KIFUIViewTestActor.h
@@ -284,6 +284,13 @@
 - (void)clearAndEnterText:(NSString *)text expectedResult:(NSString *)expectedResult;
 
 /*!
+ @abstract Sets text into a particular view matching the tester's search predicate.
+ @discussion If the element isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, then text is set on the view. Does not result in first responder changes. Does not perform expected result validation.
+ @param text The text to set.
+ */
+- (void)setText:(NSString *)text;
+
+/*!
  @abstract Waits for the software keyboard to be visible.
  @discussion If input is also possible from a hardare keyboard @c waitForKeyInputReady may be more appropriate.
  */

--- a/Classes/KIFUIViewTestActor.m
+++ b/Classes/KIFUIViewTestActor.m
@@ -257,6 +257,14 @@
     [self.actor enterTextIntoCurrentFirstResponder:text fallbackView:fallbackView];
 }
 
+- (void)setText:(NSString *)text;
+{
+    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+    if ([found.view respondsToSelector:@selector(setText:)]) {
+        [found.view performSelector:@selector(setText:) withObject:text];
+    }
+}
+
 - (void)expectToContainText:(NSString *)expectedResult;
 {
     KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];

--- a/IdentifierTests/KIFUITestActor-IdentifierTests.h
+++ b/IdentifierTests/KIFUITestActor-IdentifierTests.h
@@ -46,6 +46,14 @@
 - (void)clearTextFromAndThenEnterText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier expectedResult:(NSString *)expectedResult;
 
 /*!
+ @abstract Sets text into a particular view in the view hierarchy. No animation nor typing simulation.
+ @discussion The view or accessibility element with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, then text is set on the view. Does not result in first responder changes. Does not perform expected result validation.
+ @param text The text to set.
+ @param accessibilityIdentifier The accessibility identifier of the element to set the text on.
+ */
+- (void)setText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier;
+
+/*!
  @abstract Toggles a UISwitch into a specified position.
  @discussion The UISwitch with the given label is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Once the view is present, the step will return if it's already in the desired position. If the switch is tappable but not in the desired position, a tap event is simulated in the center of the view or element, toggling the switch into the desired position.
  @param switchIsOn The desired position of the UISwitch.

--- a/IdentifierTests/KIFUITestActor-IdentifierTests.m
+++ b/IdentifierTests/KIFUITestActor-IdentifierTests.m
@@ -63,7 +63,6 @@
 - (void)enterText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
 	return [self enterText:text intoViewWithAccessibilityIdentifier:accessibilityIdentifier expectedResult:nil];
-	
 }
 
 - (void)enterText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier expectedResult:(NSString *)expectedResult
@@ -94,6 +93,17 @@
 {
 	[self clearTextFromViewWithAccessibilityIdentifier:accessibilityIdentifier];
 	[self enterText:text intoViewWithAccessibilityIdentifier:accessibilityIdentifier expectedResult:expectedResult];
+}
+
+- (void)setText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
+{
+    UIView *view = nil;
+    UIAccessibilityElement *element = nil;
+
+    [self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
+    if ([view respondsToSelector:@selector(setText:)]) {
+        [view performSelector:@selector(setText:) withObject:text];
+    }
 }
 
 - (void)setOn:(BOOL)switchIsOn forSwitchWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier

--- a/KIF Tests/AccessibilityIdentifierTests.m
+++ b/KIF Tests/AccessibilityIdentifierTests.m
@@ -70,6 +70,16 @@
 	[tester clearTextFromAndThenEnterText:@"Yo" intoViewWithAccessibilityIdentifier:@"idGreeting"];
 }
 
+- (void)testSettingTextIntoViewWithAccessibilityIdentifier
+{
+    UIView *greetingView = [tester waitForViewWithAccessibilityIdentifier:@"idGreeting"];
+    [tester longPressViewWithAccessibilityIdentifier:@"idGreeting" duration:2];
+    [tester setText:@"Yo" intoViewWithAccessibilityIdentifier:@"idGreeting"];
+    [tester expectView:greetingView toContainText:@"Yo"];
+    [tester setText:@"Hello" intoViewWithAccessibilityIdentifier:@"idGreeting"];
+    [tester expectView:greetingView toContainText:@"Hello"];
+}
+
 - (void)testTryFindingViewWithAccessibilityIdentifier
 {
     if (![tester tryFindingViewWithAccessibilityIdentifier:@"idGreeting"])

--- a/KIF Tests/TypingTests.m
+++ b/KIF Tests/TypingTests.m
@@ -89,6 +89,16 @@
     [tester clearTextFromViewWithAccessibilityLabel:@"Greeting"];
 }
 
+- (void)testSettingTextIntoViewWithAccessibilityLabel
+{
+    UIView *greetingView = [tester waitForViewWithAccessibilityLabel:@"Greeting"];
+    [tester longPressViewWithAccessibilityLabel:@"Greeting" duration:2];
+    [tester setText:@"Yo" intoViewWithAccessibilityLabel:@"Greeting"];
+    [tester expectView:greetingView toContainText:@"Yo"];
+    [tester setText:@"Hello" intoViewWithAccessibilityLabel:@"Greeting"];
+    [tester expectView:greetingView toContainText:@"Hello"];
+}
+
 - (void)testThatClearingTextHitsTheDelegate
 {
     [tester enterText:@"hello" intoViewWithAccessibilityLabel:@"Other Text"];

--- a/KIF Tests/TypingTests_ViewTestActor.m
+++ b/KIF Tests/TypingTests_ViewTestActor.m
@@ -77,6 +77,12 @@
     [[viewTester usingLabel:@"Greeting"] enterText:@", world\n" expectedResult:@"Hello, world"];
 }
 
+- (void)testSettingTextIntoViewWithAccessibilityLabel
+{
+    [[viewTester usingLabel:@"Greeting"] setText:@"Yo"];
+    [[[viewTester usingLabel:@"Greeting"] usingValue:@"Yo"] waitForView];
+}
+
 - (void)testClearingALongTextField
 {
     [[viewTester usingLabel:@"Greeting"] clearAndEnterText:@"A man, a plan, a canal, Panama.  Able was I, ere I saw Elba."];


### PR DESCRIPTION
There are cases where text should be entered without typing simulation.
For example, cases where text is pasted, or where we do repeated text field inputs and want to have more performant tests.
This API sets the text explicitly on the view, without going through the Typist.

Note- this replaces https://github.com/kif-framework/KIF/pull/863