### PR TITLE
iOS 10: Use alternate way to enable accessibility

### DIFF
--- a/Classes/KIFAccessibilityEnabler.m
+++ b/Classes/KIFAccessibilityEnabler.m
@@ -46,12 +46,12 @@
 {
     // This works as of iOS 9.
     CFPreferencesSetAppValue((CFStringRef)@"ApplicationAccessibilityEnabled",
-                             enabled, (CFStringRef)@"com.apple.Accessibility");
+                             (__bridge CFPropertyListRef)(@(enabled)), (CFStringRef)@"com.apple.Accessibility");
     CFPreferencesSynchronize((CFStringRef)@"com.apple.Accessibility",
                              kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
     CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(),
                                          (CFStringRef)@"com.apple.accessibility.cache.app.ax",
-                                         nil, nil, kCFBooleanTrue);
+                                         nil, nil, YES);
 }
 
 - (void)enableAccessibility
@@ -124,5 +124,5 @@ void ResetAccessibilityInspector(void);
 // It appears that if you register as a test observer too late, then you don't get the testBundleDidFinish: method called, so instead we use this is a workaround. This is also works well for test envs that don't have XCTestObservation
 __attribute__((destructor))
 void ResetAccessibilityInspector() {
-  [[KIFAccessibilityEnabler sharedAccessibilityEnabler] _resetAccessibilityInspector];
+    [[KIFAccessibilityEnabler sharedAccessibilityEnabler] _resetAccessibilityInspector];
 }

--- a/Classes/KIFAccessibilityEnabler.m
+++ b/Classes/KIFAccessibilityEnabler.m
@@ -46,12 +46,12 @@
 {
     // This works as of iOS 9.
     CFPreferencesSetAppValue((CFStringRef)@"ApplicationAccessibilityEnabled",
-                             kCFBooleanTrue, (CFStringRef)@"com.apple.Accessibility");
+                             enabled, (CFStringRef)@"com.apple.Accessibility");
     CFPreferencesSynchronize((CFStringRef)@"com.apple.Accessibility",
                              kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
     CFNotificationCenterPostNotification(CFNotificationCenterGetDarwinNotifyCenter(),
                                          (CFStringRef)@"com.apple.accessibility.cache.app.ax",
-                                         nil, nil, enabled);
+                                         nil, nil, kCFBooleanTrue);
 }
 
 - (void)enableAccessibility


### PR DESCRIPTION
This addresses #876 based on what Google is doing in EarlGrey.

https://github.com/google/EarlGrey/pull/148/files

We now use this branch internally at PSPDFKit and Jenkins is green fron 8.4 to 10.0b1. (well, iOS 10 has some troubles but they are not KIF related...)

We no longer show the accessibility inspector, but I actually feel that's a good thing, and it's gone in iOS 10 anyway. The old logic has to remain until KIF drops support for iOS 8.