### PR TITLE
Call willDisplay on tableview cells

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -249,6 +249,11 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                         // Get the cell directly from the dataSource because UITableView will only vend visible cells
                         UITableViewCell *cell = [tableView.dataSource tableView:tableView cellForRowAtIndexPath:indexPath];
                         
+                        // Allow cells to be configured appropriately for display (may include setting accessibility)
+                        if ([tableView.delegate respondsToSelector:@selector(tableView:willDisplayCell:forRowAtIndexPath:)]) {
+                            [tableView.delegate tableView:tableView willDisplayCell:cell forRowAtIndexPath:indexPath];
+                        }
+
                         UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock notHidden:NO];
                         
                         // Remove the cell from the table view so that it doesn't stick around


### PR DESCRIPTION
We have a situation where we have some elements haven't yet been fully initialized and thus don't get the proper accessibilityLabel until after the `willDisplayCell` UITableViewDelegate method is called. 

It seemed reasonable to add this here, though we could alternatively change the app to set this information on creation of the cell as opposed to just before it is being displayed.

Thoughts?