### PR TITLE
Don't change the typing delay based on animation speed

### DIFF
--- a/Classes/KIFTypist.h
+++ b/Classes/KIFTypist.h
@@ -13,7 +13,10 @@
 + (void)registerForNotifications;
 + (BOOL)keyboardHidden;
 + (BOOL)enterCharacter:(NSString *)characterString;
+
++ (NSTimeInterval)keystrokeDelay;
 + (void)setKeystrokeDelay:(NSTimeInterval)delay;
+
 + (BOOL)hasHardwareKeyboard;
 + (BOOL)hasKeyInputResponder;
 

--- a/Classes/KIFTypist.m
+++ b/Classes/KIFTypist.m
@@ -89,8 +89,13 @@ static NSTimeInterval keystrokeDelay = 0.01f;
         [[UIKeyboardImpl sharedInstance] addInputString:characterString];
     }
     
-    KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, keystrokeDelay, false);
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, keystrokeDelay, false);
     return YES;
+}
+
++ (NSTimeInterval)keystrokeDelay;
+{
+    return keystrokeDelay;
 }
 
 + (void)setKeystrokeDelay:(NSTimeInterval)delay

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -387,30 +387,34 @@
 
 - (void)enterTextIntoCurrentFirstResponder:(NSString *)text fallbackView:(UIView *)fallbackView
 {
-	[text enumerateSubstringsInRange:NSMakeRange(0, text.length)
-							 options:NSStringEnumerationByComposedCharacterSequences
-						  usingBlock: ^(NSString *characterString,NSRange substringRange,NSRange enclosingRange,BOOL * stop)
+    [text enumerateSubstringsInRange:NSMakeRange(0, text.length)
+                             options:NSStringEnumerationByComposedCharacterSequences
+                          usingBlock: ^(NSString *characterString,NSRange substringRange,NSRange enclosingRange,BOOL * stop)
+    {
+        if (![KIFTypist enterCharacter:characterString]) {
+            // Attempt to cheat if we couldn't find the character
+            UIView * fallback = fallbackView;
+            if (!fallback) {
+                UIResponder *firstResponder = [[[UIApplication sharedApplication] keyWindow] firstResponder];
 
-	 {
-		 if (![KIFTypist enterCharacter:characterString]) {
-			 // Attempt to cheat if we couldn't find the character
-			 UIView * fallback = fallbackView;
-			 if (!fallback) {
-				 UIResponder *firstResponder = [[[UIApplication sharedApplication] keyWindow] firstResponder];
+                if ([firstResponder isKindOfClass:[UIView class]]) {
+                    fallback = (UIView *)firstResponder;
+                }
+            }
 
-				 if ([firstResponder isKindOfClass:[UIView class]]) {
-					 fallback = (UIView *)firstResponder;
-				 }
-			 }
+            if ([fallback isKindOfClass:[UITextField class]] || [fallback isKindOfClass:[UITextView class]] || [fallback isKindOfClass:[UISearchBar class]]) {
+                NSLog(@"KIF: Unable to find keyboard key for %@. Inserting manually.", characterString);
+                [(UITextField *)fallback setText:[[(UITextField *)fallback text] stringByAppendingString:characterString]];
+            } else {
+                [self failWithError:[NSError KIFErrorWithFormat:@"Failed to find key for character \"%@\"", characterString] stopTest:YES];
+            }
+        }
+    }];
 
-			 if ([fallback isKindOfClass:[UITextField class]] || [fallback isKindOfClass:[UITextView class]] || [fallback isKindOfClass:[UISearchBar class]]) {
-				 NSLog(@"KIF: Unable to find keyboard key for %@. Inserting manually.", characterString);
-				 [(UITextField *)fallback setText:[[(UITextField *)fallback text] stringByAppendingString:characterString]];
-			 } else {
-				 [self failWithError:[NSError KIFErrorWithFormat:@"Failed to find key for character \"%@\"", characterString] stopTest:YES];
-			 }
-		 }
-	 }];
+    NSTimeInterval remainingWaitTime = 0.01 - [KIFTypist keystrokeDelay];
+    if (remainingWaitTime > 0) {
+        CFRunLoopRunInMode(UIApplicationCurrentRunMode, remainingWaitTime, false);
+    }
 }
 
 - (void)enterText:(NSString *)text intoViewWithAccessibilityLabel:(NSString *)label


### PR DESCRIPTION
I've found in our project when attempting to bump to the latest KIF that sometimes attempting to tap a button directly after typing to be randomly unreliable (tap doesn't actually get invoked). I'm having a hard time reproducing this locally, but it happens on our CI machines (dual core mac minis) often enough to be nearly unusable (every 2-3 runs has a failure).

Rather than using `KIFRunLoopRunInModeRelativeToAnimationSpeed` for modifying the typing delay, I believe test authors should explicitly set `KIFTypist.keystrokeDelay`. The `keyWindow`'s layer animation speed has nothing to do with the keyboard window animations.  However, lowering this value hits the reliability issues I mentioned before. Rather than waiting the .01s between every tap, instead only wait the full .01s after the last keypress (which seemed to always work fine for us before).

The timings we're currently using in our base test class `-beforeEach`:

```
    UIApplication.sharedApplication.animationSpeed = 4.0;
    KIFTypist.keystrokeDelay = 0.0025f;
    KIFTestActor.defaultAnimationStabilizationTimeout = 0.1;
    KIFTestActor.defaultAnimationWaitingTimeout = 2.0;
```

I also fixed the indentation of the method in `KIFUITestActor.m`, so it reviews much better with `&w=1` on the github URL.