### PR TITLE
Revert "Expose logic for matching accessibility elements, and use it …

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -55,13 +55,6 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
         return NO;
     }
     
-    // viewContainingAccessibilityElement:.. can cause scrolling, which can cause cell reuse.
-    // If this happens, the element we kept a reference to might have been reconfigured, and a
-    // different element might be the one that matches.
-    if (![UIView accessibilityElement:element hasLabel:label accessibilityValue:value traits:traits]) {
-        return NO;
-    }
-    
     if (foundElement) { *foundElement = element; }
     if (foundView) { *foundView = view; }
     return YES;

--- a/Additions/UIView-KIFAdditions.h
+++ b/Additions/UIView-KIFAdditions.h
@@ -22,7 +22,6 @@ typedef CGPoint KIFDisplacement;
 - (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label;
 - (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label traits:(UIAccessibilityTraits)traits;
 - (UIAccessibilityElement *)accessibilityElementWithLabel:(NSString *)label accessibilityValue:(NSString *)value traits:(UIAccessibilityTraits)traits;
-+ (BOOL)accessibilityElement:(UIAccessibilityElement *)element hasLabel:(NSString *)label accessibilityValue:(NSString *)value traits:(UIAccessibilityTraits)traits;
 
 /*!
  @method accessibilityElementMatchingBlock:


### PR DESCRIPTION
…to fix bugs with cell reuse"

This reverts commit 4575a4b00eec713a294bfd3c7f2d1967be18653c.

We don't necessarily need to merge this, but I'd like to at least see if this makes Travis happier. If so, we can decide if we want to merge this, if we want to take time to track down why this is breaking integration tests, or if we want to temporarily disable the flakey tests.
