### PR TITLE
Fix Accessibility

### DIFF
--- a/Classes/KIFAccessibilityEnabler.h
+++ b/Classes/KIFAccessibilityEnabler.h
@@ -8,9 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface KIFAccessibilityEnabler : NSObject
-
-+ (instancetype)sharedAccessibilityEnabler;
-- (void)enableAccessibility;
-
-@end
+/**
+ * Provides way to enable the Accessibility Inspector.
+ */
+FOUNDATION_EXTERN void KIFEnableAccessibility(void);

--- a/Classes/KIFTestCase.m
+++ b/Classes/KIFTestCase.m
@@ -64,10 +64,7 @@ NSComparisonResult selectorSort(NSInvocation *invocOne, NSInvocation *invocTwo, 
 
 + (void)setUp
 {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        [[KIFAccessibilityEnabler sharedAccessibilityEnabler] enableAccessibility];
-    });
+    KIFEnableAccessibility();
     [self performSetupTearDownWithSelector:@selector(beforeAll)];
 }
 


### PR DESCRIPTION
The changes after #877 helped with Xcode 8 but broke our Xcode 7 builds. That PR referenced google/EarlGrey#148 but wound up using a different solution than what made it into KIF. This uses a similar approach to the EarlGrey solution.

`libAccessibility.dylib` and  `_AXSSetAutomationEnabled` seem to go way back so this feels relatively safe to use. I wasn't able to test in Xcode 6 locally, but hopefully the tests will pass.

All of our KIF tests pass with this change, using both Xcode 7 and Xcode 8.

@phatmann @steipete (cc: @justinseanmartin re: #880)

---

**UPDATE**: 

There seems to be a lot of flakiness unrelated to the Xcode 7 / 8 changes. I can get this to pass all tests locally every time, but CI seems to fail a lot more often. The pull-to-refresh tests seem to fail pretty reliably on CI.

Failing tests:
* `AccessibilityIdentifierPullToRefreshTests .testPullToRefreshByAccessibilityIdentifierWithDuration`
* `PullToRefreshTests.testPullToRefreshByAccessibilityLabelWithDuration`
* `PullToRefreshTests.testPullToRefreshWithBigContentSize`
* `TableViewTests.testSwipingRows `