### PR TITLE
Add NSPhotoLibraryUsageDescription for system alert tests

### DIFF
--- a/Test Host/Test Host-Info.plist
+++ b/Test Host/Test Host-Info.plist
@@ -26,6 +26,8 @@
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>To test system alert views.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>To test system alert views.</string>
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
Test Host's plist was missing `NSPhotoLibraryUsageDescription` privacy string, which crashes the app on iOS10 when photo library permission is requested.

From [Apple's doc](https://developer.apple.com/library/prerelease/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW17):

> Important: To protect user privacy, an iOS app linked on or after iOS 10.0, and which accesses the user’s photo library, must statically declare the intent to do so. Include the NSPhotoLibraryUsageDescription key in your app’s Info.plist file and provide a purpose string for this key. If your app attempts to access the user’s photo library without a corresponding purpose string, your app exits.