### PR TITLE
Fix passing nil into a method that has an alternative with 1 fewer arguments

### DIFF
--- a/Classes/KIFAccessibilityEnabler.m
+++ b/Classes/KIFAccessibilityEnabler.m
@@ -71,7 +71,7 @@ void KIFEnableAccessibility(void)
         // If we get to this point, the legacy method has not worked
         void *handle = loadDylibForSimulator(@"/usr/lib/libAccessibility.dylib");
         if (!handle) {
-            [NSException raise:NSGenericException format:@"Could not enable accessibility" arguments:nil];
+            [NSException raise:NSGenericException format:@"Could not enable accessibility"];
         }
         
         int (*_AXSAutomationEnabled)(void) = dlsym(handle, "_AXSAutomationEnabled");


### PR DESCRIPTION
No reason to pass nil in. In fact, for nullability we get an error w/ this at Uber.