### PR TITLE
Fix for really slow stack overflow when tableview is removed from view

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -223,7 +223,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
         }
     }
     
-    if (!matchingButOccludedElement) {
+    if (!matchingButOccludedElement && self.window) {
         if ([self isKindOfClass:[UITableView class]]) {
             UITableView *tableView = (UITableView *)self;
             
@@ -239,6 +239,10 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
             
             for (NSUInteger section = 0, numberOfSections = [tableView numberOfSections]; section < numberOfSections; section++) {
                 for (NSUInteger row = 0, numberOfRows = [tableView numberOfRowsInSection:section]; row < numberOfRows; row++) {
+                    if (!self.window) {
+                        break;
+                    }
+
                     // Skip visible rows because they are already handled
                     NSIndexPath *indexPath = [NSIndexPath indexPathForRow:row inSection:section];
                     if ([indexPathsForVisibleRows containsObject:indexPath]) {
@@ -276,6 +280,10 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
             
             for (NSUInteger section = 0, numberOfSections = [collectionView numberOfSections]; section < numberOfSections; section++) {
                 for (NSUInteger item = 0, numberOfItems = [collectionView numberOfItemsInSection:section]; item < numberOfItems; item++) {
+                    if (!self.window) {
+                        break;
+                    }
+
                     // Skip visible items because they are already handled
                     NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
                     if ([indexPathsForVisibleItems containsObject:indexPath]) {


### PR DESCRIPTION
We ran into a recent test failure within KIF that was fun and convoluted:

1. We're looking for an element on the screen to tap
2. We find a UITableView that is in a UINavigationTransitionView (animating it into place)
3. We find the UIView we want to tap inside the UITableView, but it isn't tappable at its current location, so we try to scroll it into view
4. After scrolling, we sleep for a half second and check to see if it is now tappable
5. After that half second, the UINavigationTransitionView is no longer part of the window (because the animation transition completed)
6. From this point on, we'll recursively attempt to scroll the element into view, wait half a second, and then check to see if it is visible again

It sits recursing infinitely in this loop with a half second sleep between each call (so it doesn't quickly run out of stack space) and then eventually blows up.

My solution was to bail out if we find that we're checking an element that is no longer a part of the view hierarchy.