### PR TITLE
Fix swift example

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,6 @@ If you want to write your test cases in Swift, you'll need to keep two things in
 2. The `tester` and `system` keywords are C preprocessor macros which aren't available in Swift. You can easily write a small extension to `XCTestCase` or any other class to access them:
 
 ```swift
-import KIF
- 
 extension XCTestCase {
     func tester(file : String = #file, _ line : Int = #line) -> KIFUITestActor {
         return KIFUITestActor(inFile: file, atLine: line, delegate: self)


### PR DESCRIPTION
In the readme, it shows `import KIF` in your swift test case file, but that fails, and the examples in the `Documentation/Examples` folder doesn't `import KIF`, so it seems wrong.