### PR TITLE
Support for selection in DatePickers with Minimum Date value

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -622,14 +622,30 @@
         }
         // Find the picker view
         UIPickerView *pickerView = nil;
+        NSInteger firstRowToSearchIndex = 0;
         switch (pickerType)
         {
             case KIFUIDatePicker:
+            {
                 pickerView = [[[[UIApplication sharedApplication] datePickerWindow] subviewsWithClassNameOrSuperClassNamePrefix:@"UIPickerView"] lastObject];
                 KIFTestCondition(pickerView, error, @"No picker view is present");
+                
+                // If minimum date limit exist, search the value from minimum and beyond.
+                UIDatePicker *datePicker = (UIDatePicker *)pickerView;
+                if (datePicker.datePickerMode == UIDatePickerModeDateAndTime
+                    && datePicker.minimumDate != nil) {
+                    
+                    [datePicker setDate:datePicker.minimumDate];
+                    firstRowToSearchIndex = [pickerView selectedRowInComponent:0];
+                }
+                
+                
                 break;
+            }
             case KIFUIPickerView:
+            {
                 pickerView = [[[[UIApplication sharedApplication] pickerViewWindow] subviewsWithClassNameOrSuperClassNamePrefix:@"UIPickerView"] lastObject];
+            }
         }
         
         NSInteger componentCount = [pickerView.dataSource numberOfComponentsInPickerView:pickerView];
@@ -637,7 +653,7 @@
         
         for (NSInteger componentIndex = 0; componentIndex < componentCount; componentIndex++) {
             NSInteger rowCount = [pickerView.dataSource pickerView:pickerView numberOfRowsInComponent:componentIndex];
-            for (NSInteger rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+            for (NSInteger rowIndex = firstRowToSearchIndex; rowIndex < rowCount; rowIndex++) {
                 NSString *rowTitle = nil;
                 if ([pickerView.delegate respondsToSelector:@selector(pickerView:titleForRow:forComponent:)]) {
                     rowTitle = [pickerView.delegate pickerView:pickerView titleForRow:rowIndex forComponent:componentIndex];


### PR DESCRIPTION
Currently,
when trying to use `selectDatePickerValue` on DatePickers with minimumDate set, selection fails with no error. 

After debugging I realized - since Apple push into the DatePickers a 1000 rows of data, when setting minimum date - for example Today - the default value will be in the middle (row 500).

Now when the `selectDatePickerValue` method is looking for a future date (e.g "Feb 28") it will start in row 0 and find "Feb 28" of 2016. upon selecting that value, the DatePicker View will jump back automatically to minimum value (Today) and will not select the desired date.

This pull-request suggest a fix. 
I am open for changes, feedback, etc.
I tried the most simple approach i could think of:
1) if this is a DatePicker & Minimum Date is not nil 
2) find Minimum value row (by selecting it) and start your search loop for that row forward.

Would love to see it pushed in :)