### PR TITLE
Move load back into KIFTestActor class

### DIFF
--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -18,6 +18,18 @@
 
 @implementation KIFTestActor
 
++ (void)load
+{
+    @autoreleasepool {
+        if (NSClassFromString(@"UIApplication")) {
+            [UIApplication swizzleRunLoop];
+            NSLog(@"KIFTester loaded");
+        } else {
+            NSLog(@"KIFTester skipping runloop swizzling, no UIApplication class found.");
+        }
+    }
+}
+
 - (instancetype)initWithFile:(NSString *)file line:(NSInteger)line delegate:(id<KIFTestActorDelegate>)delegate
 {
     self = [super init];
@@ -198,22 +210,6 @@ static NSTimeInterval KIFTestStepDelay = 0.1;
     NSException *newException = [NSException failureInFile:self.file atLine:(int)self.line withDescription:@"Failure in child step: %@", firstException.description];
 
     [self.delegate failWithExceptions:[exceptions arrayByAddingObject:newException] stopTest:stop];
-}
-
-@end
-
-@interface UIApplication (KIFTestActorLoading)
-
-@end
-
-@implementation UIApplication (KIFTestActorLoading)
-
-+ (void)load
-{
-    @autoreleasepool {
-        NSLog(@"KIFTester loaded");
-        [UIApplication swizzleRunLoop];
-    }
 }
 
 @end


### PR DESCRIPTION
Partially reverts changes introduced in #819.

We bumped KIF to the latest release for the first time in a while and found that some logic test targets (e.g. no app host) that happen to link KIF into them as a dynamic framework fail to dlopen at load time. I isolated it back to this change, and it appears to fix the issue that we were seeing.

Ideally, we'd have a different set of test dependencies for logic tests and app tests, but the project has manually managed dependencies and this used to work and was simpler for them to manage. As this used to work with v3.4.2, it seemed appropriate to fix this and partially restore the previous behavior.

I'm not clear if the change of moving the +load to a UIApplication was necessary or just seemed more correct. @benasher44?

I'm not 100% clear on why this is failing, but I also don't know exactly how categories are supposed to behave if UIKit isn't available at runtime. This does fix the issue of KIF being linked via a dynamic framework into a logic test though. 

Generally, it also seems safer to not place a `+load` in a UIApplication category, as you can't use a method prefix and thus might stomp another `+load` in another category or in UIKit. Right?

CC: @benasher44 @holmes @phatmann