### PR TITLE
Add a CI config for Xcode 8 w/ iOS 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: objective-c
 matrix:
   include:
-    - osx_image: xcode6.4
-      env: 'SIMULATOR="name=iPad Air,OS=8.1"'
+    - osx_image: xcode8.3
+      env: 'SIMULATOR="name=iPad Air 2,OS=10.3.1"'
     - osx_image: xcode7.3
       env: 'SIMULATOR="name=iPhone 6s,OS=9.3"'
     - osx_image: xcode6.4

--- a/KIF Tests/ModalViewTests.m
+++ b/KIF Tests/ModalViewTests.m
@@ -52,7 +52,12 @@
     
     [tester tapViewWithAccessibilityLabel:@"UIActivityViewController"];
     [tester waitForTappableViewWithAccessibilityLabel:@"Copy"];
-    [tester waitForTappableViewWithAccessibilityLabel:@"Mail"];
+
+    if ([UIDevice.currentDevice.systemVersion compare:@"10.0" options:NSNumericSearch] < 0) {
+        [tester waitForTappableViewWithAccessibilityLabel:@"Mail"];
+    } else {
+        [tester waitForTappableViewWithAccessibilityLabel:@"Add To iCloud Drive"];
+    }
 
     // On iOS7, the activity controller appears at the bottom
     // On iOS8 and beyond, it is shown in a popover control

--- a/KIF Tests/ModalViewTests_ViewTestActor.m
+++ b/KIF Tests/ModalViewTests_ViewTestActor.m
@@ -46,6 +46,13 @@
 
 - (void)testInteractionWithAnActivityViewController
 {
+    NSOperatingSystemVersion iOS11 = {11, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)]
+        && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS11]) {
+        NSLog(@"This test can't be run on iOS 11, as the activity sheet is hosted in an `AXRemoteElement`");
+        return;
+    }
+    
     if (!NSClassFromString(@"UIActivityViewController")) {
         return;
     }

--- a/KIF Tests/ModalViewTests_ViewTestActor.m
+++ b/KIF Tests/ModalViewTests_ViewTestActor.m
@@ -52,12 +52,17 @@
 
     [[viewTester usingLabel:@"UIActivityViewController"] tap];
     [[viewTester usingLabel:@"Copy"] waitForTappableView];
-    [[viewTester usingLabel:@"Mail"] waitForTappableView];
+
+    if ([UIDevice.currentDevice.systemVersion compare:@"10.0" options:NSNumericSearch] < 0) {
+        [[viewTester usingLabel:@"Mail"] waitForTappableView];
+    } else {
+        [[viewTester usingLabel:@"Add To iCloud Drive"] waitForTappableView];
+    }
 
     // On iOS7, the activity controller appears at the bottom
     // On iOS8 and beyond, it is shown in a popover control
     if ([UIDevice.currentDevice.systemVersion compare:@"8.0" options:NSNumericSearch] < 0) {
-        [tester tapViewWithAccessibilityLabel:@"Cancel"];
+        [[viewTester usingLabel:@"Cancel"] tap];
     } else {
         [self _dismissModal];
     }
@@ -68,9 +73,9 @@
 - (void)_dismissModal;
 {
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-        [tester dismissPopover];
+        [viewTester dismissPopover];
     } else {
-        [tester tapViewWithAccessibilityLabel:@"Cancel"];
+        [[viewTester usingLabel:@"Cancel"] tap];
     }
 }
 

--- a/Test Host/TapViewController.m
+++ b/Test Host/TapViewController.m
@@ -28,6 +28,9 @@
     self.lineBreakLabel.accessibilityLabel = @"A\nB\nC\n\n";
 	self.stepper.isAccessibilityElement = YES;
 	self.stepper.accessibilityLabel = @"theStepper";
+    
+    // Prevent autocorrect from kicking in, breaks tests starting with iOS10
+    self.greetingTextField.autocorrectionType = UITextAutocorrectionTypeNo;
 }
 
 - (void)memoryWarningNotification:(NSNotification *)notification


### PR DESCRIPTION
Add a CI config for Xcode 8 w/ iOS 10. This requires fixing some tests that break on this configuration.

The second commit ("Disable autocorrect when entering text") is an attempt at handling a longstanding issue where controls that have autocorrect enabled on them can lead to unexpected things entered. This is causing a new test failure in the new CI configuration of changing `ll` to `lol`.

I don't see a reason why a test would want to rely on the OS level autocorrect functionality in their test. Please feel free to voice concern about this, looking for opinions. The reasonable (and up-to-now expected) alternative would be to modify the particular text field in the Test App to not have autocorrect enabled.

I still need to do some more testing on this however, as the fix doesn't seem to quite work as expected. I'll mark this "Don't merge yet!" for now.