### PR TITLE
acknowledgeSystemAlert() crash patch

### DIFF
--- a/Classes/UIAutomationHelper.m
+++ b/Classes/UIAutomationHelper.m
@@ -132,6 +132,11 @@ static void FixReactivateApp(void)
 
 - (BOOL)_alertIsValidAndVisible:(UIAAlert *)alert;
 {
+    // Ignore alert if in process; calling isVisible on alert in process causes a signal such as EXC_BAD_INSTRUCTION (not a catchable exception)
+    UIAApplication *application = [[self target] frontMostApp];
+    if ([@(getpid()) isEqual:[application pid]])
+        return false;
+
     // [alert isValid] is returning an __NSCFBoolean which is really hard to compare against.
     // Translate the __NSCFBoolean into a vanilla BOOL.
     // See https://www.bignerdranch.com/blog/bools-sharp-corners/ for more details.


### PR DESCRIPTION
Patch for consistent crash in acknowledgeSystemAlert() if an app alert is displayed. Capital One has been using this patch on a fork for 6 months.
<img width="1120" alt="signal" src="https://cloud.githubusercontent.com/assets/28807700/26363299/9a32bc54-3fae-11e7-9e22-9262a5018209.png">
