### PR TITLE
Expand the set of exposed UIViewTester matchers and actions

### DIFF
--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -94,6 +94,8 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 @property (nonatomic) NSTimeInterval animationStabilizationTimeout;
 
 - (instancetype)usingTimeout:(NSTimeInterval)executionBlockTimeout;
+- (instancetype)usingAnimationWaitingTimeout:(NSTimeInterval)animationWaitingTimeout;
+- (instancetype)usingAnimationStabilizationTimeout:(NSTimeInterval)animationStabilizationTimeout;
 
 - (void)runBlock:(KIFTestExecutionBlock)executionBlock complete:(KIFTestCompletionBlock)completionBlock timeout:(NSTimeInterval)timeout;
 - (void)runBlock:(KIFTestExecutionBlock)executionBlock complete:(KIFTestCompletionBlock)completionBlock;

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -57,6 +57,18 @@
     return self;
 }
 
+- (instancetype)usingAnimationWaitingTimeout:(NSTimeInterval)animationWaitingTimeout;
+{
+    self.animationWaitingTimeout = animationWaitingTimeout;
+    return self;
+}
+
+- (instancetype)usingAnimationStabilizationTimeout:(NSTimeInterval)animationStabilizationTimeout;
+{
+    self.animationStabilizationTimeout = animationStabilizationTimeout;
+    return self;
+}
+
 - (BOOL)tryRunningBlock:(KIFTestExecutionBlock)executionBlock complete:(KIFTestCompletionBlock)completionBlock timeout:(NSTimeInterval)timeout error:(out NSError **)error
 {
     NSDate *startDate = [NSDate date];

--- a/Classes/KIFUIViewTestActor.h
+++ b/Classes/KIFUIViewTestActor.h
@@ -38,6 +38,7 @@ extern NSString *const inputFieldTestString;
 - (instancetype)validateEnteredText:(BOOL)validateEnteredText;
 
 #pragma mark - Searching for Accessibility Elements
+
 /*!
  These methods are used to build the tester's search predicate. they are intended to be chained together allowing for complex searches.
  You can also build constructor methods which return view testers configured to find a specific element.
@@ -57,7 +58,7 @@ extern NSString *const inputFieldTestString;
 
 /*!
  @abstract Adds a check for an accessibility label to the tester's search pedicate.
- @discussion The tester will evaluate accessibility elements looking for a maching accessibility label.
+ @discussion The tester will evaluate accessibility elements looking for a matching accessibility label.
  @param accessibilityLabel The accessibility label of an element to match.
  @return The message reciever, these methods are intended to be chained together.
  */
@@ -65,7 +66,7 @@ extern NSString *const inputFieldTestString;
 
 /*!
  @abstract Adds a check for an accessibility identifier to the tester's search pedicate.
- @discussion The tester will evaluate accessibility elements looking for a maching accessibility identifier.
+ @discussion The tester will evaluate accessibility elements looking for a matching accessibility identifier.
  @param accessibilityIdentifier The accessibility identifier of an element to match.
  @return The message reciever, these methods are intended to be chained together.
  */
@@ -73,7 +74,7 @@ extern NSString *const inputFieldTestString;
 
 /*!
  @abstract Adds a check for accessibility traits to the tester's search pedicate.
- @discussion The tester will evaluate accessibility elements looking for maching accessibility traits.
+ @discussion The tester will evaluate accessibility elements looking for matching accessibility traits.
  @param accessibilityTraits The accessibility traits of an element to match.
  @return The message reciever, these methods are intended to be chained together.
  */
@@ -81,11 +82,18 @@ extern NSString *const inputFieldTestString;
 
 /*!
  @abstract Adds a check for an accessibility value to the tester's search pedicate.
- @discussion The tester will evaluate accessibility elements looking for a maching accessibility value.
+ @discussion The tester will evaluate accessibility elements looking for a matching accessibility value.
  @param accessibilityValue The accessibility value of an element to match.
  @return The message reciever, these methods are intended to be chained together.
  */
 - (instancetype)usingValue:(NSString *)accessibilityValue;
+
+/*!
+ @abstract Adds a check to only operate on the current first responder.
+ @discussion The tester will evaluate accessibility elements waiting for a first responder.
+ @return The message reciever, these methods are intended to be chained together.
+ */
+- (instancetype)usingFirstResponder;
 
 /*!
  @abstract Adds a given predicate to the tester's search predicate.
@@ -95,7 +103,6 @@ extern NSString *const inputFieldTestString;
  */
 - (instancetype)usingPredicate:(NSPredicate *)predicate;
 
-
 #pragma mark - Acting on Accessibility Elements
 
 /*!
@@ -104,6 +111,7 @@ extern NSString *const inputFieldTestString;
  */
 
 #pragma mark Tapping, Pressing & Swiping
+
 /*!
  @abstract Tap a view matching the tester's search predicate.
  @discussion The tester will evaluate the accessibility hierarchy against it's search predicate and perform a tap on the first match.
@@ -148,6 +156,14 @@ extern NSString *const inputFieldTestString;
 - (UIView *)waitForView;
 
 /*!
+ @abstract Waits until a view or accessibility element matching the tester's search predicate is present and available for tapping.
+ @discussion The view or accessibility elemenr is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Whether or not a view is tappable is based on -[UIView hitTest:]
+
+ @return The found view, if applicable.
+ */
+- (UIView *)waitForTappableView;
+
+/*!
  @abstract Waits until a view or accessibility element is no longer present.
  @discussion The view or accessibility element is searched for in the view hierarchy. If the element is found, then the step will attempt to wait until it isn't. Note that the view does not necessarily have to be visible on the screen, and may be behind another view or offscreen. Views with their hidden property set to YES are considered absent.
  */
@@ -156,7 +172,7 @@ extern NSString *const inputFieldTestString;
 /*!
  @abstract Waits until a view or accessibility element matching the tester's search predicate is present and available for tapping.
  @discussion The view or accessibility elemenr is searched for in the view hierarchy. If the element isn't found or isn't currently tappable, then the step will attempt to wait until it is. Whether or not a view is tappable is based on -[UIView hitTest:]. */
-- (void)waitToBecomeTappable;
+- (void)waitToBecomeTappable DEPRECATED_MSG_ATTRIBUTE("Use 'waitForTappableView' instead.");
 
 /*!
  @abstract Waits until a view or accessibility element matching the tester's search predicate is the first responder.
@@ -180,8 +196,13 @@ extern NSString *const inputFieldTestString;
  */
 - (BOOL)tryFindingTappableView;
 
+/*!
+ @abstract Tries to guess if there are any unfinished animations and waits for a certain amount of time to let them finish.
+ */
+- (void)waitForAnimationsToFinish;
 
 #pragma mark Scroll Views, Table Views and Collection Views
+
 /*!
  @abstract Taps the row at indexPath in a table view matching the tester's search predicate.
  @discussion This step will tap the row at indexPath.
@@ -243,7 +264,6 @@ extern NSString *const inputFieldTestString;
  */
 - (void)scrollByFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction;
 
-
 #pragma mark Text Input
 
 /*!
@@ -266,14 +286,14 @@ extern NSString *const inputFieldTestString;
  @discussion Text is entered into the view by simulating taps on the appropriate keyboard keys if the keyboard is already displayed. Useful to enter text in UIWebViews or components with no accessibility labels.
  @param text The text to enter.
  */
-- (void)enterTextIntoCurrentFirstResponder:(NSString *)text;
+- (void)enterTextIntoCurrentFirstResponder:(NSString *)text DEPRECATED_MSG_ATTRIBUTE("Use 'usingFirstResponder' instead.");
 /*!
  @abstract Enters text into a the current first responder. if KIF is unable to type with the keyboard (which could be dismissed or obscured) the tester will call setText on the fallback view directly.
  @discussion Text is entered into the view by simulating taps on the appropriate keyboard keys if the keyboard is already displayed. Useful to enter text in UIWebViews or components with no accessibility labels.
  @param text The text to enter.
  @param fallbackView The UIView to enter if keyboard input fails.
  */
-- (void)enterTextIntoCurrentFirstResponder:(NSString *)text fallbackView:(UIView *)fallbackView;
+- (void)enterTextIntoCurrentFirstResponder:(NSString *)text fallbackView:(UIView *)fallbackView DEPRECATED_MSG_ATTRIBUTE("Please log a KIF Github issue if you have a use case for this.");
 
 /*!
  @abstract Clears text from a particular view matching the tester's search predicate.
@@ -305,10 +325,17 @@ extern NSString *const inputFieldTestString;
 
 /*!
  @abstract Sets text into a particular view matching the tester's search predicate.
- @discussion If the element isn't currently tappable, then the step will attempt to wait until it is. Once the view is present and tappable, then text is set on the view. Does not result in first responder changes. Does not perform expected result validation.
+ @discussion The text is set on the view directly with 'setText:'. Does not result in first responder changes. Does not perform expected result validation.
  @param text The text to set.
  */
 - (void)setText:(NSString *)text;
+
+/*!
+ @abstract Validates the text in a field matches the supplied expected value.
+ @discussion Waits until the view is present (up to the standard timeout), and then ensures that it has expected text.
+ @param expectedResult The text to expect the view to contain.
+ */
+- (void)expectToContainText:(NSString *)expectedResult;
 
 /*!
  @abstract Waits for the software keyboard to be visible.
@@ -390,6 +417,14 @@ extern NSString *const inputFieldTestString;
  @param datePickerColumnValues Each element in the NSArray represents a rotating wheel in the date picker control. Elements from 0 - n are listed in the order of the rotating wheels, left to right.
  */
 - (void)selectDatePickerValue:(NSArray *)datePickerColumnValues;
+
+/*!
+ @abstract Selects a value from a currently visible date picker view, according to the search order specified.
+ @discussion With a date picker view already visible, this step will select the different rotating wheel values in order of how the array parameter is passed in. Each value will be searched according to the search order provided. After it is done it will hide the date picker. It works with all 4 UIDatePickerMode* modes. The input parameter of type NSArray has to match in what order the date picker is displaying the values/columns. So if the locale is changing the input parameter has to be adjusted. Example: Mode: UIDatePickerModeDate, Locale: en_US, Input param: NSArray *date = @[@"June", @"17", @"1965"];. Example: Mode: UIDatePickerModeDate, Locale: de_DE, Input param: NSArray *date = @[@"17.", @"Juni", @"1965".
+ @param datePickerColumnValues Each element in the NSArray represents a rotating wheel in the date picker control. Elements from 0 - n are listed in the order of the rotating wheels, left to right.
+ @param searchOrder The order in which the values are being searched for selection in each compotent.
+ */
+- (void)selectDatePickerValue:(NSArray *)datePickerColumnValues withSearchOrder:(KIFPickerSearchOrder)searchOrder;
 
 /*!
  @abstract Select a certain photo from the built in photo picker.

--- a/Classes/KIFUIViewTestActor.h
+++ b/Classes/KIFUIViewTestActor.h
@@ -225,6 +225,18 @@ extern NSString *const inputFieldTestString;
 - (UITableViewCell *)waitForCellInTableViewAtIndexPath:(NSIndexPath *)indexPath;
 
 /*!
+ @abstract Scrolls a table view matching the tester's search predicate while waiting for the cell at the given indexPath to appear.
+ @discussion This step will get the cell at the indexPath.
+ 
+ For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+ 
+ @param indexPath Index path of the cell.
+ @param position Table View scroll position to scroll to. Useful for tall cells when the content needed is in a specific location.
+ @return The table view cell at the given index path.
+ */
+- (UITableViewCell *)waitForCellInTableViewAtIndexPath:(NSIndexPath *)indexPath atPosition:(UITableViewScrollPosition)position;
+
+/*!
  @abstract Moves the row at sourceIndexPath to destinationIndexPath in a table view matching the tester's search predicate.
  @discussion This step will move the row at sourceIndexPath to destinationIndexPath.
  

--- a/Classes/KIFUIViewTestActor.m
+++ b/Classes/KIFUIViewTestActor.m
@@ -14,8 +14,8 @@
 #import "NSPredicate+KIFAdditions.h"
 #import "NSString+KIFAdditions.h"
 #import "UIAccessibilityElement-KIFAdditions.h"
+#import "UIApplication-KIFAdditions.h"
 #import "UIWindow-KIFAdditions.h"
-
 
 @interface KIFUIViewTestActor ()
 
@@ -128,8 +128,13 @@ NSString *const inputFieldTestString = @"Testing";
 - (instancetype)usingFirstResponder;
 {
     NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
-        UIView *firstResponderView = (id)[[[UIApplication sharedApplication] keyWindow] firstResponder];
-        return [evaluatedObject isEqual:firstResponderView];
+        // The current first responder can be in any application window
+        for (UIWindow *window in [[UIApplication sharedApplication] windowsWithKeyWindow]) {
+            if ([evaluatedObject isEqual:window.firstResponder]) {
+                return YES;
+            }
+        }
+        return NO;
     }];
     predicate.kifPredicateDescription = [NSString stringWithFormat:@"Is First Responder"];
     

--- a/Classes/KIFUIViewTestActor.m
+++ b/Classes/KIFUIViewTestActor.m
@@ -241,8 +241,10 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (void)tap;
 {
-    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:YES];
-    [self.actor tapAccessibilityElement:found.element inView:found.view];
+    @autoreleasepool {
+        KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:YES];
+        [self.actor tapAccessibilityElement:found.element inView:found.view];
+    }
 }
 
 - (void)longPress;
@@ -252,16 +254,20 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (void)longPressWithDuration:(NSTimeInterval)duration;
 {
-    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:YES];
-    [self.actor longPressAccessibilityElement:found.element inView:found.view duration:duration];
+    @autoreleasepool {
+        KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:YES];
+        [self.actor longPressAccessibilityElement:found.element inView:found.view duration:duration];
+    }
 }
 
 #pragma mark - Text Actions;
 
 - (void)clearText;
 {
-    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor clearTextFromElement:found.element inView:found.view];
+    @autoreleasepool {
+        KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor clearTextFromElement:found.element inView:found.view];
+    }
 }
 
 - (void)clearTextFromFirstResponder;
@@ -276,8 +282,10 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (void)enterText:(NSString *)text expectedResult:(NSString *)expectedResult;
 {
-    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor enterText:text intoElement:found.element inView:found.view expectedResult:expectedResult];
+    @autoreleasepool {
+        KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor enterText:text intoElement:found.element inView:found.view expectedResult:expectedResult];
+    }
 }
 
 - (void)clearAndEnterText:(NSString *)text;
@@ -320,10 +328,11 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (void)expectToContainText:(NSString *)expectedResult;
 {
-    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor expectView:found.view toContainText:expectedResult];
+    @autoreleasepool {
+        KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor expectView:found.view toContainText:expectedResult];
+    }
 }
-
 
 #pragma mark - Touch Actions
 
@@ -334,22 +343,28 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (void)swipeInDirection:(KIFSwipeDirection)direction;
 {
-    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor swipeAccessibilityElement:found.element inView:found.view inDirection:direction];
+    @autoreleasepool {
+        KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor swipeAccessibilityElement:found.element inView:found.view inDirection:direction];
+    }
 }
 
 #pragma mark - Scroll/Table/CollectionView Actions
 
 - (void)scrollByFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction;
 {
-    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor scrollAccessibilityElement:found.element inView:found.view byFractionOfSizeHorizontal:horizontalFraction vertical:verticalFraction];
+    @autoreleasepool {
+        KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor scrollAccessibilityElement:found.element inView:found.view byFractionOfSizeHorizontal:horizontalFraction vertical:verticalFraction];
+    }
 }
 
 - (void)tapRowInTableViewAtIndexPath:(NSIndexPath *)indexPath;
 {
-    KIFUIObject *found = [[self _usingExpectedClass:[UITableView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor tapRowAtIndexPath:indexPath inTableView:(UITableView *)found.view];
+    @autoreleasepool {
+        KIFUIObject *found = [[self _usingExpectedClass:[UITableView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor tapRowAtIndexPath:indexPath inTableView:(UITableView *)found.view];
+    }
 }
 
 - (UITableViewCell *)waitForCellInTableViewAtIndexPath:(NSIndexPath *)indexPath;
@@ -367,21 +382,27 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (void)moveRowInTableViewAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath;
 {
-    KIFUIObject *found = [[self _usingExpectedClass:[UITableView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor moveRowAtIndexPath:sourceIndexPath toIndexPath:destinationIndexPath inTableView:(UITableView *)found.view];
+    @autoreleasepool {
+        KIFUIObject *found = [[self _usingExpectedClass:[UITableView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor moveRowAtIndexPath:sourceIndexPath toIndexPath:destinationIndexPath inTableView:(UITableView *)found.view];
+    }
 }
 
 
 - (void)tapCollectionViewItemAtIndexPath:(NSIndexPath *)indexPath;
 {
-    KIFUIObject *found = [[self _usingExpectedClass:[UICollectionView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor tapItemAtIndexPath:indexPath inCollectionView:(UICollectionView *)found.view];
+    @autoreleasepool {
+        KIFUIObject *found = [[self _usingExpectedClass:[UICollectionView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor tapItemAtIndexPath:indexPath inCollectionView:(UICollectionView *)found.view];
+    }
 }
 
 - (UICollectionViewCell *)waitForCellInCollectionViewAtIndexPath:(NSIndexPath *)indexPath;
 {
-    KIFUIObject *found = [[self _usingExpectedClass:[UICollectionView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    return [self.actor waitForCellAtIndexPath:indexPath inCollectionView:(UICollectionView *)found.view];
+    @autoreleasepool {
+        KIFUIObject *found = [[self _usingExpectedClass:[UICollectionView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        return [self.actor waitForCellAtIndexPath:indexPath inCollectionView:(UICollectionView *)found.view];
+    }
 }
 
 
@@ -389,14 +410,18 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (void)setSliderValue:(float)value;
 {
-    KIFUIObject *found = [[self _usingExpectedClass:[UISlider class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor setValue:value forSlider:(UISlider *)found.view];
+    @autoreleasepool {
+        KIFUIObject *found = [[self _usingExpectedClass:[UISlider class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor setValue:value forSlider:(UISlider *)found.view];
+    }
 }
 
 - (void)setSwitchOn:(BOOL)switchIsOn;
 {
-    KIFUIObject *found = [[self _usingExpectedClass:[UISwitch class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor setSwitch:(UISwitch *)found.view element:found.element On:switchIsOn];
+    @autoreleasepool {
+        KIFUIObject *found = [[self _usingExpectedClass:[UISwitch class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor setSwitch:(UISwitch *)found.view element:found.element On:switchIsOn];
+    }
 }
 
 #pragma mark - Picker Actions
@@ -408,16 +433,20 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (void)selectPickerViewRowWithTitle:(NSString *)title inComponent:(NSInteger)component;
 {
-    KIFUIObject *found = [[self _usingExpectedClass:[UIPickerView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    UIPickerView *picker = (UIPickerView *) found.view;
-    [self.actor selectPickerViewRowWithTitle:title inComponent:component fromPicker:picker withSearchOrder:KIFPickerSearchForwardFromStart];
+    @autoreleasepool {
+        KIFUIObject *found = [[self _usingExpectedClass:[UIPickerView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        UIPickerView *picker = (UIPickerView *) found.view;
+        [self.actor selectPickerViewRowWithTitle:title inComponent:component fromPicker:picker withSearchOrder:KIFPickerSearchForwardFromStart];
+    }
 }
 
 - (void)selectDatePickerViewRowWithTitle:(NSString *)title inComponent:(NSInteger)component;
 {
-    KIFUIObject *found = [[self _usingExpectedClass:[UIDatePicker class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    UIPickerView *picker = [self _getDatePickerViewFromPicker:found.view];
-    [self.actor selectPickerViewRowWithTitle:title inComponent:component fromPicker:picker withSearchOrder:KIFPickerSearchForwardFromStart];
+    @autoreleasepool {
+        KIFUIObject *found = [[self _usingExpectedClass:[UIDatePicker class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        UIPickerView *picker = [self _getDatePickerViewFromPicker:found.view];
+        [self.actor selectPickerViewRowWithTitle:title inComponent:component fromPicker:picker withSearchOrder:KIFPickerSearchForwardFromStart];
+    }
 }
 
 - (void)selectDatePickerValue:(NSArray *)datePickerColumnValues;
@@ -427,9 +456,11 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (void)selectDatePickerValue:(NSArray *)datePickerColumnValues withSearchOrder:(KIFPickerSearchOrder)searchOrder;
 {
-    KIFUIObject *found = [[self _usingExpectedClass:[UIDatePicker class]] _predicateSearchWithRequiresMatch:NO mustBeTappable:NO];
-    UIPickerView *picker = [self _getDatePickerViewFromPicker:found.view];
-    [self.actor selectDatePickerValue:datePickerColumnValues fromPicker:picker withSearchOrder:searchOrder];
+    @autoreleasepool {
+        KIFUIObject *found = [[self _usingExpectedClass:[UIDatePicker class]] _predicateSearchWithRequiresMatch:NO mustBeTappable:NO];
+        UIPickerView *picker = [self _getDatePickerViewFromPicker:found.view];
+        [self.actor selectDatePickerValue:datePickerColumnValues fromPicker:picker withSearchOrder:searchOrder];
+    }
 }
 
 #pragma mark - Photo Picker
@@ -443,15 +474,18 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (void)pullToRefresh;
 {
-    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor pullToRefreshAccessibilityElement:found.element inView:found.view pullDownDuration:0];
+    @autoreleasepool {
+        KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor pullToRefreshAccessibilityElement:found.element inView:found.view pullDownDuration:0];
+    }
 }
 
 - (void)pullToRefreshWithDuration:(KIFPullToRefreshTiming)pullDownDuration;
 {
-    KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    [self.actor pullToRefreshAccessibilityElement:found.element inView:found.view pullDownDuration:pullDownDuration];
-
+    @autoreleasepool {
+        KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        [self.actor pullToRefreshAccessibilityElement:found.element inView:found.view pullDownDuration:pullDownDuration];
+    }
 }
 
 #pragma mark - Getters

--- a/Classes/KIFUIViewTestActor.m
+++ b/Classes/KIFUIViewTestActor.m
@@ -354,8 +354,15 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (UITableViewCell *)waitForCellInTableViewAtIndexPath:(NSIndexPath *)indexPath;
 {
-    KIFUIObject *found = [[self _usingExpectedClass:[UITableView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
-    return [self.actor waitForCellAtIndexPath:indexPath inTableView:(UITableView *)found.view];
+    return [self waitForCellInTableViewAtIndexPath:indexPath atPosition:UITableViewScrollPositionMiddle];
+}
+
+- (UITableViewCell *)waitForCellInTableViewAtIndexPath:(NSIndexPath *)indexPath atPosition:(UITableViewScrollPosition)position;
+{
+    @autoreleasepool {
+        KIFUIObject *found = [[self _usingExpectedClass:[UITableView class]] _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        return [self.actor waitForCellAtIndexPath:indexPath inTableView:(UITableView *)found.view atPosition:position];
+    }
 }
 
 - (void)moveRowInTableViewAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath;

--- a/Documentation/Examples/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Documentation/Examples/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -606,6 +606,7 @@
 				62F81B4E1EBBE925009B2400 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		EB4C30D3167B9E3A00E31109 /* Build configuration list for PBXProject "Calculator" */ = {
 			isa = XCConfigurationList;

--- a/KIF Tests/GestureTests_ViewTestActor.m
+++ b/KIF Tests/GestureTests_ViewTestActor.m
@@ -98,9 +98,9 @@
 {
     // Needs to be offset from the edge to prevent the navigation controller's interactivePopGestureRecognizer from triggering
     [[viewTester usingIdentifier:@"Scroll View"] scrollByFractionOfSizeHorizontal:-0.80 vertical:-0.80];
-    [[viewTester usingLabel:@"Bottom Right"] waitToBecomeTappable];
+    [[viewTester usingLabel:@"Bottom Right"] waitForTappableView];
     [[viewTester usingIdentifier:@"Scroll View"] scrollByFractionOfSizeHorizontal:0.80 vertical:0.80];
-    [[viewTester usingLabel:@"Top Left"] waitToBecomeTappable];
+    [[viewTester usingLabel:@"Top Left"] waitForTappableView];
 }
 
 - (void)testMissingScrollableElement

--- a/KIF Tests/ModalViewTests_ViewTestActor.m
+++ b/KIF Tests/ModalViewTests_ViewTestActor.m
@@ -23,8 +23,8 @@
     [[viewTester usingLabel:@"UIAlertView"] tap];
     [[viewTester usingLabel:@"Alert View"] waitForView];
     [[viewTester usingLabel:@"Message"] waitForView];
-    [[viewTester usingLabel:@"Cancel"] waitToBecomeTappable];
-    [[viewTester usingLabel:@"Continue"] waitToBecomeTappable];
+    [[viewTester usingLabel:@"Cancel"] waitForTappableView];
+    [[viewTester usingLabel:@"Continue"] waitForTappableView];
     [[viewTester usingLabel:@"Continue"] tap];
     [[viewTester usingLabel:@"Message"] waitForAbsenceOfView];
 }
@@ -33,9 +33,9 @@
 {
     [[viewTester usingLabel:@"UIActionSheet"] tap];
     [[viewTester usingLabel:@"Action Sheet"] waitForView];
-    [[viewTester usingLabel:@"Destroy"] waitToBecomeTappable];
-    [[viewTester usingLabel:@"A"] waitToBecomeTappable];
-    [[viewTester usingLabel:@"B"] waitToBecomeTappable];
+    [[viewTester usingLabel:@"Destroy"] waitForTappableView];
+    [[viewTester usingLabel:@"A"] waitForTappableView];
+    [[viewTester usingLabel:@"B"] waitForTappableView];
 
     [self _dismissModal];
     
@@ -51,8 +51,8 @@
     }
 
     [[viewTester usingLabel:@"UIActivityViewController"] tap];
-    [[viewTester usingLabel:@"Copy"] waitToBecomeTappable];
-    [[viewTester usingLabel:@"Mail"] waitToBecomeTappable];
+    [[viewTester usingLabel:@"Copy"] waitForTappableView];
+    [[viewTester usingLabel:@"Mail"] waitForTappableView];
 
     // On iOS7, the activity controller appears at the bottom
     // On iOS8 and beyond, it is shown in a popover control

--- a/KIF Tests/SearchFieldTests_ViewTestActor.m
+++ b/KIF Tests/SearchFieldTests_ViewTestActor.m
@@ -30,7 +30,7 @@
 {
     [[viewTester usingTraits:UIAccessibilityTraitSearchField] tap];
     [[viewTester usingTraits:UIAccessibilityTraitSearchField] waitToBecomeFirstResponder];
-    [viewTester enterTextIntoCurrentFirstResponder:@"text"];
+    [[viewTester usingFirstResponder] enterText:@"text"];
     [[[viewTester usingValue:@"text"] usingTraits:UIAccessibilityTraitSearchField] waitForView];
 }
 

--- a/KIF Tests/TypingTests_ViewTestActor.m
+++ b/KIF Tests/TypingTests_ViewTestActor.m
@@ -40,13 +40,13 @@
 {
     [[[viewTester usingLabel:@"Greeting"] usingValue:@"Hello"] longPressWithDuration:2];
     [[viewTester usingLabel:@"Select All"] tap];
-    [viewTester enterTextIntoCurrentFirstResponder:@"Yo"];
+    [[viewTester usingFirstResponder] enterText:@"Yo"];
     [[[viewTester usingLabel:@"Greeting"] usingValue:@"Yo"] waitForView];
 }
 
 - (void)testFailingToEnterTextIntoFirstResponder
 {
-    KIFExpectFailure([[viewTester usingTimeout:1] enterTextIntoCurrentFirstResponder:@"Yo"]);
+    KIFExpectFailure([[[viewTester usingTimeout:1] usingFirstResponder] enterText:@"Yo"]);
 }
 
 - (void)testEnteringTextIntoViewWithAccessibilityLabel

--- a/KIF Tests/WaitForTappableViewTests_ViewTestActor.m
+++ b/KIF Tests/WaitForTappableViewTests_ViewTestActor.m
@@ -27,17 +27,17 @@
 
 - (void)testWaitingForTappableViewWithAccessibilityLabel
 {
-    [[viewTester usingLabel:@"B"] waitToBecomeTappable];
+    [[viewTester usingLabel:@"B"] waitForTappableView];
 }
 
 - (void)testWaitingForViewWithTraits
 {
-    [[[viewTester usingLabel:@"B"] usingTraits:UIAccessibilityTraitButton] waitToBecomeTappable];
+    [[[viewTester usingLabel:@"B"] usingTraits:UIAccessibilityTraitButton] waitForTappableView];
 }
 
 - (void)testWaitingForViewWithValue
 {
-    [[[[viewTester usingLabel:@"B"] usingValue:@"BB"] usingTraits:UIAccessibilityTraitButton] waitToBecomeTappable];
+    [[[[viewTester usingLabel:@"B"] usingValue:@"BB"] usingTraits:UIAccessibilityTraitButton] waitForTappableView];
 }
 
 @end

--- a/KIF Tests/WebViewTests_ViewTestActor.m
+++ b/KIF Tests/WebViewTests_ViewTestActor.m
@@ -40,8 +40,9 @@
 
 - (void)testEnteringText
 {
-    [[viewTester usingLabel:@"Input Label"] tap];
-    [viewTester enterTextIntoCurrentFirstResponder:@"Keyboard text"];
+    // Needs to opt-out of text validation, because the matched UI element is actually the UIWebView.
+    // It responds to `text`, but is equal to whole view's text rather than just being scoped to the entered text.
+    [[[viewTester validateEnteredText:NO] usingLabel:@"Input Label"] enterText:@"Keyboard text"];
 }
 
 @end


### PR DESCRIPTION
I found some actions that existed in `KIFUITestActor` that weren't being exposed in `KIFUIViewTestActor`. This tries to bring it to parity. The typing into first responder I solved by introducing `usingFirstResponder` as a matcher.