### PR TITLE
Prevent using expectedResult without validating the entered text

### DIFF
--- a/Classes/KIFUIViewTestActor.m
+++ b/Classes/KIFUIViewTestActor.m
@@ -287,6 +287,10 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (void)enterText:(NSString *)text expectedResult:(NSString *)expectedResult;
 {
+    if (!self.validateEnteredText && expectedResult) {
+        [self failWithMessage:@"Can't supply an expectedResult string if `validateEnteredText` is NO."];
+    }
+
     @autoreleasepool {
         KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
         [self.actor enterText:text intoElement:found.element inView:found.view expectedResult:expectedResult];


### PR DESCRIPTION
Add a safety check that prevents using expectedResult without validating the entered text. This was suggested by @RoyalPineapple in code review.