### PR TITLE
Add an optional compiler flag DEPRECATE_KIF_TESTER

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -11,7 +11,16 @@
 #import <UIKit/UIKit.h>
 #import "UIView-KIFAdditions.h"
 
+
+#if DEPRECATE_KIF_TESTER
+// Add `-DDEPRECATE_KIF_TESTER=1` to OTHER_CFLAGS if you'd like to prevent usage of `tester`.
+@class KIFUITestActor;
+KIFUITestActor *_KIF_tester() __attribute__((deprecated("Use of `tester` has been deprecated; Use `viewTester` instead.")));
+#define tester _KIF_tester()
+#else
 #define tester KIFActorWithClass(KIFUITestActor)
+#endif
+
 
 /*!
  @enum KIFSwipeDirection

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -26,6 +26,15 @@
 #define kKIFMinorSwipeDisplacement 5
 
 
+#if DEPRECATE_KIF_TESTER
+KIFUITestActor *_KIF_tester()
+{
+    NSCAssert(NO, @"Attempting to use deprecated `KIFUITestActor`!");
+    return nil;
+}
+#endif
+
+
 @interface KIFUITestActor ()
 
 @property (nonatomic, assign) BOOL validateEnteredText;


### PR DESCRIPTION
We've deprecated all usage of `tester` and would like to prevent further usages from creeping in.

In order to use it, we are setting: `OTHER_CFLAGS = "$(inherited) -DDEPRECATE_KIF_TESTER=1"`

When that CFLAG is present, it will generate a deprecation warning with the message:
> Use of `tester` has been deprecated; Use `viewTester` instead.