### PR TITLE
Make majorSwipeDisplacement smaller

### DIFF
--- a/Additions/UIScreen+KIFAdditions.m
+++ b/Additions/UIScreen+KIFAdditions.m
@@ -11,7 +11,7 @@
 @implementation UIScreen (KIFAdditions)
 
 - (CGFloat)majorSwipeDisplacement {
-    return self.bounds.size.width * 0.625;
+    return self.bounds.size.width * 0.5;
 }
 
 @end

--- a/KIF Tests/Additions/UIScreen+KIFAdditionsTests.m
+++ b/KIF Tests/Additions/UIScreen+KIFAdditionsTests.m
@@ -38,22 +38,22 @@
 
 @implementation UIScreen_KIFAdditionsTests
 
-- (void)test_majorSwipeDisplacement_ScreenSizeEqualTo320Pts_Returns200Pts {
-    CGRect iPhone5PortraitBounds = CGRectMake(0, 0, 320, 468);
+- (void)test_majorSwipeDisplacement_ScreenSizeEqualTo320Pts_Returns160Pts {
+    CGRect iPhone5PortraitBounds = CGRectMake(0, 0, 320, 568);
     CustomBoundsUIScreen *screen = [[CustomBoundsUIScreen alloc] initWithBounds:iPhone5PortraitBounds];
     
     CGFloat actual = screen.majorSwipeDisplacement;
     
-    XCTAssertEqual(200, actual);
+    XCTAssertEqual(160, actual);
 }
 
-- (void)test_majorSwipeDisplacement_ScreenSizeEqualTo414Pts_Returns258Point75Pts {
-    CGRect iPhone5PortraitBounds = CGRectMake(0, 0, 414, 736);
-    CustomBoundsUIScreen *screen = [[CustomBoundsUIScreen alloc] initWithBounds:iPhone5PortraitBounds];
+- (void)test_majorSwipeDisplacement_ScreenSizeEqualTo414Pts_Returns207Pts {
+    CGRect iPhone6PlusPortraitBounds = CGRectMake(0, 0, 414, 736);
+    CustomBoundsUIScreen *screen = [[CustomBoundsUIScreen alloc] initWithBounds:iPhone6PlusPortraitBounds];
     
     CGFloat actual = screen.majorSwipeDisplacement;
     
-    XCTAssertEqual(258.75, actual);
+    XCTAssertEqual(207, actual);
 }
 
 @end


### PR DESCRIPTION
On iOS 11, when performing a "full swipe" on a TableView cell, the first action is performed by default.

The `majorSwipeDisplacement` is currently used for the amount of displacement perform when swiping a cell and it seems that 0.625 is too much and performs the first action automatically. This is breaking our tests as the action is performed so there is no action to tap anymore.

This PR lowers this constant to 0.5, which I would say it's still a major swipe displacement and does not seem to trigger the new behavior on iOS 11 which would be the expected thing IMO.

Maybe in an additional PR we should also expose a method to perform a full swipe so users are also be able to test this new behavior.