### PR TITLE
Try to fix CI on Xcode 6 Travis machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
 before_install:
   - xcrun simctl list
   - brew update || brew update
+  - rvm install 2.3.1
+  - gem install bundler
 install:
   - if [ -z "$(brew ls --versions coreutils)" ] ; then brew install coreutils ; fi
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet


### PR DESCRIPTION
See if I can get the Xcode 6 Travis machines out of their currently broken state (due to stringio missing in the installed version of rubygems).