### PR TITLE
Fix waitForView cannot find UITableViewCell or label, and results in UITableView on iOS 11

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -18,6 +18,11 @@
 
 MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 
+@interface UIAccessibilityElement (KIFAdditions_Private)
+
+- (id)tableViewCell; // UITableViewCellAccessibilityElement
+
+@end
 
 @implementation UIAccessibilityElement (KIFAdditions)
 
@@ -26,7 +31,9 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     while (element && ![element isKindOfClass:[UIView class]]) {
         // Sometimes accessibilityContainer will return a view that's too far up the view hierarchy
         // UIAccessibilityElement instances will sometimes respond to view, so try to use that and then fall back to accessibilityContainer
-        id view = [element respondsToSelector:@selector(view)] ? [(id)element view] : nil;
+        id view = [element respondsToSelector:@selector(view)] ? [(id)element view]
+        : [element respondsToSelector:@selector(tableViewCell)] ? [(id)element tableViewCell]
+        : nil;
         
         if (view) {
             element = view;

--- a/KIF Tests/TableViewTests.m
+++ b/KIF Tests/TableViewTests.m
@@ -83,6 +83,20 @@
     [tester tapViewWithAccessibilityLabel:@"Cell 32"];
 }
 
+- (void)testWaitingRowByLabel
+{
+    UIView *v = [tester waitForViewWithAccessibilityLabel:@"First Cell"];
+    XCTAssertTrue([v isKindOfClass:[UITableViewCell class]] || [v isKindOfClass:NSClassFromString(@"UITableViewLabel")], @"actual: %@", [v class]);
+}
+
+- (void)testWaitingRowByLabelAfterTapping
+{
+    // for view lookup changes caused by tapping rows
+    [tester tapViewWithAccessibilityLabel:@"First Cell"];
+    UIView *v = [tester waitForViewWithAccessibilityLabel:@"First Cell"];
+    XCTAssertTrue([v isKindOfClass:[UITableViewCell class]] || [v isKindOfClass:NSClassFromString(@"UITableViewLabel")], @"actual: %@", [v class]);
+}
+
 - (void)testMoveRowDown
 {
     [tester tapViewWithAccessibilityLabel:@"Edit"];

--- a/KIF Tests/TableViewTests_ViewTestActor.m
+++ b/KIF Tests/TableViewTests_ViewTestActor.m
@@ -83,6 +83,20 @@
     [[viewTester usingLabel:@"Cell 32"] tap];
 }
 
+- (void)testWaitingRowByLabel
+{
+    UIView *v = [[viewTester usingLabel:@"First Cell"] waitForView];
+    XCTAssertTrue([v isKindOfClass:[UITableViewCell class]] || [v isKindOfClass:NSClassFromString(@"UITableViewLabel")], @"actual: %@", [v class]);
+}
+
+- (void)testWaitingRowByLabelAfterTapping
+{
+    // for view lookup changes caused by tapping rows
+    [[viewTester usingLabel:@"First Cell"] tap];
+    UIView *v = [[viewTester usingLabel:@"First Cell"] waitForView];
+    XCTAssertTrue([v isKindOfClass:[UITableViewCell class]] || [v isKindOfClass:NSClassFromString(@"UITableViewLabel")], @"actual: %@", [v class]);
+}
+
 - (void)testMoveRowDown
 {
     [[viewTester usingLabel:@"Edit"] tap];


### PR DESCRIPTION
On Xcode 9 & iOS 11, `waitForViewWithAccessibilityLabel: @"label text on the cell"` returns its `UITableView`. As commented in the existing code, UITableView is too far in view hierarchy to work with cells level.
On iOS 10, it correctly returns `UITableViewCell` or `UITableViewLabel`.

This PR adds testcases to reproduce issue. (After my some inspections, `tapViewWithAccessibilityLabel` change some unknown states which affects reproducibility, I have added 2 testcases.)
Then this patches the view finding logic by searching `-tableViewCell` in addition to `-view`.

`element accessibilityContainer` for table cells is like below:

iOS 10: `UITextAccessibilityElement -> accessibilityContainer = UITableViewCell`
iOS 11: `UITextAccessibilityElement -> accessibilityContainer = UITableViewCellAccessibilityElement -> accessibilityContainer = UITableView`

Thus, we can take `UITableViewCell` on iOS 10, but we unexpectedly go through to `UITableView` on iOS 11.