### PR TITLE
Add missing autoreleasepool

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -505,9 +505,11 @@ KIFUITestActor *_KIF_tester()
 
 - (void)clearTextFromFirstResponder
 {
-    UIView *firstResponder = (id)[[[UIApplication sharedApplication] keyWindow] firstResponder];
-    if ([firstResponder isKindOfClass:[UIView class]]) {
-        [self clearTextFromElement:(UIAccessibilityElement *)firstResponder inView:firstResponder];
+    @autoreleasepool {
+        UIView *firstResponder = (id)[[[UIApplication sharedApplication] keyWindow] firstResponder];
+        if ([firstResponder isKindOfClass:[UIView class]]) {
+            [self clearTextFromElement:(UIAccessibilityElement *)firstResponder inView:firstResponder];
+        }
     }
 }
 


### PR DESCRIPTION
Add an autoreleasepool to prevent object lifetimes from being extended. Thanks @justinseanmartin!