### PR TITLE
Fix the waitForAnimationToFinishWithTimeout to wait until animation done OR the timeout expires

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -229,7 +229,7 @@ KIFUITestActor *_KIF_tester()
             [window performBlockOnDescendentViews:^(UIView *view, BOOL *stop) {
                 BOOL isViewVisible = [view isVisibleInViewHierarchy];   // do not wait for animations of views that aren't visible
                 BOOL hasUnfinishedSystemAnimation = [NSStringFromClass(view.class) isEqualToString:@"_UIParallaxDimmingView"];  // indicates that the view-hierarchy is in an in-between-state of an animation
-                if (isViewVisible && ([view.layer animationKeys] count] > 0 || hasUnfinishedSystemAnimation)) {
+                if (isViewVisible && ([[view.layer animationKeys] count] > 0 || hasUnfinishedSystemAnimation)) {
                     runningAnimationFound = YES;
                     if (stop != NULL) {
                         *stop = YES;

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -229,7 +229,7 @@ KIFUITestActor *_KIF_tester()
             [window performBlockOnDescendentViews:^(UIView *view, BOOL *stop) {
                 BOOL isViewVisible = [view isVisibleInViewHierarchy];   // do not wait for animations of views that aren't visible
                 BOOL hasUnfinishedSystemAnimation = [NSStringFromClass(view.class) isEqualToString:@"_UIParallaxDimmingView"];  // indicates that the view-hierarchy is in an in-between-state of an animation
-                if (isViewVisible && ([view.layer hasAnimations] || hasUnfinishedSystemAnimation)) {
+                if (isViewVisible && ([view.layer animationKeys] count] > 0 || hasUnfinishedSystemAnimation)) {
                     runningAnimationFound = YES;
                     if (stop != NULL) {
                         *stop = YES;


### PR DESCRIPTION
Change the wait check to look for the animationKeys count being 0 in the layer. The old check does not do anything (always return true), and as a result, it will just wait until the timeout expires even if the animation finishes much earlier.