### PR TITLE
Add -[KIFUIViewTestActor usingAbsenceOfTraits:] 

### DIFF
--- a/Classes/KIFUIViewTestActor.h
+++ b/Classes/KIFUIViewTestActor.h
@@ -75,6 +75,7 @@ extern NSString *const inputFieldTestString;
 /*!
  @abstract Adds a check for accessibility traits to the tester's search predicate.
  @discussion The tester will evaluate accessibility elements looking for matching accessibility traits.
+ Note: You cannot assert the lack of accessibility traits by passing in UIAccessibilityTraitsNone.
  @param accessibilityTraits The accessibility traits of an element to match.
  @return The message reciever, these methods are intended to be chained together.
  */
@@ -83,7 +84,17 @@ extern NSString *const inputFieldTestString;
 /*!
  @abstract Adds a check to avoid views with accessibility traits to the tester's search predicate.
  @discussion The tester will evaluate accessibility elements for the purposes of excluding accessibility traits.
- @param accessibilityTraits The accessibility traits of an element to avoid matching.
+ If more than one trait is supplied in the bitmask, none of them may be present in order for this to be true.
+ Note: You cannot assert the presence of accessibility traits by passing in UIAccessibilityTraitsNone.
+
+ Example:
+ Given a view with the accessibility traits .Button | .Selected, and we request the absence of .KeyboardCommand, this will match.
+ Given a view with the accessibility traits .Button | .Selected, and we request the absence of .KeyboardCommand | .PlaysSound, this will match.
+
+ Given a view with the accessibility traits .Button | .Selected, and we request the absence of .Selected, this will not match.
+ Given a view with the accessibility traits .Button | .Selected, and we request the absence of .Button | .Selected, this will not match.
+ Given a view with the accessibility traits .Button | .Selected, and we request the absence of .KeyboardCommand | .Button, this will not match.
+
  @return The message reciever, these methods are intended to be chained together.
  */
 - (instancetype)usingAbsenceOfTraits:(UIAccessibilityTraits)accessibilityTraits;

--- a/Classes/KIFUIViewTestActor.h
+++ b/Classes/KIFUIViewTestActor.h
@@ -57,7 +57,7 @@ extern NSString *const inputFieldTestString;
 */
 
 /*!
- @abstract Adds a check for an accessibility label to the tester's search pedicate.
+ @abstract Adds a check for an accessibility label to the tester's search predicate.
  @discussion The tester will evaluate accessibility elements looking for a matching accessibility label.
  @param accessibilityLabel The accessibility label of an element to match.
  @return The message reciever, these methods are intended to be chained together.
@@ -65,7 +65,7 @@ extern NSString *const inputFieldTestString;
 - (instancetype)usingLabel:(NSString *)accessibilityLabel;
 
 /*!
- @abstract Adds a check for an accessibility identifier to the tester's search pedicate.
+ @abstract Adds a check for an accessibility identifier to the tester's search predicate.
  @discussion The tester will evaluate accessibility elements looking for a matching accessibility identifier.
  @param accessibilityIdentifier The accessibility identifier of an element to match.
  @return The message reciever, these methods are intended to be chained together.
@@ -73,7 +73,7 @@ extern NSString *const inputFieldTestString;
 - (instancetype)usingIdentifier:(NSString *)accessibilityIdentifier;
 
 /*!
- @abstract Adds a check for accessibility traits to the tester's search pedicate.
+ @abstract Adds a check for accessibility traits to the tester's search predicate.
  @discussion The tester will evaluate accessibility elements looking for matching accessibility traits.
  @param accessibilityTraits The accessibility traits of an element to match.
  @return The message reciever, these methods are intended to be chained together.
@@ -81,7 +81,7 @@ extern NSString *const inputFieldTestString;
 - (instancetype)usingTraits:(UIAccessibilityTraits)accessibilityTraits;
 
 /*!
- @abstract Adds a check to avoid views with accessibility traits to the tester's search pedicate.
+ @abstract Adds a check to avoid views with accessibility traits to the tester's search predicate.
  @discussion The tester will evaluate accessibility elements for the purposes of excluding accessibility traits.
  @param accessibilityTraits The accessibility traits of an element to avoid matching.
  @return The message reciever, these methods are intended to be chained together.
@@ -89,7 +89,7 @@ extern NSString *const inputFieldTestString;
 - (instancetype)usingAbsenceOfTraits:(UIAccessibilityTraits)accessibilityTraits;
 
 /*!
- @abstract Adds a check for an accessibility value to the tester's search pedicate.
+ @abstract Adds a check for an accessibility value to the tester's search predicate.
  @discussion The tester will evaluate accessibility elements looking for a matching accessibility value.
  @param accessibilityValue The accessibility value of an element to match.
  @return The message reciever, these methods are intended to be chained together.

--- a/Classes/KIFUIViewTestActor.h
+++ b/Classes/KIFUIViewTestActor.h
@@ -81,6 +81,14 @@ extern NSString *const inputFieldTestString;
 - (instancetype)usingTraits:(UIAccessibilityTraits)accessibilityTraits;
 
 /*!
+ @abstract Adds a check to avoid views with accessibility traits to the tester's search pedicate.
+ @discussion The tester will evaluate accessibility elements for the purposes of excluding accessibility traits.
+ @param accessibilityTraits The accessibility traits of an element to avoid matching.
+ @return The message reciever, these methods are intended to be chained together.
+ */
+- (instancetype)usingAbsenceOfTraits:(UIAccessibilityTraits)accessibilityTraits;
+
+/*!
  @abstract Adds a check for an accessibility value to the tester's search pedicate.
  @discussion The tester will evaluate accessibility elements looking for a matching accessibility value.
  @param accessibilityValue The accessibility value of an element to match.

--- a/Classes/KIFUIViewTestActor.m
+++ b/Classes/KIFUIViewTestActor.m
@@ -111,6 +111,14 @@ NSString *const inputFieldTestString = @"Testing";
     return [self usingPredicate:predicate];
 }
 
+- (instancetype)usingAbsenceOfTraits:(UIAccessibilityTraits)accessibilityTraits;
+{
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"(accessibilityTraits & %@) != %@", @(accessibilityTraits), @(accessibilityTraits)];
+    predicate.kifPredicateDescription = [NSString stringWithFormat:@"Accessibility traits excluding \"%@\"", [UIAccessibilityElement stringFromAccessibilityTraits:accessibilityTraits]];
+
+    return [self usingPredicate:predicate];
+}
+
 - (instancetype)usingValue:(NSString *)accessibilityValue;
 {
     NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {

--- a/KIF Tests/TappingTests_ViewTestActor.m
+++ b/KIF Tests/TappingTests_ViewTestActor.m
@@ -36,7 +36,7 @@
 
 - (void)afterEach
 {
-    [[[viewTester usingLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+    [[[[viewTester usingLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] usingAbsenceOfTraits:UIAccessibilityTraitKeyboardKey] tap];
 }
 
 - (void)testTappingViewWithAccessibilityLabel

--- a/Test Host/en.lproj/MainStoryboard.storyboard
+++ b/Test Host/en.lproj/MainStoryboard.storyboard
@@ -1591,6 +1591,14 @@ Line Break
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="gtk-te-yLC">
+                                <rect key="frame" x="285" y="205" width="68" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <accessibility key="accessibilityConfiguration">
+                                    <accessibilityTraits key="traits" keyboardKey="YES"/>
+                                </accessibility>
+                                <state key="normal" title="Test Suite"/>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                     </view>


### PR DESCRIPTION
This allows us to differentiate between views that may have the same accessibility label and share some— but not all— accessibility traits.

For example, this allows us to differentiate between a "Next" button in a navigation bar or input accessory (with the ax trait of `.Button`), and a return key that also says "Next" on the input view itself (that may have the ax trait of `.Button` on some OS's \*cough\*iOS 10.2\*cough\* and will always have the ax trait of `.KeyboardKey`).