### PR TITLE
Add more generic alert tapping capabilities

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -579,6 +579,13 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
  @discussion Use this to dissmiss a location services authorization dialog or a photos access dialog by tapping the 'Allow' button. No action is taken if no alert is present.
  */
 - (BOOL)acknowledgeSystemAlert;
+
+/*!
+ @abstract If present, dismisses a system alert with the button at the given index, if any exists, usually 'Allow'. Returns YES if a dialog was dismissed, NO otherwise.
+ @discussion Use this to dissmiss a location services authorization dialog or a photos access dialog by tapping a specified button. No action is taken if no alert is present.
+*/
+- (BOOL)acknowledgeSystemAlertWithIndex:(NSUInteger)index;
+
 #endif
 
 /*!

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -582,7 +582,7 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 
 /*!
  @abstract If present, dismisses a system alert with the button at the given index, if any exists, usually 'Allow'. Returns YES if a dialog was dismissed, NO otherwise.
- @discussion Use this to dissmiss a location services authorization dialog or a photos access dialog by tapping a specified button. No action is taken if no alert is present.
+ @discussion Use this to dissmiss a location services authorization dialog or a photos access dialog by tapping a button at the specified index. No action is taken if no alert is present.
 */
 - (BOOL)acknowledgeSystemAlertWithIndex:(NSUInteger)index;
 

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -1009,6 +1009,11 @@ KIFUITestActor *_KIF_tester()
     return [UIAutomationHelper acknowledgeSystemAlert];
 }
 
+- (BOOL)acknowledgeSystemAlertWithIndex:(NSUInteger)index
+{
+    return [UIAutomationHelper acknowledgeSystemAlertWithIndex: index];
+}
+
 #endif
 
 - (void)tapItemAtIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView

--- a/Classes/UIAutomationHelper.h
+++ b/Classes/UIAutomationHelper.h
@@ -15,6 +15,8 @@
 
 + (BOOL)acknowledgeSystemAlert;
 
++ (BOOL)acknowledgeSystemAlertWithIndex:(NSUInteger)index;
+
 + (void)deactivateAppForDuration:(NSNumber *)duration;
 
 @end

--- a/Classes/UIAutomationHelper.m
+++ b/Classes/UIAutomationHelper.m
@@ -114,6 +114,8 @@ static void FixReactivateApp(void)
 
 - (BOOL)acknowledgeSystemAlert {
 	UIAAlert* alert = [[self target] frontMostApp].alert;
+    // Even though `acknowledgeSystemAlertWithIndex:` checks the index, we have to have
+    // an additional check here to ensure that when `alert.buttons.count` is 0, subtracting one doesn't cause a wrap-around (2^63 - 1).
     if (alert.buttons.count > 0) {
         return [self acknowledgeSystemAlertWithIndex:alert.buttons.count - 1];
     }

--- a/Classes/UIAutomationHelper.m
+++ b/Classes/UIAutomationHelper.m
@@ -104,23 +104,37 @@ static void FixReactivateApp(void)
     return [[self sharedHelper] acknowledgeSystemAlert];
 }
 
++ (BOOL)acknowledgeSystemAlertWithIndex:(NSUInteger)index {
+    return [[self sharedHelper] acknowledgeSystemAlertWithIndex:index];
+}
+
 + (void)deactivateAppForDuration:(NSNumber *)duration {
     [[self sharedHelper] deactivateAppForDuration:duration];
 }
 
 - (BOOL)acknowledgeSystemAlert {
+	UIAAlert* alert = [[self target] frontMostApp].alert;
+    if (alert.buttons.count > 0) {
+        return [self acknowledgeSystemAlertWithIndex:alert.buttons.count - 1];
+    }
+    return NO;
+}
+
+// Inspired by:  https://github.com/jamesjn/KIF/tree/acknowledge-location-alert
+- (BOOL)acknowledgeSystemAlertWithIndex:(NSUInteger)index {
     UIAApplication *application = [[self target] frontMostApp];
-	UIAAlert* alert = application.alert;
-	if (![alert isKindOfClass:[self nilElementClass]] && [self _alertIsValidAndVisible:alert]) {
-            [[alert.buttons lastObject] tap];
-            while ([self _alertIsValidAndVisible:alert]) {
-                // Wait for button press to complete.
-                KIFRunLoopRunInModeRelativeToAnimationSpeed(UIApplicationCurrentRunMode, 0.1, false);
-            }
-            // Wait for alert dismissial animation.
-            KIFRunLoopRunInModeRelativeToAnimationSpeed(UIApplicationCurrentRunMode, 0.4, false);
-            return YES;
-	}
+    UIAAlert *alert = application.alert;
+    BOOL isIndexInRange = index < alert.buttons.count;
+    if (![alert isKindOfClass:[self nilElementClass]] && [self _alertIsValidAndVisible:alert] && isIndexInRange) {
+        [alert.buttons[index] tap];
+        while ([self _alertIsValidAndVisible:alert]) {
+            // Wait for button press to complete.
+            KIFRunLoopRunInModeRelativeToAnimationSpeed(UIApplicationCurrentRunMode, 0.1, false);
+        }
+        // Wait for alert dismissial animation.
+        KIFRunLoopRunInModeRelativeToAnimationSpeed(UIApplicationCurrentRunMode, 0.4, false);
+        return YES;
+    }
     return NO;
 }
 


### PR DESCRIPTION
## Added:
- method for tapping system alerts at varying index. This is incredibly useful for tapping system alert (like location alerts) that use new iOS 11 permissions (never allow, allow while in app, always allow - as they pertain to location permissions in this instance).
- refactored `acknowledgeSystemAlert` to call `acknowledgeSystemAlertWithIndex:`

Inspired by: https://github.com/jamesjn/KIF/blob/3361a50389309326aa4a4fc580d4a37421829b58/Classes/UIAutomationHelper.m#L131 (@jamesjn)