### PR TITLE
Xcode 9 and iOS 11 fixes + Travis CI (& drop XC6 support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ matrix:
   include:
     - osx_image: xcode9.2
       env: 'SIMULATOR="name=iPad Pro (12.9-inch) (2nd generation),OS=11.2"'
+    - osx_image: xcode9.2
+      env: 'SIMULATOR="name=iPhone 7 Plus,OS=10.3.1"'
     - osx_image: xcode8.3
-      env: 'SIMULATOR="name=iPad Air 2,OS=10.3.1"'
+      env: 'SIMULATOR="name=iPhone 5,OS=9.3"'
     - osx_image: xcode7.3
-      env: 'SIMULATOR="name=iPhone 6s,OS=9.3"'
-    - osx_image: xcode6.4
-      env: 'SIMULATOR="name=iPhone 4s,OS=8.4"'
+      env: 'SIMULATOR="name=iPad 2,OS=8.1"'
 
 before_install:
   - xcrun simctl list

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: objective-c
 matrix:
   include:
+    - osx_image: xcode9.2
+      env: 'SIMULATOR="name=iPad Pro (12.9-inch) (2nd generation),OS=11.2"'
     - osx_image: xcode8.3
       env: 'SIMULATOR="name=iPad Air 2,OS=10.3.1"'
     - osx_image: xcode7.3

--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -171,40 +171,42 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
         return nil;
     }
     
-    // Scroll the view (and superviews) to be visible if necessary
-    UIView *superview = (UIScrollView *)view;
-    while (superview) {
-        // Fix for iOS7 table view cells containing scroll views
-        if ([superview.superview isKindOfClass:[UITableViewCell class]]) {
-            break;
-        }
-        
-        if ([superview isKindOfClass:[UIScrollView class]]) {
-            UIScrollView *scrollView = (UIScrollView *)superview;
-            
-            if (((UIAccessibilityElement *)view == element) && ![view isKindOfClass:[UITableViewCell class]]) {
-                [scrollView scrollViewToVisible:view animated:YES];
-            } else if ([view isKindOfClass:[UITableViewCell class]] && [scrollView.superview isKindOfClass:[UITableView class]]) {
-                UITableViewCell *cell = (UITableViewCell *)view;
-                UITableView *tableView = (UITableView *)scrollView.superview;
-                NSIndexPath *indexPath = [tableView indexPathForCell:cell];
-                [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:YES];
-            } else {
-                CGRect elementFrame = [view.window convertRect:element.accessibilityFrame toView:scrollView];
-                CGRect visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y, CGRectGetWidth(scrollView.bounds), CGRectGetHeight(scrollView.bounds));
-                
-                // Only call scrollRectToVisible if the element isn't already visible
-                // iOS 8 will sometimes incorrectly scroll table views so the element scrolls out of view
-                if (!CGRectContainsRect(visibleRect, elementFrame)) {
-                    [scrollView scrollRectToVisible:elementFrame animated:YES];
-                }
+    if (!view.isVisibleInWindowFrame) {
+        // Scroll the view (and superviews) to be visible if necessary
+        UIView *superview = (UIScrollView *)view;
+        while (superview) {
+            // Fix for iOS7 table view cells containing scroll views
+            if ([superview.superview isKindOfClass:[UITableViewCell class]]) {
+                break;
             }
             
-            // Give the scroll view a small amount of time to perform the scroll.
-            KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, 0.3, false);
+            if ([superview isKindOfClass:[UIScrollView class]]) {
+                UIScrollView *scrollView = (UIScrollView *)superview;
+                
+                if (((UIAccessibilityElement *)view == element) && ![view isKindOfClass:[UITableViewCell class]]) {
+                    [scrollView scrollViewToVisible:view animated:YES];
+                } else if ([view isKindOfClass:[UITableViewCell class]] && [scrollView.superview isKindOfClass:[UITableView class]]) {
+                    UITableViewCell *cell = (UITableViewCell *)view;
+                    UITableView *tableView = (UITableView *)scrollView.superview;
+                    NSIndexPath *indexPath = [tableView indexPathForCell:cell];
+                    [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:YES];
+                } else {
+                    CGRect elementFrame = [view.window convertRect:element.accessibilityFrame toView:scrollView];
+                    CGRect visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y, CGRectGetWidth(scrollView.bounds), CGRectGetHeight(scrollView.bounds));
+                    
+                    // Only call scrollRectToVisible if the element isn't already visible
+                    // iOS 8 will sometimes incorrectly scroll table views so the element scrolls out of view
+                    if (!CGRectContainsRect(visibleRect, elementFrame)) {
+                        [scrollView scrollRectToVisible:elementFrame animated:YES];
+                    }
+                }
+                
+                // Give the scroll view a small amount of time to perform the scroll.
+                KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, 0.3, false);
+            }
+            
+            superview = superview.superview;
         }
-        
-        superview = superview.superview;
     }
     
     if ([[UIApplication sharedApplication] isIgnoringInteractionEvents]) {

--- a/Additions/UITableView-KIFAdditions.m
+++ b/Additions/UITableView-KIFAdditions.m
@@ -40,7 +40,18 @@
         indexPath = [NSIndexPath indexPathForRow:[self numberOfRowsInSection:indexPath.section] + indexPath.row inSection:indexPath.section];
     }
     
-    CGPoint destinationPoint = CGPointMake(sourcePoint.x, CGPointCenteredInRect([self rectForRowAtIndexPath:indexPath]).y);
+    CGRect destinationCellRect = [self rectForRowAtIndexPath:indexPath];
+    CGFloat destinationDragY = CGPointCenteredInRect(destinationCellRect).y;
+
+    // In iOS11, the behavior for dragging table rows has been changed to be dependent on the direction that they are being dragged
+    NSOperatingSystemVersion iOS11 = {11, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS11]) {
+        if (destinationDragY - sourcePoint.y > 0) {
+            // Dragging Down
+            destinationDragY += destinationCellRect.size.height;
+        }
+    }
+    CGPoint destinationPoint = CGPointMake(sourcePoint.x, destinationDragY);
     
     // Create the touch (there should only be one touch object for the whole drag)
     UITouch *touch = [[UITouch alloc] initAtPoint:sourcePoint inView:self];

--- a/Additions/UIView-KIFAdditions.h
+++ b/Additions/UIView-KIFAdditions.h
@@ -98,6 +98,11 @@ typedef CGPoint KIFDisplacement;
 - (BOOL)isVisibleInViewHierarchy;
 
 /*!
+ @abstract Evaluates if the view has some portion of its frame intersect with its ancestor views clip it from being visible on the screen.
+ */
+- (BOOL)isVisibleInWindowFrame;
+
+/*!
  @method performBlockOnDescendentViews:
  @abstract Calls a block on the view itself and on all its descendent views.
  @param block The block that will be called on the views. Stop the traversation of the views by assigning YES to the stop-parameter of the block.

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -920,6 +920,26 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     return result;
 }
 
+- (BOOL)isVisibleInWindowFrame;
+{
+    __block CGRect visibleFrame = [self.superview convertRect:self.frame toView:nil];
+    [self performBlockOnAscendentViews:^(UIView *view, BOOL *stop) {
+        if (view.clipsToBounds) {
+            CGRect clippingFrame = [view.superview convertRect:view.frame toView:nil];
+            visibleFrame = CGRectIntersection(visibleFrame, clippingFrame);
+        }
+        if (CGSizeEqualToSize(visibleFrame.size, CGSizeZero)) {
+            // Our frame has been fully clipped
+            *stop = YES;
+        }
+        if (view.superview == view.window) {
+            // Walked all ancestors (skip the top level window that has no superview)
+            *stop = YES;
+        }
+    }];
+    return !CGSizeEqualToSize(visibleFrame.size, CGSizeZero);
+}
+
 - (void)performBlockOnDescendentViews:(void (^)(UIView *view, BOOL *stop))block
 {
     BOOL stop = NO;

--- a/KIF Tests/ExistTests.m
+++ b/KIF Tests/ExistTests.m
@@ -9,20 +9,31 @@
 #import <KIF/KIF.h>
 
 @interface ExistTests : KIFTestCase
-
 @end
 
 @implementation ExistTests
 
+- (void)beforeAll;
+{
+    [super beforeAll];
+
+    // If a previous test was still in the process of navigating back to the main view, let that complete before starting this test
+    [tester waitForAnimationsToFinish];
+}
+
 - (void)testExistsViewWithAccessibilityLabel
 {
-    if ([tester tryFindingTappableViewWithAccessibilityLabel:@"Tapping" error:NULL] && ![tester tryFindingTappableViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton error:NULL]) {
+    BOOL tappingFound = [tester tryFindingTappableViewWithAccessibilityLabel:@"Tapping" error:NULL];
+    BOOL testSuiteFound = [tester tryFindingTappableViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton error:NULL];
+    if (tappingFound && !testSuiteFound) {
         [tester tapViewWithAccessibilityLabel:@"Tapping"];
     } else {
         [tester fail];
     }
     
-    if ([tester tryFindingTappableViewWithAccessibilityLabel:@"Test Suite" error:NULL] && ![tester tryFindingTappableViewWithAccessibilityLabel:@"Tapping" error:NULL]) {
+    tappingFound = [tester tryFindingTappableViewWithAccessibilityLabel:@"Tapping" error:NULL];
+    testSuiteFound = [tester tryFindingTappableViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton error:NULL];
+    if (testSuiteFound && !tappingFound) {
         [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
     } else {
         [tester fail];

--- a/KIF Tests/ExistTests_ViewTestActor.m
+++ b/KIF Tests/ExistTests_ViewTestActor.m
@@ -14,6 +14,14 @@
 
 @implementation ExistTests_ViewTestActor
 
+- (void)beforeAll;
+{
+    [super beforeAll];
+
+    // If a previous test was still in the process of navigating back to the main view, let that complete before starting this test
+    [tester waitForAnimationsToFinish];
+}
+
 - (void)testExistsViewWithAccessibilityLabel
 {
     if ([[viewTester usingLabel:@"Tapping"] tryFindingTappableView] && ![[[viewTester usingLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tryFindingTappableView]) {

--- a/KIF Tests/ModalViewTests.m
+++ b/KIF Tests/ModalViewTests.m
@@ -46,6 +46,13 @@
 
 - (void)testInteractionWithAnActivityViewController
 {
+    NSOperatingSystemVersion iOS11 = {11, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)]
+        && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS11]) {
+        NSLog(@"This test can't be run on iOS 11, as the activity sheet is hosted in an `AXRemoteElement`");
+        return;
+    }
+    
     if (!NSClassFromString(@"UIActivityViewController")) {
         return;
     }

--- a/KIF Tests/ModalViewTests_ViewTestActor.m
+++ b/KIF Tests/ModalViewTests_ViewTestActor.m
@@ -46,6 +46,13 @@
 
 - (void)testInteractionWithAnActivityViewController
 {
+    NSOperatingSystemVersion iOS11 = {11, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)]
+        && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS11]) {
+        NSLog(@"This test can't be run on iOS 11, as the activity sheet is hosted in an `AXRemoteElement`");
+        return;
+    }
+    
     if (!NSClassFromString(@"UIActivityViewController")) {
         return;
     }

--- a/KIF Tests/SpecificControlTests.m
+++ b/KIF Tests/SpecificControlTests.m
@@ -45,6 +45,13 @@
 
 - (void)testPickingAPhoto
 {
+    NSOperatingSystemVersion iOS11 = {11, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)]
+        && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS11]) {
+        NSLog(@"This test can't be run on iOS 11, as the activity sheet is hosted in an `AXRemoteElement`");
+        return;
+    }
+    
     // 'acknowledgeSystemAlert' can't be used on iOS7
     // The console shows a message "AX Lookup problem! 22 com.apple.iphone.axserver:-1"
     if ([UIDevice.currentDevice.systemVersion compare:@"8.0" options:NSNumericSearch] < 0) {

--- a/KIF Tests/SpecificControlTests_ViewTestActor.m
+++ b/KIF Tests/SpecificControlTests_ViewTestActor.m
@@ -45,6 +45,12 @@
 
 - (void)testPickingAPhoto
 {
+    NSOperatingSystemVersion iOS11 = {11, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS11]) {
+        NSLog(@"This test can't be run on iOS 11, as the photo picker UI is hosted in an `AXRemoteElement`");
+        return;
+    }
+
     // 'acknowledgeSystemAlert' can't be used on iOS7
     // The console shows a message "AX Lookup problem! 22 com.apple.iphone.axserver:-1"
     if ([UIDevice.currentDevice.systemVersion compare:@"8.0" options:NSNumericSearch] < 0) {

--- a/KIF Tests/WaitForAnimationTests.m
+++ b/KIF Tests/WaitForAnimationTests.m
@@ -20,7 +20,7 @@
 }
 
 - (void)afterEach {
-    [tester tapViewWithAccessibilityLabel:@"Back"];
+    [tester tapViewWithAccessibilityLabel:@"TapView"];
     [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
 }
 

--- a/KIF Tests/WaitForAnimationTests_ViewTestActor.m
+++ b/KIF Tests/WaitForAnimationTests_ViewTestActor.m
@@ -22,7 +22,7 @@
 
 - (void)afterEach
 {
-    [[viewTester usingLabel:@"Back"] tap];
+    [[viewTester usingLabel:@"TapView"] tap];
     [[[viewTester usingLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
 }
 

--- a/KIF Tests/WaitForViewTests.m
+++ b/KIF Tests/WaitForViewTests.m
@@ -28,7 +28,20 @@
 
 - (void)testWaitingForViewWithTraits
 {
-    [tester waitForViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitStaticText];
+    NSString *label = nil;
+    UIAccessibilityTraits traits = UIAccessibilityTraitNone;
+
+    NSOperatingSystemVersion iOS9 = {9, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && ![[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS9]) {
+        // In iOS 8 and before, you couldn't identify the table view elements as buttons
+        label = @"Test Suite";
+        traits = UIAccessibilityTraitStaticText;
+    } else {
+        // In iOS 11, the static text trait of the navigation bar header goes away for some reason
+        label = @"UIAlertView";
+        traits = UIAccessibilityTraitButton;
+    }
+    [tester waitForViewWithAccessibilityLabel:label traits:traits];
 }
 
 - (void)testWaitingForViewWithValue

--- a/KIF Tests/WaitForViewTests.m
+++ b/KIF Tests/WaitForViewTests.m
@@ -13,6 +13,14 @@
 
 @implementation WaitForViewTests
 
+- (void)beforeAll;
+{
+    [super beforeAll];
+
+    // If a previous test was still in the process of navigating back to the main view, let that complete before starting this test
+    [tester waitForAnimationsToFinish];
+}
+
 - (void)testWaitingForViewWithAccessibilityLabel
 {
     [tester waitForViewWithAccessibilityLabel:@"Test Suite"];

--- a/KIF Tests/WaitForViewTests_ViewTestActor.m
+++ b/KIF Tests/WaitForViewTests_ViewTestActor.m
@@ -30,7 +30,20 @@
 
 - (void)testWaitingForViewWithTraits
 {
-    [[[viewTester usingLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitStaticText] waitForView];
+    NSString *label = nil;
+    UIAccessibilityTraits traits = UIAccessibilityTraitNone;
+
+    NSOperatingSystemVersion iOS9 = {9, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && ![[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS9]) {
+        // In iOS 8 and before, you couldn't identify the table view elements as buttons
+        label = @"Test Suite";
+        traits = UIAccessibilityTraitStaticText;
+    } else {
+        // In iOS 11, the static text trait of the navigation bar header goes away for some reason
+        label = @"UIAlertView";
+        traits = UIAccessibilityTraitButton;
+    }
+    [[[viewTester usingLabel:label] usingTraits:traits] waitForView];
 }
 
 - (void)testWaitingForViewWithValue

--- a/KIF Tests/WaitForViewTests_ViewTestActor.m
+++ b/KIF Tests/WaitForViewTests_ViewTestActor.m
@@ -15,6 +15,14 @@
 
 @implementation WaitForViewTests_ViewTestActor
 
+- (void)beforeAll;
+{
+    [super beforeAll];
+
+    // If a previous test was still in the process of navigating back to the main view, let that complete before starting this test
+    [tester waitForAnimationsToFinish];
+}
+
 - (void)testWaitingForViewWithAccessibilityLabel
 {
     [[viewTester usingLabel:@"Test Suite"] waitForView];

--- a/KIF.xcodeproj/xcshareddata/xcschemes/KIF.xcscheme
+++ b/KIF.xcodeproj/xcshareddata/xcschemes/KIF.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -37,14 +38,6 @@
                BlueprintName = "KIF Tests"
                ReferencedContainer = "container:KIF.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "AccessibilityIdentifierPullToRefreshTests">
-               </Test>
-               <Test
-                  Identifier = "PullToRefreshTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>
@@ -63,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/KIF.xcodeproj/xcshareddata/xcschemes/KIF.xcscheme
+++ b/KIF.xcodeproj/xcshareddata/xcschemes/KIF.xcscheme
@@ -72,6 +72,13 @@
             ReferencedContainer = "container:KIF.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "KIF_PRINTVIEWTREEONFAILURE"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ All of the tests for KIF are written in Objective-C. This allows for maximum int
 #### Easy Configuration
 KIF integrates directly into your Xcode project, so there's no need to run an additional web server or install any additional packages.
 
-#### Wide OS coverage
-KIF's test suite has been run against iOS 8.1 and above, though lower versions will likely work.
+#### Wide OS and Xcode coverage
+KIF's test suite is being run against iOS 8+ and Xcode 7+. Lower versions will likely still work, but your mileage may vary. We do our best to retain backwards compatibility as much as possible.
 
 #### Test Like a User
 KIF attempts to imitate actual user input. Automation is done using tap events wherever possible.
@@ -214,7 +214,7 @@ Most of the tester actions in the test are already defined by the KIF framework,
 @end
 ```
 
-Everything should now be configured. When you run the integration tests using the test button, ⌘U, or the Xcode 5 Test Navigator (⌘5).
+Everything should now be configured. When you run the integration tests using the test button, ⌘U, or the Xcode Test Navigator (⌘5).
 
 Use with other testing frameworks
 ---------------------------------
@@ -307,7 +307,7 @@ or if you get another "unrecognized selector" error inside the KIF code, make su
 Continuous Integration
 ----------------------
 
-A continuous integration (CI) process is highly recommended and is extremely useful in ensuring that your application stays functional. The easiest way to do this will be with Xcode 5, either using Bots, or Jenkins or another tool that uses xcodebuild.  For tools using xcodebuild, review the manpage for instructions on using test destinations.
+A continuous integration (CI) process is highly recommended and is extremely useful in ensuring that your application stays functional. The easiest way to do this will be with Xcode, either using Bots, or Jenkins or another tool that uses xcodebuild.  For tools using xcodebuild, review the manpage for instructions on using test destinations.
 
 Contributing
 ------------


### PR DESCRIPTION
Resolves #1000, #1022

As a followup to getting CI running on Xcode 8, now we are getting a configuration running against Xcode 9. 

After getting Travis to run the tests properly on XC6, it turns out that they fail anyway. I don't have an environment that I can run the tests and fix them, and it seems like it is time to drop Xcode 6 support anyway (XC7 was GMed 2.5 ago). It would probably honestly be reasonable to even drop XC7 support as well, but we might as well keep it as long as the tests are passing and it isn't causing us trouble.

KIF Framework Changes:
* Changed `[UIAccessibilityElement-KIFAdditions viewContainingAccessibilityElement:tappable:error:]` to only attempt to scroll an element into the view if it isn't currently visible. There was some behavior broken in the "swipe to delete" tests (`[TableViewTests testSwipingRows]`) and this seemed like reasonable default behavior to have in the general case that also fixes the "swipe to delete" test.
* Fixed `deactivateAppForDuration:` (#1000) so that the test for that functionality also continues to work. The fix isn't great, but I can't think of a better approach at the moment, as it appears the functionality is broken within UIAutomation.
* Updated the README to indicate that we are supporting Xcode 7+.

Test Changes:
* I found that a couple of tests were disabled for no reason AFAIK. I've added them back into the running test suite and made sure that they pass.
* There are a couple tests that needed to be disabled for running on iOS 11, as the share sheet and photo picker controls are no longer accessible within the app.
* There was a race condition in `ExistTests.m` on iOS11 that it would try to find the element before the animation was actually complete. There may be some worse underlying bug here in detecting that animations have completed on iOS11, but this fixes the test for now and we'll potentially need to investigate this more later.