### PR TITLE
Allow disabling UITestActor animations to speed up tests

### DIFF
--- a/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -15,6 +15,7 @@
 #import "UIView-KIFAdditions.h"
 #import "LoadableCategory.h"
 #import "KIFTestActor.h"
+#import "KIFUITestActor.h"
 
 MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 
@@ -182,14 +183,15 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
             
             if ([superview isKindOfClass:[UIScrollView class]]) {
                 UIScrollView *scrollView = (UIScrollView *)superview;
+                BOOL animationEnabled = [KIFUITestActor testActorAnimationsEnabled];
                 
                 if (((UIAccessibilityElement *)view == element) && ![view isKindOfClass:[UITableViewCell class]]) {
-                    [scrollView scrollViewToVisible:view animated:YES];
+                    [scrollView scrollViewToVisible:view animated:animationEnabled];
                 } else if ([view isKindOfClass:[UITableViewCell class]] && [scrollView.superview isKindOfClass:[UITableView class]]) {
                     UITableViewCell *cell = (UITableViewCell *)view;
                     UITableView *tableView = (UITableView *)scrollView.superview;
                     NSIndexPath *indexPath = [tableView indexPathForCell:cell];
-                    [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:YES];
+                    [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:animationEnabled];
                 } else {
                     CGRect elementFrame = [view.window convertRect:element.accessibilityFrame toView:scrollView];
                     CGRect visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y, CGRectGetWidth(scrollView.bounds), CGRectGetHeight(scrollView.bounds));
@@ -197,12 +199,13 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
                     // Only call scrollRectToVisible if the element isn't already visible
                     // iOS 8 will sometimes incorrectly scroll table views so the element scrolls out of view
                     if (!CGRectContainsRect(visibleRect, elementFrame)) {
-                        [scrollView scrollRectToVisible:elementFrame animated:YES];
+                        [scrollView scrollRectToVisible:elementFrame animated:animationEnabled];
                     }
                 }
                 
                 // Give the scroll view a small amount of time to perform the scroll.
-                KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, 0.3, false);
+                CFTimeInterval delay = animationEnabled ? 0.3 : 0.05;
+                KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, delay, false);
             }
             
             superview = superview.superview;

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -14,6 +14,7 @@
 #import "UITouch-KIFAdditions.h"
 #import <objc/runtime.h>
 #import "UIEvent+KIFAdditions.h"
+#import "KIFUITestActor.h"
 
 double KIFDegreesToRadians(double deg) {
     return (deg) / 180.0 * M_PI;
@@ -265,9 +266,11 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                     }
                     
                     // Scroll to the cell and wait for the animation to complete
-                    [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:YES];
+                    BOOL animationEnabled = [KIFUITestActor testActorAnimationsEnabled];
+                    [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:animationEnabled];
                     // Note: using KIFRunLoopRunInModeRelativeToAnimationSpeed here may cause tests to stall
-                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.5, false);
+                    CFTimeInterval delay = animationEnabled ? 0.5 : 0.05;
+                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, delay, false);
                     
                     // Now try finding the element again
                     return [self accessibilityElementMatchingBlock:matchBlock];

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -824,4 +824,17 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
  */
 - (void)deactivateAppForDuration:(NSTimeInterval)duration KIF_DEPRECATED("Use [system deactivateAppForDuration:] instead.");
 
+/*!
+ @method testActorAnimationsEnabled
+ @abstract Flag to disable/enable animations done by the UITestActor, by default this value is YES. This doesn't affect animations performed by the app being tested.
+ @discussion To change the default value of this flag, call +setTestActorAnimationsEnabled: with a different value.
+ */
++ (BOOL)testActorAnimationsEnabled;
+
+/*!
+ @method setTestActorAnimationsEnabled:
+ @abstract Sets the flag value to enable or disable animations done by the UITestActor.
+ */
++ (void)setTestActorAnimationsEnabled:(BOOL)animationsEnabled;
+
 @end

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -41,6 +41,7 @@ KIFUITestActor *_KIF_tester()
 
 @end
 
+static BOOL KIFUITestActorAnimationsEnabled = YES;
 
 @implementation KIFUITestActor
 
@@ -839,7 +840,7 @@ KIFUITestActor *_KIF_tester()
     }
 
     NSLog(@"Faking turning switch %@", switchIsOn ? @"ON" : @"OFF");
-    [switchView setOn:switchIsOn animated:YES];
+    [switchView setOn:switchIsOn animated:[[self class] testActorAnimationsEnabled]];
     [switchView sendActionsForControlEvents:UIControlEventValueChanged];
     [self waitForTimeInterval:0.5 relativeToAnimationSpeed:YES];
 
@@ -1209,7 +1210,7 @@ KIFUITestActor *_KIF_tester()
     __block UITableViewCell *cell = nil;
     __block CGFloat lastYOffset = CGFLOAT_MAX;
     [self runBlock:^KIFTestStepResult(NSError **error) {
-        [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:position animated:YES];
+        [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:position animated:[[self class] testActorAnimationsEnabled]];
         cell = [tableView cellForRowAtIndexPath:indexPath];
         KIFTestWaitCondition(!!cell, error, @"Table view cell at index path %@ not found", indexPath);
         
@@ -1266,7 +1267,7 @@ KIFUITestActor *_KIF_tester()
 
     [collectionView scrollToItemAtIndexPath:indexPath
                            atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally | UICollectionViewScrollPositionCenteredVertically
-                                   animated:YES];
+                                   animated:[[self class] testActorAnimationsEnabled]];
 
     // waitForAnimationsToFinish doesn't allow collection view to settle when animations are sped up
     // So use waitForTimeInterval instead
@@ -1408,6 +1409,16 @@ KIFUITestActor *_KIF_tester()
         case KIFSwipeDirectionDown:
             return CGPointMake(kKIFMinorSwipeDisplacement, UIScreen.mainScreen.majorSwipeDisplacement);
     }
+}
+
++ (BOOL)testActorAnimationsEnabled;
+{
+    return KIFUITestActorAnimationsEnabled;
+}
+
++ (void)setTestActorAnimationsEnabled:(BOOL)animationsEnabled;
+{
+    KIFUITestActorAnimationsEnabled = animationsEnabled;
 }
 
 @end

--- a/KIF Tests/CollectionViewTests.m
+++ b/KIF Tests/CollectionViewTests.m
@@ -16,16 +16,28 @@
 
 - (void)beforeEach
 {
+    XCTAssertTrue([[tester class] testActorAnimationsEnabled]);
     [tester tapViewWithAccessibilityLabel:@"CollectionViews"];
 }
 
 - (void)afterEach
 {
     [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
+    [[tester class] setTestActorAnimationsEnabled:YES];
 }
 
 - (void)testTappingItems
 {
+    [tester tapItemAtIndexPath:[NSIndexPath indexPathForItem:199 inSection:0] inCollectionViewWithAccessibilityIdentifier:@"CollectionView Tests CollectionView"];
+    [tester waitForViewWithAccessibilityLabel:@"Last Cell" traits:UIAccessibilityTraitSelected];
+    [tester tapItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0] inCollectionViewWithAccessibilityIdentifier:@"CollectionView Tests CollectionView"];
+    [tester waitForViewWithAccessibilityLabel:@"First Cell" traits:UIAccessibilityTraitSelected];
+}
+
+- (void)testTappingItemsWithoutAnimation
+{
+    [[tester class] setTestActorAnimationsEnabled:NO];
+
     [tester tapItemAtIndexPath:[NSIndexPath indexPathForItem:199 inSection:0] inCollectionViewWithAccessibilityIdentifier:@"CollectionView Tests CollectionView"];
     [tester waitForViewWithAccessibilityLabel:@"Last Cell" traits:UIAccessibilityTraitSelected];
     [tester tapItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0] inCollectionViewWithAccessibilityIdentifier:@"CollectionView Tests CollectionView"];
@@ -37,6 +49,15 @@
     [tester tapItemAtIndexPath:[NSIndexPath indexPathForItem:-1 inSection:-1] inCollectionViewWithAccessibilityIdentifier:@"CollectionView Tests CollectionView"];
     [tester waitForViewWithAccessibilityLabel:@"Last Cell" traits:UIAccessibilityTraitSelected];
 }
+
+- (void)testTappingLastItemAndSectionWithoutAnimation
+{
+    [[tester class] setTestActorAnimationsEnabled:NO];
+
+    [tester tapItemAtIndexPath:[NSIndexPath indexPathForItem:-1 inSection:-1] inCollectionViewWithAccessibilityIdentifier:@"CollectionView Tests CollectionView"];
+    [tester waitForViewWithAccessibilityLabel:@"Last Cell" traits:UIAccessibilityTraitSelected];
+}
+
 
 - (void)testOutOfBounds
 {

--- a/KIF Tests/ScrollViewTests.m
+++ b/KIF Tests/ScrollViewTests.m
@@ -16,12 +16,14 @@
 
 - (void)beforeEach
 {
+    XCTAssertTrue([[tester class] testActorAnimationsEnabled]);
     [tester tapViewWithAccessibilityLabel:@"ScrollViews"];
 }
 
 - (void)afterEach
 {
     [tester tapViewWithAccessibilityLabel:@"Test Suite" traits:UIAccessibilityTraitButton];
+    [[tester class] setTestActorAnimationsEnabled:YES];
 }
 
 - (void)testScrollingToTapOffscreenViews
@@ -32,8 +34,23 @@
     [tester tapViewWithAccessibilityLabel:@"Left"];
 }
 
+- (void)testScrollingToTapOffscreenViewsWithoutAnimation
+{
+    [[tester class] setTestActorAnimationsEnabled:NO];
+    [tester tapViewWithAccessibilityLabel:@"Down"];
+    [tester tapViewWithAccessibilityLabel:@"Up"];
+    [tester tapViewWithAccessibilityLabel:@"Right"];
+    [tester tapViewWithAccessibilityLabel:@"Left"];
+}
+
 - (void)testScrollingToTapOffscreenTextView
 {
+    [tester tapViewWithAccessibilityLabel:@"TextView"];
+}
+
+- (void)testScrollingToTapOffscreenTextViewWithoutAnimation
+{
+    [[tester class] setTestActorAnimationsEnabled:NO];
     [tester tapViewWithAccessibilityLabel:@"TextView"];
 }
 


### PR DESCRIPTION
The `KIFUITestActor` by default, performs actions with animation. Those animations (scrolling a table view or a scroll view) can't be speeded up using the `layer.speed` and in a test suite with hundred of tests involving UITableViews this could slow down dramatically the overall running time. 

This PR creates a new settable property in the `KIFUITestActor` to allow disabling this default behaviour.