### PR TITLE
Adding stabilization code to waitForAnimationsToFinishWithTimeout

### DIFF
--- a/Classes/KIFTestActor.h
+++ b/Classes/KIFTestActor.h
@@ -92,6 +92,7 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 @property (nonatomic) NSTimeInterval executionBlockTimeout;
 @property (nonatomic) NSTimeInterval animationWaitingTimeout;
 @property (nonatomic) NSTimeInterval animationStabilizationTimeout;
+@property (nonatomic) NSTimeInterval mainThreadDispatchStabilizationTimeout;
 
 - (instancetype)usingTimeout:(NSTimeInterval)executionBlockTimeout;
 - (instancetype)usingAnimationWaitingTimeout:(NSTimeInterval)animationWaitingTimeout;
@@ -132,6 +133,19 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
  @abstract Sets the amount of time to wait before starting to check for animations
  */
 + (void)setDefaultAnimationStabilizationTimeout:(NSTimeInterval)newDefaultAnimationStabilizationTimeout;
+
+/*!
+ @method defaultMainThreadDispatchStabilizationTimeout
+ @abstract The default amount of time to wait for the main thread to process animations.
+ @discussion To change the default value of the timeout property, call +setDefaultMainThreadDispatchStabilizationTimeout: with a different value.
+ */
++ (NSTimeInterval)defaultMainThreadDispatchStabilizationTimeout;
+
+/*!
+ @method setDefaultMainThreadDispatchStabilizationTimeout:
+ @abstract Sets the amount of time to wait for the main thread to process animations.
+ */
++ (void)setDefaultMainThreadDispatchStabilizationTimeout:(NSTimeInterval)newDefaultMainThreadDispatchStabilizationTimeout;
 
 /*!
  @method defaultTimeout

--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -46,6 +46,7 @@
         _executionBlockTimeout = [[self class] defaultTimeout];
         _animationWaitingTimeout = [[self class] defaultAnimationWaitingTimeout];
         _animationStabilizationTimeout = [[self class] defaultAnimationStabilizationTimeout];
+        _mainThreadDispatchStabilizationTimeout = [[self class] defaultMainThreadDispatchStabilizationTimeout];
     }
     return self;
 }
@@ -127,6 +128,7 @@
 
 static NSTimeInterval KIFTestStepDefaultAnimationWaitingTimeout = 0.5;
 static NSTimeInterval KIFTestStepDefaultAnimationStabilizationTimeout = 0.5;
+static NSTimeInterval KIFTestStepDefaultMainThreadDispatchStabilizationTimeout = 0.5;
 static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
 static NSTimeInterval KIFTestStepDelay = 0.1;
 
@@ -149,6 +151,17 @@ static NSTimeInterval KIFTestStepDelay = 0.1;
 {
     KIFTestStepDefaultAnimationStabilizationTimeout = newDefaultAnimationStabilizationTimeout;
 }
+
++ (NSTimeInterval)defaultMainThreadDispatchStabilizationTimeout
+{
+    return KIFTestStepDefaultMainThreadDispatchStabilizationTimeout;
+}
+
++ (void)setDefaultMainThreadDispatchStabilizationTimeout:(NSTimeInterval)newDefaultMainThreadDispatchStabilizationTimeout;
+{
+    KIFTestStepDefaultMainThreadDispatchStabilizationTimeout = newDefaultMainThreadDispatchStabilizationTimeout;
+}
+
 
 + (NSTimeInterval)defaultTimeout;
 {


### PR DESCRIPTION
We've found that a race condition can sometimes occur whereby a touch event enqueued on the main queue runloop executes before the UI element it's meant to tap has actually appeared onscreen.

When that happens, KIF can wind up sending UI tap events to a view while it's still in the midst of animating onscreen.

We've determined that enqueuing a simple task (set a boolean to `YES`) on the main thread, and spinning a runloop until its execution just before the end of `waitForAnimationsToFinishWithTimeout`, we can avoid this race condition.

Users can configure how long we wait (or if we wait at all, if set to 0) by setting `KIFTestActor.mainThreadDispatchStabilizationTimeout`, or pass a custom timeout to `[KIFUITestActor waitForAnimationsToFinishWithTimeout:(NSTimeInterval)timeout stabilizationTime:(NSTimeInterval)stabilizationTime mainThreadDispatchStabilizationTime:(NSTimeInterval)mainThreadDispatchStabilizationTime]`