### PR TITLE
Adding autocorrect/smart quotes/smart dashes swizzling for UITextView

### DIFF
--- a/KIF.podspec
+++ b/KIF.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = "KIF"
-  s.version                 = "3.7.2"
+  s.version                 = "3.7.3"
   s.summary                 = "Keep It Functional - iOS UI acceptance testing in an XCUnit harness."
   s.homepage                = "https://github.com/kif-framework/KIF/"
   s.license                 = 'Apache 2.0'


### PR DESCRIPTION
The original change to prevent autocorrect/smart quotes/smart dashes only worked on `UITextField`, but not `UITextView`. This simply adds that change for `UITextView` as well.