### PR TITLE
Fix bug with table view elements that are matched but offscreen

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -321,6 +321,23 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
         KIFTestWaitCondition(view.isUserInteractionActuallyEnabled, error, @"View is not enabled for interaction: %@", view);
 
         CGPoint tappablePointInElement = [self tappablePointInElement:element andView:view];
+
+        // If the element isn't immediately tappable, try checking if it is contained within scroll views that can be scrolled to make it tappable.
+        if (isnan(tappablePointInElement.x)) {
+            UIView *container = view;
+
+            do {
+                if ([container isKindOfClass:UIScrollView.class]) {
+                    UIScrollView *containerScrollView = (UIScrollView *)container;
+                    CGRect rect = [view convertRect:view.frame toView:containerScrollView];
+                    [containerScrollView scrollRectToVisible:rect animated:NO];
+                }
+
+                container = container.superview;
+            } while (container != nil);
+
+            tappablePointInElement = [self tappablePointInElement:element andView:view];
+        }
         
         // This is mostly redundant of the test in _accessibilityElementWithLabel:
         KIFTestWaitCondition(!isnan(tappablePointInElement.x), error, @"View is not tappable: %@", view);


### PR DESCRIPTION
This bug has existed for a while, but I hadn't gotten around to fixing it until verifying the fix in #1020, which started hitting this in our app.

The issue is that if a table view cell contains a matching element, and that element is fully offscreen but the tableViewCell is partially onscreen, we won't scroll it into view during the matching operation (in `-[UIView(KIFAdditions) accessibilityElementMatchingBlock:notHidden:]`) and tapping the element will fail. 

The fix here is that right before attempting to tap an element, if it isn't currently tappable on the screen and is contained within one or more UIScrollView's, attempt to reposition the scroll views such that the element to tap is visible on the screen.