### PR TITLE
Update XCTestCase-KIFAdditions.m

### DIFF
--- a/Additions/XCTestCase-KIFAdditions.m
+++ b/Additions/XCTestCase-KIFAdditions.m
@@ -65,12 +65,17 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
 - (void)writeScreenshotForException:(NSException *)exception;
 {
     [[UIApplication sharedApplication] writeScreenshotForLine:[exception.userInfo[@"LineNumberKey"] unsignedIntegerValue] inFile:exception.userInfo[@"FilenameKey"] description:nil error:NULL];
-        
+    
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
     [XCTContext runActivityNamed:(@"screenshot") block:^(id<XCTActivity>  _Nonnull activity) {
         XCUIScreenshot *screenShot = [[XCUIScreen mainScreen] screenshot];
         XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenShot];
         [activity addAttachment:(attachment)];
+        dispatch_semaphore_signal(semaphore);
     }];
+    
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
 }
 
 - (void)printViewHierarchyIfOptedIn;

--- a/Additions/XCTestCase-KIFAdditions.m
+++ b/Additions/XCTestCase-KIFAdditions.m
@@ -68,12 +68,18 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
     
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
+#ifdef __IPHONE_11_0
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
     [XCTContext runActivityNamed:(@"screenshot") block:^(id<XCTActivity>  _Nonnull activity) {
         XCUIScreenshot *screenShot = [[XCUIScreen mainScreen] screenshot];
         XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenShot];
         [activity addAttachment:(attachment)];
         dispatch_semaphore_signal(semaphore);
     }];
+    
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+#endif
     
     dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
 }

--- a/Additions/XCTestCase-KIFAdditions.m
+++ b/Additions/XCTestCase-KIFAdditions.m
@@ -67,6 +67,7 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
     [[UIApplication sharedApplication] writeScreenshotForLine:[exception.userInfo[@"LineNumberKey"] unsignedIntegerValue] inFile:exception.userInfo[@"FilenameKey"] description:nil error:NULL];
     
 #ifdef __IPHONE_11_0
+    //semaphore will make sure the screenshot will be captured. otherwise it will crash on getting screenshot!  
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
     [XCTContext runActivityNamed:(@"screenshot") block:^(id<XCTActivity>  _Nonnull activity) {

--- a/Additions/XCTestCase-KIFAdditions.m
+++ b/Additions/XCTestCase-KIFAdditions.m
@@ -65,6 +65,12 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
 - (void)writeScreenshotForException:(NSException *)exception;
 {
     [[UIApplication sharedApplication] writeScreenshotForLine:[exception.userInfo[@"LineNumberKey"] unsignedIntegerValue] inFile:exception.userInfo[@"FilenameKey"] description:nil error:NULL];
+        
+    [XCTContext runActivityNamed:(@"screenshot") block:^(id<XCTActivity>  _Nonnull activity) {
+        XCUIScreenshot *screenShot = [[XCUIScreen mainScreen] screenshot];
+        XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenShot];
+        [activity addAttachment:(attachment)];
+    }];
 }
 
 - (void)printViewHierarchyIfOptedIn;

--- a/Additions/XCTestCase-KIFAdditions.m
+++ b/Additions/XCTestCase-KIFAdditions.m
@@ -66,8 +66,6 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
 {
     [[UIApplication sharedApplication] writeScreenshotForLine:[exception.userInfo[@"LineNumberKey"] unsignedIntegerValue] inFile:exception.userInfo[@"FilenameKey"] description:nil error:NULL];
     
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
 #ifdef __IPHONE_11_0
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
@@ -81,7 +79,6 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
     dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
 #endif
     
-    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
 }
 
 - (void)printViewHierarchyIfOptedIn;

--- a/Additions/XCTestCase-KIFAdditions.m
+++ b/Additions/XCTestCase-KIFAdditions.m
@@ -67,17 +67,19 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
     [[UIApplication sharedApplication] writeScreenshotForLine:[exception.userInfo[@"LineNumberKey"] unsignedIntegerValue] inFile:exception.userInfo[@"FilenameKey"] description:nil error:NULL];
     
 #ifdef __IPHONE_11_0
-    //semaphore will make sure the screenshot will be captured. otherwise it will crash on getting screenshot!  
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-    [XCTContext runActivityNamed:(@"screenshot") block:^(id<XCTActivity>  _Nonnull activity) {
-        XCUIScreenshot *screenShot = [[XCUIScreen mainScreen] screenshot];
-        XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenShot];
-        [activity addAttachment:(attachment)];
-        dispatch_semaphore_signal(semaphore);
-    }];
-    
-    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 11.0) {
+        //semaphore will make sure the screenshot will be captured. otherwise it will crash on getting screenshot!
+        dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+        
+        [XCTContext runActivityNamed:(@"screenshot") block:^(id<XCTActivity>  _Nonnull activity) {
+            XCUIScreenshot *screenShot = [[XCUIScreen mainScreen] screenshot];
+            XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenShot];
+            [activity addAttachment:(attachment)];
+            dispatch_semaphore_signal(semaphore);
+        }];
+        
+        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    }
 #endif
     
 }


### PR DESCRIPTION
add KIFScreenshot as attachment to XCTContext activity when KIF_SCREENSHOT is set as environment variable. So the report in Xcode or any html report would include the snapshot like below : 
![screen shot 2018-06-04 at 4 57 51 pm](https://user-images.githubusercontent.com/33662696/40941356-8dd6a6ee-6818-11e8-8bec-f9b250310a9c.png)
