### PR TITLE
Remove travis tests for iOS 8.1 and replace with iPad 5th gen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - osx_image: xcode9.2
       env: 'SIMULATOR="name=iPhone 7 Plus,OS=10.3.1"'
     - osx_image: xcode9.2
-	  env: 'SIMULATOR="name=iPad (5th generation),OS=10.3.2"'
+      env: 'SIMULATOR="name=iPad (5th generation),OS=10.3.2"'
     - osx_image: xcode8.3
       env: 'SIMULATOR="name=iPhone 5,OS=9.3"'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ matrix:
       env: 'SIMULATOR="name=iPad Pro (12.9-inch) (2nd generation),OS=11.2"'
     - osx_image: xcode9.2
       env: 'SIMULATOR="name=iPhone 7 Plus,OS=10.3.1"'
+    - osx_image: xcode9.2
+	  env: 'SIMULATOR="name=iPad (5th generation),OS=10.3.2"'
     - osx_image: xcode8.3
       env: 'SIMULATOR="name=iPhone 5,OS=9.3"'
-    - osx_image: xcode7.3
-      env: 'SIMULATOR="name=iPad 2,OS=8.1"'
 
 before_install:
   - xcrun simctl list

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - osx_image: xcode9.2
       env: 'SIMULATOR="name=iPhone 7 Plus,OS=10.3.1"'
     - osx_image: xcode9.2
-      env: 'SIMULATOR="name=iPad (5th generation),OS=10.3.2"'
+      env: 'SIMULATOR="name=iPad (5th generation),OS=10.3.1"'
     - osx_image: xcode8.3
       env: 'SIMULATOR="name=iPhone 5,OS=9.3"'
 


### PR DESCRIPTION
Justification is based off of a comment in another PR by: @qzim, "https://data.apteligent.com/ios/ indicates a 0.46% iOS 8 usage"