### PR TITLE
Fix crash on rotate on very small angle

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -653,7 +653,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     }
 
     // Dispatching the event doesn't actually update the first responder, so fake it
-    if ([touches[0] view] == self && [self canBecomeFirstResponder]) {
+    if ([touches.firstObject view] == self && [self canBecomeFirstResponder]) {
         [self becomeFirstResponder];
     }
 


### PR DESCRIPTION
Tested on rotation on very small angle.
AS IS
Crash on`view.twoFingerRotate(at: CGPoint(x: 0, y: 0), angle: angle)` when angle = 0.01
IN RESULT
No crash