### PR TITLE
Issue #1085: Make XCTestCase 'just work'

### DIFF
--- a/Classes/KIFTestActor.m
+++ b/Classes/KIFTestActor.m
@@ -36,8 +36,6 @@
 
 - (instancetype)initWithFile:(NSString *)file line:(NSInteger)line delegate:(id<KIFTestActorDelegate>)delegate
 {
-    NSAssert(KIFAccessibilityEnabled(), @"The method `KIFEnableAccessibility()` hasn't been called yet. Either call it explicitly before any of your tests run, or subclass KIFTestCase to get this behavior automatically.");
-
     self = [super init];
     if (self) {
         _file = file;
@@ -76,6 +74,13 @@
 
 - (BOOL)tryRunningBlock:(KIFTestExecutionBlock)executionBlock complete:(KIFTestCompletionBlock)completionBlock timeout:(NSTimeInterval)timeout error:(out NSError **)error
 {
+    // Ensure that regardless of whether tests subclass KIFTestCase or not,
+    // accessibility will have been enabled.
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        KIFEnableAccessibility();
+    });
+
     NSDate *startDate = [NSDate date];
     KIFTestStepResult result;
     NSError *internalError;

--- a/Classes/KIFTestCase.m
+++ b/Classes/KIFTestCase.m
@@ -64,7 +64,6 @@ NSComparisonResult selectorSort(NSInvocation *invocOne, NSInvocation *invocTwo, 
 
 + (void)setUp
 {
-    KIFEnableAccessibility();
     [self performSetupTearDownWithSelector:@selector(beforeAll)];
 }
 


### PR DESCRIPTION
There isn't a need to require test writers to explicitly call
KIFEnableAccessibility. Instead, call to enable accessibility on
the first attempt to perform an action via KIFTestActor.

This resolves issue #1085.