### PR TITLE
Issue #1084: Avoid `XCUIScreenshot` in Xcode 10 Beta, where the functionality is broken

### DIFF
--- a/Additions/XCTestCase-KIFAdditions.m
+++ b/Additions/XCTestCase-KIFAdditions.m
@@ -65,8 +65,11 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
 - (void)writeScreenshotForException:(NSException *)exception;
 {
     [[UIApplication sharedApplication] writeScreenshotForLine:[exception.userInfo[@"LineNumberKey"] unsignedIntegerValue] inFile:exception.userInfo[@"FilenameKey"] description:nil error:NULL];
-    
-#ifdef __IPHONE_11_0
+
+    // Per #1084, something broke in this code starting with Xcode 10.
+    // For now, this will be disabled and can be fixed later by anyone
+    // that relies on this functionality.
+#if defined(__IPHONE_11_0) && !defined(__IPHONE_12_0)
     if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 11.0) {
         //semaphore will make sure the screenshot will be captured. otherwise it will crash on getting screenshot!
         dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);


### PR DESCRIPTION
Something broke in this code starting with Xcode 10. For now, this will be disabled and can be fixed later by anyone that relies on this functionality.

Resolves #1084

CC: @maryamaffinityclick (added this functionality)
CC: @LWX124 (reported the issue)