### PR TITLE
Fix scrollViewToVisible:animated:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
 before_install:
   - xcrun simctl list
   - brew update || brew update
-  - rvm install 2.3.1
   - gem install bundler
 install:
   - if [ -z "$(brew ls --versions coreutils)" ] ; then brew install coreutils ; fi

--- a/Additions/UIScrollView-KIFAdditions.m
+++ b/Additions/UIScrollView-KIFAdditions.m
@@ -46,9 +46,9 @@ MAKE_CATEGORIES_LOADABLE(UIScrollView_KIFAdditions)
     contentInset = self.contentInset;
 #endif
     CGFloat minX = -self.contentInset.left;
-    CGFloat maxX = minX + MAX(0, self.contentSize.width + contentInset.right - CGRectGetWidth(self.bounds));
+    CGFloat maxX = minX + MAX(0, self.contentSize.width + contentInset.left + contentInset.right - CGRectGetWidth(self.bounds));
     CGFloat minY = -self.contentInset.top;
-    CGFloat maxY = minY + MAX(0, self.contentSize.height + contentInset.bottom - CGRectGetHeight(self.bounds));
+    CGFloat maxY = minY + MAX(0, self.contentSize.height + contentInset.top + contentInset.bottom - CGRectGetHeight(self.bounds));
     contentOffset.x = MAX(minX, MIN(contentOffset.x, maxX));
     contentOffset.y = MAX(minY, MIN(contentOffset.y, maxY));
     

--- a/Test Host/ScrollViewController.m
+++ b/Test Host/ScrollViewController.m
@@ -19,6 +19,7 @@
     [super viewDidLoad];
 
     self.scrollView.accessibilityLabel = @"Scroll View";
+    self.scrollView.contentInset = UIEdgeInsetsMake(2000, 2000, 0, 0);
     self.scrollView.contentSize = CGSizeMake(2000, 2000);
     self.scrollView.delegate = self;
     

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -44,8 +44,6 @@ env NSUnbufferedIO=YES xcodebuild test -project "Documentation/Examples/Testable
 env NSUnbufferedIO=YES xcodebuild build -project "Documentation/Examples/Calculator/Calculator.xcodeproj" -scheme "Calculator" -derivedDataPath=${PWD}/build/Calculator -destination "platform=iOS Simulator,${SIMULATOR}" | xcpretty -c
 
 if is_xcode_version_8_plus; then
-  # Ensure that we can build a release for carthage (no longer supports Xcode 7)
-  brew outdated carthage || brew upgrade carthage
   carthage build --no-skip-current
   carthage archive KIF
 fi


### PR DESCRIPTION
When `UIScrollView` has some `contentInset` set, the `scrollViewToVisible:animated:` is not scrolling to the right position. This PR exposes the bug in the tests and fixes the implementation.