### PR TITLE
Don't crash if there is no key window

### DIFF
--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -115,7 +115,7 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
 {
     NSMutableArray *windows = self.windows.mutableCopy;
     UIWindow *keyWindow = self.keyWindow;
-    if (![windows containsObject:keyWindow]) {
+    if (keyWindow && ![windows containsObject:keyWindow]) {
         [windows addObject:keyWindow];
     }
     return windows;


### PR DESCRIPTION
The issue is pretty self explanatory. We were using this helper in our code and ran into a situation where keyWindow may be nil if this helper is used during test setup.