### PR TITLE
Add "atPosition:" variations to UICollectionView waitForCellAtIndexPa…

### DIFF
--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -752,19 +752,33 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
  @abstract Scrolls a collection view while waiting for the cell at the given indexPath to appear.
  @discussion This step will get the cell at the indexPath.
  
- For cases where you may need to work from the end of a table view rather than the beginning, negative sections count back from the end of the table view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
- 
+ By default, scrolls to the vertical and horizontal middle of the cell. If you need to scroll to custom positions, use the @c atPosition: variation.
+ For cases where you may need to work from the end of a collection view rather than the beginning, negative sections count back from the end of the collection view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+
  @param indexPath Index path of the cell.
  @param collectionView UICollectionView containing the cell.
  @result Collection view cell at index path
  */
 - (UICollectionViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView;
 
+/*!
+ @abstract Scrolls a collection view while waiting for the cell at the given indexPath to appear.
+ @discussion This step will get the cell at the indexPath.
+
+ For cases where you may need to work from the end of a collection view rather than the beginning, negative sections count back from the end of the collection view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+
+ @param indexPath Index path of the cell.
+ @param collectionView UICollectionView containing the cell.
+ @param position Collection View scroll position to scroll to. Useful for custom-sized cells when the content needed is in a specific location.
+ @result Collection view cell at index path
+ */
+- (UICollectionViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView atPosition:(UICollectionViewScrollPosition)position;
 
 /*!
- @abstract Scrolls a given collection view while waiting for the item at the given indexPath to appear.
+ @abstract Scrolls a collection view with the given identifier while waiting for the item at the given indexPath to appear.
  @discussion This step will get the view with the specified accessibility identifier and then get the cell at indexPath.
  
+ By default, scrolls to the vertical and horizontal middle of the cell. If you need to scroll to custom positions, use the @c atPosition: variation.
  For cases where you may need to work from the end of a collection view rather than the beginning, negative sections count back from the end of the collection view (-1 is the last section) and negative items count back from the end of the section (-1 is the last item for that section).
  
  @param indexPath Index path of the item to tap.
@@ -772,6 +786,19 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
  @result Collection view cell at index path
  */
 - (UICollectionViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inCollectionViewWithAccessibilityIdentifier:(NSString *)identifier;
+
+/*!
+ @abstract Scrolls a collection view with the given identifier while waiting for the item at the given indexPath to appear.
+ @discussion This step will get the view with the specified accessibility identifier and then get the cell at indexPath.
+
+ For cases where you may need to work from the end of a collection view rather than the beginning, negative sections count back from the end of the collection view (-1 is the last section) and negative rows count back from the end of the section (-1 is the last row for that section).
+
+ @param indexPath Index path of the cell.
+ @param identifier Accessibility identifier of the table view.
+ @param position Collection View scroll position to scroll to. Useful for custom-sized cells when the content needed is in a specific location.
+ @result Table view cell at index path
+ */
+- (UICollectionViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inCollectionViewWithAccessibilityIdentifier:(NSString *)identifier atPosition:(UICollectionViewScrollPosition)position;
 
 /*!
  @abstract Moves the row at sourceIndexPath to destinationIndexPath in a table view with the given identifier.

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -1274,12 +1274,24 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
 
 - (UICollectionViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inCollectionViewWithAccessibilityIdentifier:(NSString *)identifier
 {
+    return [self waitForCellAtIndexPath:indexPath inCollectionViewWithAccessibilityIdentifier:identifier atPosition:UICollectionViewScrollPositionCenteredHorizontally |
+            UICollectionViewScrollPositionCenteredVertically];
+}
+
+- (UICollectionViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inCollectionViewWithAccessibilityIdentifier:(NSString *)identifier atPosition:(UICollectionViewScrollPosition)position;
+{
     UICollectionView *collectionView;
     [self waitForAccessibilityElement:NULL view:&collectionView withIdentifier:identifier tappable:NO];
-    return [self waitForCellAtIndexPath:indexPath inCollectionView:collectionView];
+    return [self waitForCellAtIndexPath:indexPath inCollectionView:collectionView atPosition:position];
 }
 
 - (UICollectionViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView
+{
+    return [self waitForCellAtIndexPath:indexPath inCollectionView:collectionView atPosition:UICollectionViewScrollPositionCenteredHorizontally |
+            UICollectionViewScrollPositionCenteredVertically];
+}
+
+- (UICollectionViewCell *)waitForCellAtIndexPath:(NSIndexPath *)indexPath inCollectionView:(UICollectionView *)collectionView atPosition:(UICollectionViewScrollPosition)position
 {
     if (![collectionView isKindOfClass:[UICollectionView class]]) {
         [self failWithError:[NSError KIFErrorWithFormat:@"View is not a collection view"] stopTest:YES];
@@ -1310,7 +1322,7 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
     }];
 
     [collectionView scrollToItemAtIndexPath:indexPath
-                           atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally | UICollectionViewScrollPositionCenteredVertically
+                           atScrollPosition:position
                                    animated:[[self class] testActorAnimationsEnabled]];
 
     // waitForAnimationsToFinish doesn't allow collection view to settle when animations are sped up

--- a/KIF Tests/CollectionViewTests.m
+++ b/KIF Tests/CollectionViewTests.m
@@ -59,6 +59,27 @@
 }
 
 
+- (void)testTappingLastAndFirstRowAtPositionWithAccessiblityIdentifier
+{
+    UICollectionViewCell *lastCell = [tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:-1] inCollectionViewWithAccessibilityIdentifier:@"CollectionView Tests CollectionView" atPosition:UICollectionViewScrollPositionBottom];
+    CGPoint lastPosition = [lastCell.superview convertPoint:lastCell.frame.origin toView:nil];
+    XCTAssertEqual(lastCell.frame.origin.x, lastPosition.x);
+    UICollectionViewCell *firstCell = [tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inCollectionViewWithAccessibilityIdentifier:@"CollectionView Tests CollectionView" atPosition:UICollectionViewScrollPositionTop];
+    CGPoint firstPosition = [firstCell.superview convertPoint:firstCell.frame.origin toView:nil];
+    XCTAssertEqual(0, firstPosition.x);
+}
+
+- (void)testTappingLastAndFirstRowAtPositionWithView
+{
+    UICollectionView *collectionView = (UICollectionView *)[[viewTester usingIdentifier:@"CollectionView Tests CollectionView"] waitForView];
+    UICollectionViewCell *lastCell = [tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:-1] inCollectionView:collectionView atPosition:UICollectionViewScrollPositionBottom];
+    CGPoint lastPosition = [lastCell.superview convertPoint:lastCell.frame.origin toView:nil];
+    XCTAssertEqual(lastCell.frame.origin.x, lastPosition.x);
+    UICollectionViewCell *firstCell = [tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inCollectionView:collectionView atPosition:UICollectionViewScrollPositionTop];
+    CGPoint firstPosition = [firstCell.superview convertPoint:firstCell.frame.origin toView:nil];
+    XCTAssertEqual(0, firstPosition.x);
+}
+
 - (void)testOutOfBounds
 {
     KIFExpectFailure([[tester usingTimeout:1] tapItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:99] inCollectionViewWithAccessibilityIdentifier:@"CollectionView Tests CollectionView"]);

--- a/KIF Tests/CollectionViewTests.m
+++ b/KIF Tests/CollectionViewTests.m
@@ -59,25 +59,29 @@
 }
 
 
-- (void)testTappingLastAndFirstRowAtPositionWithAccessiblityIdentifier
+- (void)testScrollingLastAndFirstRowAtPositionWithAccessiblityIdentifier
 {
     UICollectionViewCell *lastCell = [tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:-1] inCollectionViewWithAccessibilityIdentifier:@"CollectionView Tests CollectionView" atPosition:UICollectionViewScrollPositionBottom];
-    CGPoint lastPosition = [lastCell.superview convertPoint:lastCell.frame.origin toView:nil];
-    XCTAssertEqual(lastCell.frame.origin.x, lastPosition.x);
+    CGRect lastCellConverted = [lastCell.superview convertRect:lastCell.frame toView:nil];
+    CGRect superviewConverted = [lastCell convertRect:lastCell.superview.frame toView:nil];
+    XCTAssertEqual(lastCellConverted.origin.y, superviewConverted.origin.y);
     UICollectionViewCell *firstCell = [tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inCollectionViewWithAccessibilityIdentifier:@"CollectionView Tests CollectionView" atPosition:UICollectionViewScrollPositionTop];
-    CGPoint firstPosition = [firstCell.superview convertPoint:firstCell.frame.origin toView:nil];
-    XCTAssertEqual(0, firstPosition.x);
+    CGRect firstCellConverted = [firstCell.superview convertRect:firstCell.frame toView:nil];
+    superviewConverted = [firstCell convertRect:firstCell.superview.frame toView:nil];
+    XCTAssertEqual(firstCellConverted.origin.y, superviewConverted.origin.y);
 }
 
-- (void)testTappingLastAndFirstRowAtPositionWithView
+- (void)testScrollingLastAndFirstRowAtPositionWithView
 {
     UICollectionView *collectionView = (UICollectionView *)[[viewTester usingIdentifier:@"CollectionView Tests CollectionView"] waitForView];
     UICollectionViewCell *lastCell = [tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:-1 inSection:-1] inCollectionView:collectionView atPosition:UICollectionViewScrollPositionBottom];
-    CGPoint lastPosition = [lastCell.superview convertPoint:lastCell.frame.origin toView:nil];
-    XCTAssertEqual(lastCell.frame.origin.x, lastPosition.x);
+    CGRect lastCellConverted = [lastCell.superview convertRect:lastCell.frame toView:nil];
+    CGRect superviewConverted = [lastCell convertRect:lastCell.superview.frame toView:nil];
+    XCTAssertEqual(lastCellConverted.origin.y, superviewConverted.origin.y);
     UICollectionViewCell *firstCell = [tester waitForCellAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] inCollectionView:collectionView atPosition:UICollectionViewScrollPositionTop];
-    CGPoint firstPosition = [firstCell.superview convertPoint:firstCell.frame.origin toView:nil];
-    XCTAssertEqual(0, firstPosition.x);
+    CGRect firstCellConverted = [firstCell.superview convertRect:firstCell.frame toView:nil];
+    superviewConverted = [firstCell convertRect:firstCell.superview.frame toView:nil];
+    XCTAssertEqual(firstCellConverted.origin.y, superviewConverted.origin.y);
 }
 
 - (void)testOutOfBounds


### PR DESCRIPTION
Taking over from @gaperlinski for #1061 :

> Allows the consumers to specify custom UICollectionViewScrollPosition of the cell they want to scroll to. UICollectionViewScrollPositionCenteredHorizontally | UICollectionViewScrollPositionCenteredVertically remains to the default value.