### PR TITLE
Fix Xcode 11 (Beta) build error (implicit conversion warning)

### DIFF
--- a/Classes/KIFSystemTestActor.m
+++ b/Classes/KIFSystemTestActor.m
@@ -58,7 +58,7 @@
 
 - (void)simulateDeviceRotationToOrientation:(UIDeviceOrientation)orientation
 {
-    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:orientation] forKey:@"orientation"];
+    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:(int)orientation] forKey:@"orientation"];
 }
 
 

--- a/Classes/KIFSystemTestActor.m
+++ b/Classes/KIFSystemTestActor.m
@@ -58,7 +58,7 @@
 
 - (void)simulateDeviceRotationToOrientation:(UIDeviceOrientation)orientation
 {
-    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:(int)orientation] forKey:@"orientation"];
+    [[UIDevice currentDevice] setValue:@(orientation) forKey:@"orientation"];
 }
 
 


### PR DESCRIPTION
Fixes:

```
KIF/Classes/KIFSystemTestActor.m:61:64: error: implicit conversion loses integer precision: 'UIDeviceOrientation' (aka 'enum UIDeviceOrientation') to 'int' [-Werror,-Wshorten-64-to-32]
    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:orientation] forKey:@"orientation"];
```