### PR TITLE
Prevent EXC_BAD_ACCESS crash by null-checking proper error

### DIFF
--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -181,7 +181,7 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
 
     NSError *directoryCreationError = nil;
     if (![[NSFileManager defaultManager] createDirectoryAtPath:outputPath withIntermediateDirectories:YES attributes:nil error:&directoryCreationError]) {
-        if (directoryCreationError) {
+        if (error) {
             *error = [NSError KIFErrorWithFormat:@"Couldn't create directory at path %@ (details: %@)", outputPath, directoryCreationError];
         }
         return NO;


### PR DESCRIPTION
### Problem

If writing a screenshot fails due to failure to create a directory, an error is assigned to the `error` parameter. However, when `writeScreenShotForLine:...` is called with a `NULL` error param by `writeScreenshotForException:` in XCTestCase-KIFAdditions.m, the assignment causes a crash with EXC_BAD_ACCESS.

Relevant excerpt from XCTestCase-KIFAdditions.m: https://github.com/kif-framework/KIF/blob/0ea470b4731c95782d9a34342efbf5de3ec23183/Additions/XCTestCase-KIFAdditions.m#L67 

This regression was introduced by commit f4705fb963dd872995580846eaa777681c10fd1a (#981), which changed the error checked by the `if (error) { ... }` check away from `error`. 


### Fix

Revert f4705fb963dd872995580846eaa777681c10fd1a -- check proper error again.

This parallels all the other `if (error)` checks in `writeScreenShotForLine:...`. 

### QA Plan

- [x] Confirm that crash no longer occurs when writing a screenshot fails due to failure to create a directory
- [x] Confirm that behavior is acceptable when `directoryCreationError` is nil:
   - When simulating a `nil` `directoryCreationError`, result of printing `error`: `Error Domain=KIFTest Code=0 "Couldn't create directory at path $CIRCLE_ARTIFACTS (details: (null))" UserInfo={NSLocalizedDescription=Couldn't create directory at path $CIRCLE_ARTIFACTS (details: (null))}`

