### PR TITLE
Fix bug when acknowledging system alerts in Xcode 11.1

### DIFF
--- a/Classes/UIAutomationHelper.m
+++ b/Classes/UIAutomationHelper.m
@@ -120,14 +120,18 @@ static void FixReactivateApp(void)
 {
     UIAApplication *application = [[self target] frontMostApp];
     UIAAlert *alert = application.alert;
+    UIAElement *foundElement;
 
 #ifdef __IPHONE_13_1
     if ([alert isKindOfClass:[self nilElementClass]]) {
         // application.alert returns UIAElementNil on iOS 13.1
         // Instead find the alert by looking for the alert's window and getting the UIAAlert off of it
-        alert = (UIAAlert *)[[[[[application windows] filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(UIAElement *_Nullable evaluatedObject, NSDictionary<NSString *, id> *_Nullable bindings) {
+        foundElement = (UIAElement *)[[[application windows] filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(UIAElement *_Nullable evaluatedObject, NSDictionary<NSString *, id> *_Nullable bindings) {
             return [[evaluatedObject valueForKey:@"type"] isEqualToString:@"SBAlertItemWindow"];
-        }]] firstObject] elements] firstObject];
+        }]] firstObject];
+        alert = (UIAAlert *) [[foundElement.elements filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(UIAElement *_Nullable evaluatedObject, NSDictionary<NSString *, id> *_Nullable bindings) {
+        return [[evaluatedObject valueForKey:@"type"] isEqualToString:@"_UIAlertControllerView"];
+        }]] firstObject];
     }
 #endif
 

--- a/Classes/UIAutomationHelper.m
+++ b/Classes/UIAutomationHelper.m
@@ -120,13 +120,12 @@ static void FixReactivateApp(void)
 {
     UIAApplication *application = [[self target] frontMostApp];
     UIAAlert *alert = application.alert;
-    UIAElement *foundElement;
 
 #ifdef __IPHONE_13_1
     if ([alert isKindOfClass:[self nilElementClass]]) {
         // application.alert returns UIAElementNil on iOS 13.1
         // Instead find the alert by looking for the alert's window and getting the UIAAlert off of it
-        foundElement = (UIAElement *)[[[application windows] filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(UIAElement *_Nullable evaluatedObject, NSDictionary<NSString *, id> *_Nullable bindings) {
+        UIAElement *foundElement = (UIAElement *)[[[application windows] filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(UIAElement *_Nullable evaluatedObject, NSDictionary<NSString *, id> *_Nullable bindings) {
             return [[evaluatedObject valueForKey:@"type"] isEqualToString:@"SBAlertItemWindow"];
         }]] firstObject];
         alert = (UIAAlert *) [[foundElement.elements filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(UIAElement *_Nullable evaluatedObject, NSDictionary<NSString *, id> *_Nullable bindings) {


### PR DESCRIPTION
After upgrading to Xcode 11.1, KIF tests on our app were no longer able to acknowledge system notifications. After debugging it was found that the UIAlert is not always the first item in the list of elements. This change searches the list of elements for the UIAlertControllerView making it more resilient.

May help issue #1127