### PR TITLE
Scroll once when waiting for UITableViewCells

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -1251,10 +1251,13 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
         return KIFTestStepResultSuccess;
     }];
 
+    [tableView scrollToRowAtIndexPath:indexPath
+                     atScrollPosition:position
+                             animated:[[self class] testActorAnimationsEnabled]];
+
     __block UITableViewCell *cell = nil;
     __block CGFloat lastYOffset = CGFLOAT_MAX;
     [self runBlock:^KIFTestStepResult(NSError **error) {
-        [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:position animated:[[self class] testActorAnimationsEnabled]];
         cell = [tableView cellForRowAtIndexPath:indexPath];
         KIFTestWaitCondition(!!cell, error, @"Table view cell at index path %@ not found", indexPath);
         


### PR DESCRIPTION
Previously we would call `UITableView.scrollToRow(at:at:animated:)`
every runloop while we waited for the scroll to complete. This caused
multiple unnecessary calls to the delegate's
`scrollViewDidEndScrollingAnimation(_:)` method. This change resolves
the issue by moving the call to scroll to the row outside of the
`KIFTestActor.run(_:)` block.