### PR TITLE
Widen `firstResponder` searches to all windows

### DIFF
--- a/Additions/UIApplication-KIFAdditions.h
+++ b/Additions/UIApplication-KIFAdditions.h
@@ -75,6 +75,11 @@ CF_EXPORT SInt32 KIFRunLoopRunInModeRelativeToAnimationSpeed(CFStringRef mode, C
  */
 - (NSArray *)windowsWithKeyWindow;
 
+/// @discussion The first responders are ordered in the reverse order of @c -windowsWithKeyWindow
+/// to return in order of nearest visually.
+/// @returns All first responders in the application.
+- (NSArray<UIResponder *> *)firstResponders;
+
 /*!
  The current Core Animation speed of the keyWindow's CALayer.
  */

--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -8,6 +8,7 @@
 //  which Square, Inc. licenses this file to you.
 
 #import "UIApplication-KIFAdditions.h"
+#import "UIWindow-KIFAdditions.h"
 #import "LoadableCategory.h"
 #import "UIView-KIFAdditions.h"
 #import "NSError-KIFAdditions.h"
@@ -97,6 +98,20 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
 - (UIWindow *)dimmingViewWindow;
 {
     return [self getWindowForSubviewClass:@"UIDimmingView"];
+}
+
+- (NSArray<UIResponder *> *)firstResponders;
+{
+    NSMutableArray *responders = [NSMutableArray array];
+
+    for (UIWindow *window in [[self windowsWithKeyWindow] reverseObjectEnumerator]) {
+        UIResponder *responder = window.firstResponder;
+        if (responder) {
+            [responders addObject:responder];
+        }
+    }
+
+    return [responders copy];
 }
 
 - (UIWindow *)getWindowForSubviewClass:(NSString*)className;

--- a/Classes/KIFUITestActor.h
+++ b/Classes/KIFUITestActor.h
@@ -678,7 +678,7 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 /*!
  @abstract Waits until a view or accessibility element is the first responder.
  @discussion The first responder is found by searching the view hierarchy of the application's
- main window and its accessibility label is compared to the given value. If they match, the
+ windows and its accessibility label is compared to the given value. If they match, the
  step returns success else it will attempt to wait until they do.
  @param label The accessibility label of the element to wait for.
  */
@@ -687,7 +687,7 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 /*!
  @abstract Waits until a view or accessibility element is the first responder.
  @discussion The first responder is found by searching the view hierarchy of the application's
- main window and its accessibility label is compared to the given value. If they match, the
+ windows and its accessibility label is compared to the given value. If they match, the
  step returns success else it will attempt to wait until they do.
  @param label The accessibility label of the element to wait for.
  @param traits The accessibility traits of the element to wait for. Elements that do not include at least these traits are ignored.

--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -220,7 +220,7 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
             [self waitForTimeInterval:maximumWaitingTimeInterval relativeToAnimationSpeed:YES];
         }
     } else {
-    
+
         // Wait for the view to stabilize and give them a chance to start animations before we wait for them.
         [self waitForTimeInterval:stabilizationTime relativeToAnimationSpeed:YES];
         maximumWaitingTimeInterval -= stabilizationTime;
@@ -468,7 +468,7 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
     [text enumerateSubstringsInRange:NSMakeRange(0, text.length)
                              options:NSStringEnumerationByComposedCharacterSequences
                           usingBlock: ^(NSString *characterString,NSRange substringRange,NSRange enclosingRange,BOOL * stop)
-    {
+     {
         if (![KIFTypist enterCharacter:characterString]) {
             NSLog(@"KIF: Unable to find keyboard key for %@. Will attempt to insert manually.", characterString);
 
@@ -480,7 +480,7 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
             } else {
                 [fallbackViews addObjectsFromArray:[[UIApplication sharedApplication] firstResponders]];
             }
-
+            
             for (id fallback in [fallbackViews copy]) {
                 if (![fallback isKindOfClass:[UITextField class]] &&
                     ![fallback isKindOfClass:[UITextView class]] &&
@@ -998,7 +998,7 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
 
     // Tap the desired photo in the grid
     // TODO: This currently only works for the first page of photos. It should scroll appropriately at some point.
-     UIAccessibilityElement *headerElt = [[UIApplication sharedApplication] accessibilityElementMatchingBlock:^(UIAccessibilityElement *element) {
+    UIAccessibilityElement *headerElt = [[UIApplication sharedApplication] accessibilityElementMatchingBlock:^(UIAccessibilityElement *element) {
         return [NSStringFromClass(element.class) isEqual:@"UINavigationItemButtonView"];
     }];
     UIView* headerView = [UIAccessibilityElement viewContainingAccessibilityElement:headerElt];
@@ -1117,56 +1117,56 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
 - (void)swipeAccessibilityElement:(UIAccessibilityElement *)element inView:(UIView *)viewToSwipe inDirection:(KIFSwipeDirection)direction
 {
     // The original version of this came from http://groups.google.com/group/kif-framework/browse_thread/thread/df3f47eff9f5ac8c
-  
+
     const NSUInteger kNumberOfPointsInSwipePath = 20;
-  
+
     // Within this method, all geometry is done in the coordinate system of the view to swipe.
     CGRect elementFrame = [self elementFrameForElement:element andView:viewToSwipe];
 
     CGPoint swipeStart = CGPointCenteredInRect(elementFrame);
 
     KIFDisplacement swipeDisplacement = [self _displacementForSwipingInDirection:direction];
-  
+
     [viewToSwipe dragFromPoint:swipeStart displacement:swipeDisplacement steps:kNumberOfPointsInSwipePath];
 }
 
 - (void)pullToRefreshViewWithAccessibilityLabel:(NSString *)label
 {
-	[self pullToRefreshViewWithAccessibilityLabel:label value:nil pullDownDuration:0 traits:UIAccessibilityTraitNone];
+    [self pullToRefreshViewWithAccessibilityLabel:label value:nil pullDownDuration:0 traits:UIAccessibilityTraitNone];
 }
 
 - (void)pullToRefreshViewWithAccessibilityLabel:(NSString *)label pullDownDuration:(KIFPullToRefreshTiming) pullDownDuration
 {
-	[self pullToRefreshViewWithAccessibilityLabel:label value:nil pullDownDuration:pullDownDuration traits:UIAccessibilityTraitNone];
+    [self pullToRefreshViewWithAccessibilityLabel:label value:nil pullDownDuration:pullDownDuration traits:UIAccessibilityTraitNone];
 }
 
 - (void)pullToRefreshViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value
 {
-	[self pullToRefreshViewWithAccessibilityLabel:label value:value pullDownDuration:0 traits:UIAccessibilityTraitNone];
+    [self pullToRefreshViewWithAccessibilityLabel:label value:value pullDownDuration:0 traits:UIAccessibilityTraitNone];
 }
 
 - (void)pullToRefreshViewWithAccessibilityLabel:(NSString *)label value:(NSString *)value pullDownDuration:(KIFPullToRefreshTiming) pullDownDuration traits:(UIAccessibilityTraits)traits
 {
-	UIView *viewToSwipe = nil;
-	UIAccessibilityElement *element = nil;
+    UIView *viewToSwipe = nil;
+    UIAccessibilityElement *element = nil;
 
-	[self waitForAccessibilityElement:&element view:&viewToSwipe withLabel:label value:value traits:traits tappable:YES];
+    [self waitForAccessibilityElement:&element view:&viewToSwipe withLabel:label value:value traits:traits tappable:YES];
 
-	[self pullToRefreshAccessibilityElement:element inView:viewToSwipe pullDownDuration:pullDownDuration];
+    [self pullToRefreshAccessibilityElement:element inView:viewToSwipe pullDownDuration:pullDownDuration];
 }
 
 - (void)pullToRefreshAccessibilityElement:(UIAccessibilityElement *)element inView:(UIView *)viewToSwipe pullDownDuration:(KIFPullToRefreshTiming) pullDownDuration
 {
-	//Based on swipeAccessibilityElement
+    //Based on swipeAccessibilityElement
 
-	const NSUInteger kNumberOfPointsInSwipePath = pullDownDuration ? pullDownDuration : KIFPullToRefreshInAboutAHalfSecond;
+    const NSUInteger kNumberOfPointsInSwipePath = pullDownDuration ? pullDownDuration : KIFPullToRefreshInAboutAHalfSecond;
 
     // Can handle only the touchable space.
     CGRect elementFrame = [viewToSwipe convertRect:viewToSwipe.bounds toView:[UIApplication sharedApplication].keyWindow.rootViewController.view];
     CGPoint swipeStart = CGPointCenteredInRect(elementFrame);
-	CGPoint swipeDisplacement = CGPointMake(CGRectGetMidX(elementFrame), CGRectGetMaxY(elementFrame));
+    CGPoint swipeDisplacement = CGPointMake(CGRectGetMidX(elementFrame), CGRectGetMaxY(elementFrame));
 
-	[viewToSwipe dragFromPoint:swipeStart displacement:swipeDisplacement steps:kNumberOfPointsInSwipePath];
+    [viewToSwipe dragFromPoint:swipeStart displacement:swipeDisplacement steps:kNumberOfPointsInSwipePath];
 }
 
 - (void)scrollViewWithAccessibilityLabel:(NSString *)label byFractionOfSizeHorizontal:(CGFloat)horizontalFraction vertical:(CGFloat)verticalFraction
@@ -1438,43 +1438,43 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
 
 -(void) tapStepperWithAccessibilityLabel: (NSString *)accessibilityLabel increment: (KIFStepperDirection) stepperDirection
 {
-	@autoreleasepool {
-		UIView *view = nil;
-		UIAccessibilityElement *element = nil;
-		[self waitForAccessibilityElement:&element view:&view withLabel:accessibilityLabel value:nil traits:UIAccessibilityTraitNone tappable:YES];
-		[self tapStepperWithAccessibilityElement:element increment:stepperDirection inView:view];
-	}
+    @autoreleasepool {
+        UIView *view = nil;
+        UIAccessibilityElement *element = nil;
+        [self waitForAccessibilityElement:&element view:&view withLabel:accessibilityLabel value:nil traits:UIAccessibilityTraitNone tappable:YES];
+        [self tapStepperWithAccessibilityElement:element increment:stepperDirection inView:view];
+    }
 }
 
 //inspired by http://www.raywenderlich.com/61419/ios-ui-testing-with-kif
 - (void)tapStepperWithAccessibilityElement:(UIAccessibilityElement *)element increment: (KIFStepperDirection) stepperDirection inView:(UIView *)view
 {
-	[self runBlock:^KIFTestStepResult(NSError **error) {
+    [self runBlock:^KIFTestStepResult(NSError **error) {
 
-		KIFTestWaitCondition(view.isUserInteractionActuallyEnabled, error, @"View is not enabled for interaction: %@", view);
+        KIFTestWaitCondition(view.isUserInteractionActuallyEnabled, error, @"View is not enabled for interaction: %@", view);
 
         CGPoint stepperPointToTap = [self tappablePointInElement:element andView:view];
 
-		switch (stepperDirection)
-		{
-			case KIFStepperDirectionIncrement:
-				stepperPointToTap.x += CGRectGetWidth(view.frame) / 4;
-				break;
-			case KIFStepperDirectionDecrement:
-				stepperPointToTap.x -= CGRectGetWidth(view.frame) / 4;
-				break;
-		}
+        switch (stepperDirection)
+        {
+            case KIFStepperDirectionIncrement:
+                stepperPointToTap.x += CGRectGetWidth(view.frame) / 4;
+                break;
+            case KIFStepperDirectionDecrement:
+                stepperPointToTap.x -= CGRectGetWidth(view.frame) / 4;
+                break;
+        }
 
-		// This is mostly redundant of the test in _accessibilityElementWithLabel:
-		KIFTestWaitCondition(!isnan(stepperPointToTap.x), error, @"View is not tappable: %@", view);
-		[view tapAtPoint:stepperPointToTap];
+        // This is mostly redundant of the test in _accessibilityElementWithLabel:
+        KIFTestWaitCondition(!isnan(stepperPointToTap.x), error, @"View is not tappable: %@", view);
+        [view tapAtPoint:stepperPointToTap];
 
-		KIFTestCondition(![view canBecomeFirstResponder] || [view isDescendantOfFirstResponder], error, @"Failed to make the view into the first responder: %@", view);
+        KIFTestCondition(![view canBecomeFirstResponder] || [view isDescendantOfFirstResponder], error, @"Failed to make the view into the first responder: %@", view);
 
-		return KIFTestStepResultSuccess;
-	}];
+        return KIFTestStepResultSuccess;
+    }];
 
-	[self waitForAnimationsToFinish];
+    [self waitForAnimationsToFinish];
 }
 
 - (CGRect) elementFrameForElement:(UIAccessibilityElement *)element andView:(UIView *)view

--- a/Classes/KIFUIViewTestActor.h
+++ b/Classes/KIFUIViewTestActor.h
@@ -195,8 +195,8 @@ extern NSString *const inputFieldTestString;
 
 /*!
  @abstract Waits until a view or accessibility element matching the tester's search predicate is the first responder.
- @discussion The first responder is found by searching the view hierarchy of the application's
- main window and its accessibility label is compared to the given value. If they match, the
+ @discussion The first responder is found by searching the view hierarchy of all the application's
+ windows and its accessibility label is compared to the given value. If they match, the
  step returns success else it will attempt to wait until they do.
  */
 - (void)waitToBecomeFirstResponder;

--- a/Classes/KIFUIViewTestActor.m
+++ b/Classes/KIFUIViewTestActor.m
@@ -210,9 +210,17 @@ NSString *const inputFieldTestString = @"Testing";
 - (void)waitToBecomeFirstResponder;
 {
     [self runBlock:^KIFTestStepResult(NSError **error) {
-        UIResponder *firstResponder = [[[UIApplication sharedApplication] keyWindow] firstResponder];
+        BOOL didMatch = NO;
+        NSArray *firstResponders = [[UIApplication sharedApplication] firstResponders];
 
-        KIFTestWaitCondition([self.predicate evaluateWithObject:firstResponder], error, @"Expected first responder to match '%@', got '%@'", self.predicate, firstResponder);
+        for (UIResponder *firstResponder in firstResponders) {
+            if ([self.predicate evaluateWithObject:firstResponder]) {
+                didMatch = YES;
+                break;
+            }
+        }
+
+        KIFTestWaitCondition(didMatch, error, @"Expected to find a first responder matching '%@', got: %@", self.predicate.kifPredicateDescription, firstResponders);
         return KIFTestStepResultSuccess;
     }];
 }

--- a/IdentifierTests/KIFUITestActor-IdentifierTests.m
+++ b/IdentifierTests/KIFUITestActor-IdentifierTests.m
@@ -53,47 +53,47 @@
 
 - (void)longPressViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier duration:(NSTimeInterval)duration
 {
-	@autoreleasepool {
-		UIView *view = nil;
-		UIAccessibilityElement *element = nil;
-		[self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
-		[self longPressAccessibilityElement:element inView:view duration:duration];
-	}
+    @autoreleasepool {
+        UIView *view = nil;
+        UIAccessibilityElement *element = nil;
+        [self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
+        [self longPressAccessibilityElement:element inView:view duration:duration];
+    }
 }
 
 - (void)enterText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
-	return [self enterText:text intoViewWithAccessibilityIdentifier:accessibilityIdentifier expectedResult:nil];
+    return [self enterText:text intoViewWithAccessibilityIdentifier:accessibilityIdentifier expectedResult:nil];
 }
 
 - (void)enterText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier expectedResult:(NSString *)expectedResult
 {
-	UIView *view = nil;
-	UIAccessibilityElement *element = nil;
-	
-	[self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
+    UIView *view = nil;
+    UIAccessibilityElement *element = nil;
+
+    [self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
     [self enterText:text intoElement:element inView:view expectedResult:expectedResult];
 }
 
 - (void)clearTextFromViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
-	UIView *view = nil;
-	UIAccessibilityElement *element = nil;
-	
-	[self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
-	[self clearTextFromElement:element inView:view];
+    UIView *view = nil;
+    UIAccessibilityElement *element = nil;
+
+    [self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
+    [self clearTextFromElement:element inView:view];
 }
 
 - (void)clearTextFromAndThenEnterText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
-	[self clearTextFromViewWithAccessibilityIdentifier:accessibilityIdentifier];
-	[self enterText:text intoViewWithAccessibilityIdentifier:accessibilityIdentifier];
+    [self clearTextFromViewWithAccessibilityIdentifier:accessibilityIdentifier];
+    [self enterText:text intoViewWithAccessibilityIdentifier:accessibilityIdentifier];
 }
 
 - (void)clearTextFromAndThenEnterText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier expectedResult:(NSString *)expectedResult
 {
-	[self clearTextFromViewWithAccessibilityIdentifier:accessibilityIdentifier];
-	[self enterText:text intoViewWithAccessibilityIdentifier:accessibilityIdentifier expectedResult:expectedResult];
+    [self clearTextFromViewWithAccessibilityIdentifier:accessibilityIdentifier];
+    [self enterText:text intoViewWithAccessibilityIdentifier:accessibilityIdentifier expectedResult:expectedResult];
 }
 
 - (void)setText:(NSString *)text intoViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
@@ -109,56 +109,56 @@
 
 - (void)setOn:(BOOL)switchIsOn forSwitchWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
-	UIView *view = nil;
-	UIAccessibilityElement *element = nil;
-	
-	[self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
-	
-	if (![view isKindOfClass:[UISwitch class]]) {
-		[self failWithError:[NSError KIFErrorWithFormat:@"View with accessibility identifier \"%@\" is a %@, not a UISwitch", accessibilityIdentifier, NSStringFromClass([view class])] stopTest:YES];
-	}
-	
-	UISwitch *switchView = (UISwitch *)view;
-	
-	// No need to switch it if it's already in the correct position
-	if (switchView.isOn == switchIsOn) {
-		return;
-	}
-	
-	[self tapAccessibilityElement:element inView:view];
-	
-	// If we succeeded, stop the test.
-	if (switchView.isOn == switchIsOn) {
-		return;
-	}
-	
-	NSLog(@"Faking turning switch %@ with accessibility identifier %@", switchIsOn ? @"ON" : @"OFF", accessibilityIdentifier);
-	[switchView setOn:switchIsOn animated:YES];
-	[switchView sendActionsForControlEvents:UIControlEventValueChanged];
-	[self waitForTimeInterval:0.5];
-	
-	// We gave it our best shot.  Fail the test.
-	if (switchView.isOn != switchIsOn) {
-		[self failWithError:[NSError KIFErrorWithFormat:@"Failed to toggle switch to \"%@\"; instead, it was \"%@\"", switchIsOn ? @"ON" : @"OFF", switchView.on ? @"ON" : @"OFF"] stopTest:YES];
-	}
-	
+    UIView *view = nil;
+    UIAccessibilityElement *element = nil;
+
+    [self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
+
+    if (![view isKindOfClass:[UISwitch class]]) {
+        [self failWithError:[NSError KIFErrorWithFormat:@"View with accessibility identifier \"%@\" is a %@, not a UISwitch", accessibilityIdentifier, NSStringFromClass([view class])] stopTest:YES];
+    }
+
+    UISwitch *switchView = (UISwitch *)view;
+
+    // No need to switch it if it's already in the correct position
+    if (switchView.isOn == switchIsOn) {
+        return;
+    }
+
+    [self tapAccessibilityElement:element inView:view];
+
+    // If we succeeded, stop the test.
+    if (switchView.isOn == switchIsOn) {
+        return;
+    }
+
+    NSLog(@"Faking turning switch %@ with accessibility identifier %@", switchIsOn ? @"ON" : @"OFF", accessibilityIdentifier);
+    [switchView setOn:switchIsOn animated:YES];
+    [switchView sendActionsForControlEvents:UIControlEventValueChanged];
+    [self waitForTimeInterval:0.5];
+
+    // We gave it our best shot.  Fail the test.
+    if (switchView.isOn != switchIsOn) {
+        [self failWithError:[NSError KIFErrorWithFormat:@"Failed to toggle switch to \"%@\"; instead, it was \"%@\"", switchIsOn ? @"ON" : @"OFF", switchView.on ? @"ON" : @"OFF"] stopTest:YES];
+    }
+
 }
 
 - (void)setValue:(float)value forSliderWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
-	UISlider *slider = nil;
-	UIAccessibilityElement *element = nil;
-	[self waitForAccessibilityElement:&element view:&slider withIdentifier:accessibilityIdentifier tappable:YES];
-	
-	if (![slider isKindOfClass:[UISlider class]]) {
-		[self failWithError:[NSError KIFErrorWithFormat:@"View with accessibility identifier \"%@\" is a %@, not a UISlider", accessibilityIdentifier, NSStringFromClass([slider class])] stopTest:YES];
-	}
-	[self setValue:value forSlider:slider];
+    UISlider *slider = nil;
+    UIAccessibilityElement *element = nil;
+    [self waitForAccessibilityElement:&element view:&slider withIdentifier:accessibilityIdentifier tappable:YES];
+
+    if (![slider isKindOfClass:[UISlider class]]) {
+        [self failWithError:[NSError KIFErrorWithFormat:@"View with accessibility identifier \"%@\" is a %@, not a UISlider", accessibilityIdentifier, NSStringFromClass([slider class])] stopTest:YES];
+    }
+    [self setValue:value forSlider:slider];
 }
 
 - (void)waitForFirstResponderWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
-	[self runBlock:^KIFTestStepResult(NSError **error) {
+    [self runBlock:^KIFTestStepResult(NSError **error) {
         BOOL didMatch = NO;
         NSArray *firstResponders = [[UIApplication sharedApplication] firstResponders];
 
@@ -181,12 +181,12 @@
             }
         }
 
-		KIFTestWaitCondition(didMatch,
-							 error, @"Expected to find a first responder with accessibility identifier '%@', got: %@",
-							 accessibilityIdentifier, firstResponders);
-		
-		return KIFTestStepResultSuccess;
-	}];
+        KIFTestWaitCondition(didMatch,
+                             error, @"Expected to find a first responder with accessibility identifier '%@', got: %@",
+                             accessibilityIdentifier, firstResponders);
+
+        return KIFTestStepResultSuccess;
+    }];
 }
 
 - (BOOL) tryFindingViewWithAccessibilityIdentifier:(NSString *) accessibilityIdentifier
@@ -207,31 +207,31 @@
 
 - (void)pullToRefreshViewWithAccessibilityIdentifier:(NSString *)identifier
 {
-	UIView *viewToSwipe = nil;
-	UIAccessibilityElement *element = nil;
+    UIView *viewToSwipe = nil;
+    UIAccessibilityElement *element = nil;
 
-	[self waitForAccessibilityElement: &element view:&viewToSwipe withIdentifier:identifier tappable:NO];
+    [self waitForAccessibilityElement: &element view:&viewToSwipe withIdentifier:identifier tappable:NO];
 
-	[self pullToRefreshAccessibilityElement:element inView:viewToSwipe pullDownDuration:0];
+    [self pullToRefreshAccessibilityElement:element inView:viewToSwipe pullDownDuration:0];
 }
 
 - (void)pullToRefreshViewWithAccessibilityIdentifier:(NSString *)identifier pullDownDuration:(KIFPullToRefreshTiming) pullDownDuration
 {
-	UIView *viewToSwipe = nil;
-	UIAccessibilityElement *element = nil;
+    UIView *viewToSwipe = nil;
+    UIAccessibilityElement *element = nil;
 
-	[self waitForAccessibilityElement: &element view:&viewToSwipe withIdentifier:identifier tappable:NO];
+    [self waitForAccessibilityElement: &element view:&viewToSwipe withIdentifier:identifier tappable:NO];
 
-	[self pullToRefreshAccessibilityElement:element inView:viewToSwipe pullDownDuration:pullDownDuration];
+    [self pullToRefreshAccessibilityElement:element inView:viewToSwipe pullDownDuration:pullDownDuration];
 }
 
 -(void) tapStepperWithAccessibilityIdentifier: (NSString *)accessibilityIdentifier increment: (KIFStepperDirection) stepperDirection
 {
-	@autoreleasepool {
-		UIView *view = nil;
-		UIAccessibilityElement *element = nil;
-		[self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
-		[self tapStepperWithAccessibilityElement:element increment:stepperDirection inView:view];
-	}
+    @autoreleasepool {
+        UIView *view = nil;
+        UIAccessibilityElement *element = nil;
+        [self waitForAccessibilityElement:&element view:&view withIdentifier:accessibilityIdentifier tappable:YES];
+        [self tapStepperWithAccessibilityElement:element increment:stepperDirection inView:view];
+    }
 }
 @end


### PR DESCRIPTION
Previously searches for `UIWindow.firstResponder` were limited to the
`UIApplication.keyWindow`. In practice, it is very possible for users to
add additional valid windows that are not the key window and have first
responders. To accommodate those cases, this change broadens the search
for a first responder of an application to an array of first responders
found in `UIApplication.windowsWithKeyWindow`.