### PR TITLE
Fix navigation back button tap (issue #1134)

### DIFF
--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -929,7 +929,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 
 - (BOOL)isNavigationItemView;
 {
-    return [self isKindOfClass:NSClassFromString(@"UINavigationItemView")] || [self isKindOfClass:NSClassFromString(@"_UINavigationBarBackIndicatorView")];
+    return [self isKindOfClass:NSClassFromString(@"UINavigationItemView")] || [self isKindOfClass:NSClassFromString(@"_UINavigationBarBackIndicatorView")] || [self isKindOfClass:NSClassFromString(@"_UIModernBarButton")];
 }
 
 - (UIWindow *)windowOrIdentityWindow


### PR DESCRIPTION
For more recent iOS versions the internal view hierarchy of navigation bar buttons has changed. A lot of unit tests are broken because it is not possible to tap on the back button anymore.

This PR adds a check for marking the new button as a navigation item view.