### PR TITLE
Wait for animations to complete after performing a scroll action

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -1199,6 +1199,8 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
     scrollStart.y -= scrollDisplacement.y / 2;
 
     [viewToScroll dragFromPoint:scrollStart displacement:scrollDisplacement steps:kNumberOfPointsInScrollPath];
+
+    [self waitForAnimationsToFinish];
 }
 
 - (void)waitForFirstResponderWithAccessibilityLabel:(NSString *)label


### PR DESCRIPTION
We're seeing an issue where we're unable to tap on an element right after performing a `-[KIFUIViewTestActor scrollByFractionOfSizeHorizontal:vertical:]` action. It appears to help ensure that the view has stabilized before attempting to interact with that UI element.