### PR TITLE
Adds a visualizer to KIF

### DIFF
--- a/Additions/UIApplication-KIFAdditions.h
+++ b/Additions/UIApplication-KIFAdditions.h
@@ -118,6 +118,12 @@ CF_EXPORT SInt32 KIFRunLoopRunInModeRelativeToAnimationSpeed(CFStringRef mode, C
  */
 + (void)stopMockingOpenURL;
 
+/*
+ Sends event to visualizer and application.
+ */
+- (void)kif_sendEvent:(UIEvent *)event;
+
+
 @end
 
 @interface UIApplication (Private)

--- a/Additions/UIApplication-KIFAdditions.m
+++ b/Additions/UIApplication-KIFAdditions.m
@@ -12,6 +12,7 @@
 #import "LoadableCategory.h"
 #import "UIView-KIFAdditions.h"
 #import "NSError-KIFAdditions.h"
+#import "KIFEventVisualizer.h"
 #import <QuartzCore/QuartzCore.h>
 #import <objc/runtime.h>
 #import <objc/message.h>
@@ -350,6 +351,14 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
 + (void)stopMockingOpenURL;
 {
     _KIF_UIApplicationMockOpenURL = NO;
+}
+
+#pragma mark - Send Event
+
+- (void)kif_sendEvent:(UIEvent *)event
+{
+    [[KIFEventVisualizer sharedVisualizer] visualizeEvent:event];
+    [self sendEvent:event];
 }
 
 @end

--- a/Additions/UITableView-KIFAdditions.m
+++ b/Additions/UITableView-KIFAdditions.m
@@ -58,7 +58,7 @@
     [touch setPhaseAndUpdateTimestamp:UITouchPhaseBegan];
     
     UIEvent *eventDown = [self eventWithTouch:touch];
-    [[UIApplication sharedApplication] sendEvent:eventDown];
+    [[UIApplication sharedApplication] kif_sendEvent:eventDown];
     
     // Hold long enough to enter reordering mode
     CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.2, false);
@@ -75,7 +75,7 @@
         [touch setPhaseAndUpdateTimestamp:UITouchPhaseMoved];
         
         UIEvent *eventDrag = [self eventWithTouch:touch];
-        [[UIApplication sharedApplication] sendEvent:eventDrag];
+        [[UIApplication sharedApplication] kif_sendEvent:eventDrag];
         
         CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.01, false);
     }
@@ -86,7 +86,7 @@
     [touch setPhaseAndUpdateTimestamp:UITouchPhaseEnded];
     
     UIEvent *eventUp = [self eventWithTouch:touch];
-    [[UIApplication sharedApplication] sendEvent:eventUp];
+    [[UIApplication sharedApplication] kif_sendEvent:eventUp];
     
     // Dispatching the event doesn't actually update the first responder, so fake it
     if (touch.view == self && [self canBecomeFirstResponder]) {

--- a/Additions/UIView-KIFAdditions.m
+++ b/Additions/UIView-KIFAdditions.m
@@ -481,10 +481,10 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     
     UIEvent *event = [self eventWithTouch:touch];
 
-    [[UIApplication sharedApplication] sendEvent:event];
+    [[UIApplication sharedApplication] kif_sendEvent:event];
     
     [touch setPhaseAndUpdateTimestamp:UITouchPhaseEnded];
-    [[UIApplication sharedApplication] sendEvent:event];
+    [[UIApplication sharedApplication] kif_sendEvent:event];
 
     // Dispatching the event doesn't actually update the first responder, so fake it
     if ([touch.view isDescendantOfView:self] && [self canBecomeFirstResponder]) {
@@ -502,12 +502,12 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     [touch2 setPhaseAndUpdateTimestamp:UITouchPhaseBegan];
 
     UIEvent *event = [self eventWithTouches:@[touch1, touch2]];
-    [[UIApplication sharedApplication] sendEvent:event];
+    [[UIApplication sharedApplication] kif_sendEvent:event];
 
     [touch1 setPhaseAndUpdateTimestamp:UITouchPhaseEnded];
     [touch2 setPhaseAndUpdateTimestamp:UITouchPhaseEnded];
 
-    [[UIApplication sharedApplication] sendEvent:event];
+    [[UIApplication sharedApplication] kif_sendEvent:event];
 }
 
 #define DRAG_TOUCH_DELAY 0.01
@@ -518,7 +518,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     [touch setPhaseAndUpdateTimestamp:UITouchPhaseBegan];
     
     UIEvent *eventDown = [self eventWithTouch:touch];
-    [[UIApplication sharedApplication] sendEvent:eventDown];
+    [[UIApplication sharedApplication] kif_sendEvent:eventDown];
     
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, DRAG_TOUCH_DELAY, false);
     
@@ -527,14 +527,14 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
         [touch setPhaseAndUpdateTimestamp:UITouchPhaseStationary];
         
         UIEvent *eventStillDown = [self eventWithTouch:touch];
-        [[UIApplication sharedApplication] sendEvent:eventStillDown];
+        [[UIApplication sharedApplication] kif_sendEvent:eventStillDown];
         
         CFRunLoopRunInMode(kCFRunLoopDefaultMode, DRAG_TOUCH_DELAY, false);
     }
     
     [touch setPhaseAndUpdateTimestamp:UITouchPhaseEnded];
     UIEvent *eventUp = [self eventWithTouch:touch];
-    [[UIApplication sharedApplication] sendEvent:eventUp];
+    [[UIApplication sharedApplication] kif_sendEvent:eventUp];
     
     // Dispatching the event doesn't actually update the first responder, so fake it
     if ([touch.view isDescendantOfView:self] && [self canBecomeFirstResponder]) {
@@ -621,7 +621,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                 [touches addObject:touch];
             }
             UIEvent *eventDown = [self eventWithTouches:[NSArray arrayWithArray:touches]];
-            [[UIApplication sharedApplication] sendEvent:eventDown];
+            [[UIApplication sharedApplication] kif_sendEvent:eventDown];
             
             CFRunLoopRunInMode(UIApplicationCurrentRunMode, DRAG_TOUCH_DELAY, false);
         }
@@ -637,7 +637,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                 [touch setPhaseAndUpdateTimestamp:UITouchPhaseMoved];
             }
             UIEvent *event = [self eventWithTouches:[NSArray arrayWithArray:touches]];
-            [[UIApplication sharedApplication] sendEvent:event];
+            [[UIApplication sharedApplication] kif_sendEvent:event];
 
             CFRunLoopRunInMode(UIApplicationCurrentRunMode, DRAG_TOUCH_DELAY, false);
 
@@ -646,7 +646,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                 for (UITouch * touch in touches) {
                     [touch setPhaseAndUpdateTimestamp:UITouchPhaseEnded];
                     UIEvent *eventUp = [self eventWithTouch:touch];
-                    [[UIApplication sharedApplication] sendEvent:eventUp];
+                    [[UIApplication sharedApplication] kif_sendEvent:eventUp];
                     
                 }
 

--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -13,6 +13,18 @@
 		0EAA1C171B4B372700FFB2FB /* IOHIDEvent+KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EAA1C111B4B371700FFB2FB /* IOHIDEvent+KIF.h */; };
 		0EAA1C181B4B372700FFB2FB /* IOHIDEvent+KIF.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */; };
 		22191DFC24BF7944004CAA18 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 22191DFB24BF7944004CAA18 /* Default-568h@2x.png */; };
+		228FD17224C0B52900170CD3 /* KIFEventVisualizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 228FD17024C0B52900170CD3 /* KIFEventVisualizer.h */; };
+		228FD17324C0B52900170CD3 /* KIFEventVisualizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 228FD17124C0B52900170CD3 /* KIFEventVisualizer.m */; };
+		22B82C96251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 22B82C94251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.h */; };
+		22B82C97251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = 22B82C95251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.m */; };
+		22B82C9A2511052500AE8B73 /* KIFTouchVisualizerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 22B82C982511052500AE8B73 /* KIFTouchVisualizerView.h */; };
+		22B82C9B2511052500AE8B73 /* KIFTouchVisualizerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 22B82C992511052500AE8B73 /* KIFTouchVisualizerView.m */; };
+		22B82C9C251156F200AE8B73 /* KIFEventVisualizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 228FD17024C0B52900170CD3 /* KIFEventVisualizer.h */; };
+		22B82C9D251156F200AE8B73 /* KIFEventVisualizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 228FD17124C0B52900170CD3 /* KIFEventVisualizer.m */; };
+		22B82C9E251156F200AE8B73 /* KIFTouchVisualizerViewCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 22B82C94251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.h */; };
+		22B82C9F251156F200AE8B73 /* KIFTouchVisualizerViewCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = 22B82C95251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.m */; };
+		22B82CA0251156F200AE8B73 /* KIFTouchVisualizerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 22B82C982511052500AE8B73 /* KIFTouchVisualizerView.h */; };
+		22B82CA1251156F200AE8B73 /* KIFTouchVisualizerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 22B82C992511052500AE8B73 /* KIFTouchVisualizerView.m */; };
 		2CDEE1CB181DBED200DF6E63 /* PickerController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CDEE1CA181DBED200DF6E63 /* PickerController.m */; };
 		3812FB611A1212A700335733 /* AnimationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3812FB601A1212A700335733 /* AnimationViewController.m */; };
 		3812FB631A12188700335733 /* WaitForAnimationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3812FB621A12188700335733 /* WaitForAnimationTests.m */; };
@@ -290,6 +302,12 @@
 		0EAA1C121B4B371700FFB2FB /* IOHIDEvent+KIF.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IOHIDEvent+KIF.m"; sourceTree = "<group>"; };
 		22191DFA24BF793F004CAA18 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainStoryboard.storyboard; sourceTree = "<group>"; };
 		22191DFB24BF7944004CAA18 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		228FD17024C0B52900170CD3 /* KIFEventVisualizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KIFEventVisualizer.h; sourceTree = "<group>"; };
+		228FD17124C0B52900170CD3 /* KIFEventVisualizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KIFEventVisualizer.m; sourceTree = "<group>"; };
+		22B82C94251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KIFTouchVisualizerViewCoordinator.h; sourceTree = "<group>"; };
+		22B82C95251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KIFTouchVisualizerViewCoordinator.m; sourceTree = "<group>"; };
+		22B82C982511052500AE8B73 /* KIFTouchVisualizerView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KIFTouchVisualizerView.h; sourceTree = "<group>"; };
+		22B82C992511052500AE8B73 /* KIFTouchVisualizerView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KIFTouchVisualizerView.m; sourceTree = "<group>"; };
 		2CDEE1CA181DBED200DF6E63 /* PickerController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PickerController.m; sourceTree = "<group>"; };
 		2CED883D181F5EE1005ABD20 /* PickerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PickerTests.m; sourceTree = "<group>"; };
 		3812FB601A1212A700335733 /* AnimationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AnimationViewController.m; sourceTree = "<group>"; };
@@ -551,6 +569,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		22B82C8F2511038200AE8B73 /* Visualizer */ = {
+			isa = PBXGroup;
+			children = (
+				228FD17024C0B52900170CD3 /* KIFEventVisualizer.h */,
+				228FD17124C0B52900170CD3 /* KIFEventVisualizer.m */,
+				22B82C94251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.h */,
+				22B82C95251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.m */,
+				22B82C982511052500AE8B73 /* KIFTouchVisualizerView.h */,
+				22B82C992511052500AE8B73 /* KIFTouchVisualizerView.m */,
+			);
+			path = Visualizer;
+			sourceTree = "<group>";
+		};
 		9CC9673C1AD4B1B600576D13 /* KIF Framework */ = {
 			isa = PBXGroup;
 			children = (
@@ -738,6 +769,7 @@
 		EB60ECBC177F8C51005A041A /* KIF */ = {
 			isa = PBXGroup;
 			children = (
+				22B82C8F2511038200AE8B73 /* Visualizer */,
 				AAB0729313971AB2008AF393 /* Additions */,
 				AAB0728413971A98008AF393 /* Classes */,
 				EB1A44D21A0C3222004A3F61 /* Identifier Tests */,
@@ -925,6 +957,7 @@
 				9CC9677C1AD4B20700576D13 /* KIFTestActor.h in Headers */,
 				9CC9677F1AD4B20700576D13 /* KIFTypist.h in Headers */,
 				9CC967811AD4B20700576D13 /* KIFTestStepValidation.h in Headers */,
+				22B82C9C251156F200AE8B73 /* KIFEventVisualizer.h in Headers */,
 				F6C685401D937FC200B10EC6 /* CAAnimation+KIFAdditions.h in Headers */,
 				9CC967751AD4B1FF00576D13 /* KIFUITestActor.h in Headers */,
 				9CC967771AD4B1FF00576D13 /* KIFUITestActor-ConditionalTests.h in Headers */,
@@ -932,12 +965,14 @@
 				9CC967611AD4B1F100576D13 /* UITouch-KIFAdditions.h in Headers */,
 				9CC967631AD4B1F100576D13 /* UIView-KIFAdditions.h in Headers */,
 				9CC967651AD4B1F100576D13 /* UIWindow-KIFAdditions.h in Headers */,
+				22B82C9E251156F200AE8B73 /* KIFTouchVisualizerViewCoordinator.h in Headers */,
 				FAC00C4C1C8E6D9900C38752 /* UIScreen+KIFAdditions.h in Headers */,
 				DCAB06B91EFD7A180051C676 /* KIFUITestActor_Private.h in Headers */,
 				9CC967671AD4B1F100576D13 /* UITableView-KIFAdditions.h in Headers */,
 				9CC967691AD4B1F100576D13 /* NSBundle-KIFAdditions.h in Headers */,
 				5C877DD11B0A8B8F006A3AC6 /* UIView-Debugging.h in Headers */,
 				9CC9676B1AD4B1F100576D13 /* NSError-KIFAdditions.h in Headers */,
+				22B82CA0251156F200AE8B73 /* KIFTouchVisualizerView.h in Headers */,
 				9CC9676D1AD4B1F100576D13 /* XCTestCase-KIFAdditions.h in Headers */,
 				9CC9676F1AD4B1F100576D13 /* NSException-KIFAdditions.h in Headers */,
 				9CC967711AD4B1F100576D13 /* UIEvent+KIFAdditions.h in Headers */,
@@ -958,6 +993,7 @@
 				EABD46921857A0C700A5F081 /* CGGeometry-KIFAdditions.h in Headers */,
 				EABD46931857A0C700A5F081 /* UIAccessibilityElement-KIFAdditions.h in Headers */,
 				9CC967BE1AD4B55E00576D13 /* KIF-XCTestPrefix.pch in Headers */,
+				22B82C9A2511052500AE8B73 /* KIFTouchVisualizerView.h in Headers */,
 				EABD46941857A0C700A5F081 /* UIApplication-KIFAdditions.h in Headers */,
 				FA9E18791C5AC962004E5E8D /* NSString+KIFAdditions.h in Headers */,
 				FAB4C4741A815CA900C52EDF /* NSPredicate+KIFAdditions.h in Headers */,
@@ -980,6 +1016,7 @@
 				EABD469F1857A0C700A5F081 /* KIFSystemTestActor.h in Headers */,
 				EABD46A01857A0C700A5F081 /* KIFUITestActor.h in Headers */,
 				EABD46A11857A0C700A5F081 /* NSBundle-KIFAdditions.h in Headers */,
+				228FD17224C0B52900170CD3 /* KIFEventVisualizer.h in Headers */,
 				EAC8096A1864F19C000E819F /* NSException-KIFAdditions.h in Headers */,
 				EABD46961857A0C700A5F081 /* XCTestCase-KIFAdditions.h in Headers */,
 				B66B1BDD202254A000D0E4B2 /* KIFTextInputTraitsOverrides.h in Headers */,
@@ -988,6 +1025,7 @@
 				EABD46A21857A0C700A5F081 /* NSError-KIFAdditions.h in Headers */,
 				DCAB06B81EFD7A170051C676 /* KIFUITestActor_Private.h in Headers */,
 				EABD46A31857A0C700A5F081 /* KIFTestStepValidation.h in Headers */,
+				22B82C96251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.h in Headers */,
 				3ADD25CC71BF27D675768787 /* UIView-Debugging.h in Headers */,
 				EB2526481981BF7A00DBC747 /* KIFUITestActor-ConditionalTests.h in Headers */,
 			);
@@ -1217,14 +1255,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				22B82C9F251156F200AE8B73 /* KIFTouchVisualizerViewCoordinator.m in Sources */,
 				9CC967D01AD4B5B900576D13 /* KIFTestCase.m in Sources */,
 				0EAA1C181B4B372700FFB2FB /* IOHIDEvent+KIF.m in Sources */,
 				FAB89FB71CAAED5300C6DFC1 /* NSString+KIFAdditions.m in Sources */,
 				9CC967D11AD4B5B900576D13 /* KIFTestActor.m in Sources */,
+				22B82C9D251156F200AE8B73 /* KIFEventVisualizer.m in Sources */,
 				9CC967D21AD4B5B900576D13 /* KIFTypist.m in Sources */,
 				9CC967D31AD4B5B900576D13 /* KIFTestStepValidation.m in Sources */,
 				9CC967D41AD4B5B900576D13 /* UIAutomationHelper.m in Sources */,
 				9CC967D51AD4B5B900576D13 /* KIFUITestActor-IdentifierTests.m in Sources */,
+				22B82CA1251156F200AE8B73 /* KIFTouchVisualizerView.m in Sources */,
 				9CC967CD1AD4B59A00576D13 /* KIFSystemTestActor.m in Sources */,
 				9CC967CE1AD4B59A00576D13 /* KIFUITestActor.m in Sources */,
 				F6C685411D937FC900B10EC6 /* CAAnimation+KIFAdditions.m in Sources */,
@@ -1262,6 +1303,7 @@
 				EABD467B1857A0C700A5F081 /* CGGeometry-KIFAdditions.m in Sources */,
 				0EAA1C141B4B371700FFB2FB /* IOHIDEvent+KIF.m in Sources */,
 				FA9E187A1C5AC962004E5E8D /* NSString+KIFAdditions.m in Sources */,
+				228FD17324C0B52900170CD3 /* KIFEventVisualizer.m in Sources */,
 				EABD467C1857A0C700A5F081 /* UIAccessibilityElement-KIFAdditions.m in Sources */,
 				84D293BD1A2CC30B00C10944 /* UIAutomationHelper.m in Sources */,
 				EABD467D1857A0C700A5F081 /* UIApplication-KIFAdditions.m in Sources */,
@@ -1274,6 +1316,7 @@
 				D927B9E018F9E46400DAD036 /* UITableView-KIFAdditions.m in Sources */,
 				EABD46831857A0C700A5F081 /* KIFTypist.m in Sources */,
 				EABD46841857A0C700A5F081 /* KIFTestActor.m in Sources */,
+				22B82C97251104C500AE8B73 /* KIFTouchVisualizerViewCoordinator.m in Sources */,
 				EABD46851857A0C700A5F081 /* KIFTestCase.m in Sources */,
 				EABD46861857A0C700A5F081 /* XCTestCase-KIFAdditions.m in Sources */,
 				EB1A44D61A0C3268004A3F61 /* KIFUITestActor-IdentifierTests.m in Sources */,
@@ -1281,6 +1324,7 @@
 				E977D1081AA4062B005645BF /* UIEvent+KIFAdditions.m in Sources */,
 				85DB946F1C5A3E860025F83E /* CALayer-KIFAdditions.m in Sources */,
 				EABD46871857A0C700A5F081 /* KIFSystemTestActor.m in Sources */,
+				22B82C9B2511052500AE8B73 /* KIFTouchVisualizerView.m in Sources */,
 				EAC8096B1864F19C000E819F /* NSException-KIFAdditions.m in Sources */,
 				EABD46881857A0C700A5F081 /* KIFUITestActor.m in Sources */,
 				EABD46891857A0C700A5F081 /* NSBundle-KIFAdditions.m in Sources */,

--- a/KIF.xcodeproj/xcshareddata/xcschemes/KIF.xcscheme
+++ b/KIF.xcodeproj/xcshareddata/xcschemes/KIF.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EABD46791857A0C700A5F081"
+            BuildableName = "libKIF.a"
+            BlueprintName = "KIF"
+            ReferencedContainer = "container:KIF.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EABD46791857A0C700A5F081"
-            BuildableName = "libKIF.a"
-            BlueprintName = "KIF"
-            ReferencedContainer = "container:KIF.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -76,9 +74,12 @@
             value = "YES"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "VISUALIZE_TOUCHES"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Visualizer/KIFEventVisualizer.h
+++ b/Visualizer/KIFEventVisualizer.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+@interface KIFEventVisualizer : NSObject
+
++ (nonnull instancetype)sharedVisualizer;
+
+- (void)visualizeEvent:(nonnull UIEvent *)event;
+
+// Unavailable.
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+
+
+@end

--- a/Visualizer/KIFEventVisualizer.m
+++ b/Visualizer/KIFEventVisualizer.m
@@ -1,0 +1,84 @@
+#import <UIKit/UIKit.h>
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+#import "KIFEventVisualizer.h"
+#import "KIFTouchVisualizerViewCoordinator.h"
+
+@interface KIFEventVisualizer()
+
+@property (strong, nonatomic, readonly) KIFTouchVisualizerViewCoordinator *coordinator;
+@property (strong, nonatomic, readonly) UIWindow *window;
+
+@end
+
+@implementation KIFEventVisualizer
+
++ (instancetype)sharedVisualizer
+{
+    static dispatch_once_t onceToken;
+    static KIFEventVisualizer *sharedVisualizer = nil;
+    dispatch_once(&onceToken, ^{
+        sharedVisualizer = [[KIFEventVisualizer alloc] initPrivate];
+    });
+    
+    return sharedVisualizer;
+}
+
+- (instancetype)initPrivate
+{
+    self = [super init];
+    
+    _window = [[UIWindow alloc] init];
+    _window.userInteractionEnabled = NO;
+    _window.windowLevel = UIWindowLevelAlert + 1;
+    _window.hidden = NO;
+    _window.backgroundColor = UIColor.clearColor;
+    _coordinator = [[KIFTouchVisualizerViewCoordinator alloc] initWithView:_window];
+    
+    return self;
+}
+
+- (void)visualizeEvent:(UIEvent *)event
+{
+    // Currently only support touch events, ignore all others.
+    if(event.type != UIEventTypeTouches) {
+        return;
+    }
+    
+    static BOOL shouldVisualizeTouches;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSString *shouldVisualizeTouchesValue = [NSProcessInfo.processInfo.environment objectForKey:@"VISUALIZE_TOUCHES"];
+        shouldVisualizeTouches = [[shouldVisualizeTouchesValue uppercaseString] isEqualToString:@"YES"];
+    });
+    
+    // Don't visualize touches unless explicitly told to.
+    if(!shouldVisualizeTouches) {
+        return;
+    }
+
+    for (UITouch *touch in event.allTouches) {
+        switch (touch.phase) {
+            case UITouchPhaseBegan:
+                [self.coordinator touchStarted:touch];
+                break;
+                
+            case UITouchPhaseMoved:
+                [self.coordinator touchMoved:touch];
+                break;
+                              
+            case UITouchPhaseCancelled:
+            case UITouchPhaseEnded:
+                [self.coordinator touchEnded:touch];
+                break;
+
+            default:
+                break;
+        }
+    }
+}
+
+@end
+

--- a/Visualizer/KIFTouchVisualizerView.h
+++ b/Visualizer/KIFTouchVisualizerView.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+
+@interface KIFTouchVisualizerView : UIView
+
+- (nonnull instancetype)initWithCenter:(CGPoint)center;
+
+@end
+

--- a/Visualizer/KIFTouchVisualizerView.m
+++ b/Visualizer/KIFTouchVisualizerView.m
@@ -1,0 +1,21 @@
+#import "KIFTouchVisualizerView.h"
+
+static CGFloat KIFVisualizerCircleViewDiameter = 40.0;
+
+@interface KIFTouchVisualizerView()
+@end
+
+@implementation KIFTouchVisualizerView
+
+- (instancetype)initWithCenter:(CGPoint)center
+{
+    CGFloat radius = KIFVisualizerCircleViewDiameter / 2.0;
+    self = [super initWithFrame:CGRectMake(center.x - radius, center.y - radius, KIFVisualizerCircleViewDiameter, KIFVisualizerCircleViewDiameter)];
+    self.backgroundColor = [[UIColor alloc] initWithRed:175.0/255.0 green:82.0/255.0 blue:222.0/255.0 alpha:0.5];
+    self.layer.borderWidth = 3.0;
+    self.layer.borderColor = [[[UIColor alloc] initWithRed:175.0/255.0 green:82.0/255.0 blue:222.0/255.0 alpha:0.9] CGColor];
+    self.layer.cornerRadius = radius;
+    return self;
+}
+
+@end

--- a/Visualizer/KIFTouchVisualizerViewCoordinator.h
+++ b/Visualizer/KIFTouchVisualizerViewCoordinator.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@interface KIFTouchVisualizerViewCoordinator : NSObject
+
+// The view that the coordinator is managing with the touches.
+- (nonnull instancetype)initWithView:(nonnull UIView *)view NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)init NS_UNAVAILABLE;
+
+- (void)touchStarted:(nonnull UITouch *)touch;
+- (void)touchMoved:(nonnull UITouch *)touch;
+- (void)touchEnded:(nonnull UITouch *)touch;
+
+@end

--- a/Visualizer/KIFTouchVisualizerViewCoordinator.m
+++ b/Visualizer/KIFTouchVisualizerViewCoordinator.m
@@ -1,0 +1,59 @@
+#import "KIFTouchVisualizerViewCoordinator.h"
+#import "KIFTouchVisualizerView.h"
+
+static const CGFloat KIFTouchAnimationDuration = 0.75;
+
+@interface KIFTouchVisualizerViewCoordinator ()
+
+@property (weak, nonatomic, readonly) UIView *view;
+@property (strong, nonatomic, readonly) NSMutableDictionary<NSNumber *, KIFTouchVisualizerView *> *touchToView;
+
+@end
+
+@implementation KIFTouchVisualizerViewCoordinator
+
+- (instancetype)initWithView:(UIWindow *)view
+{
+    self = [super init];
+    
+    _view = view;
+    _touchToView = [NSMutableDictionary dictionary];
+    
+    return self;
+}
+
+- (void)touchStarted:(nonnull UITouch *)touch
+{
+    KIFTouchVisualizerView *touchView = [[KIFTouchVisualizerView alloc] initWithCenter:[touch locationInView:self.view]];
+    [self.view addSubview:touchView];
+    self.touchToView[@(touch.hash)] = touchView;
+}
+
+- (void)touchMoved:(nonnull UITouch *)touch
+{
+    KIFTouchVisualizerView *oldView = self.touchToView[@(touch.hash)];
+    self.touchToView[@(touch.hash)] = [[KIFTouchVisualizerView alloc] initWithCenter:[touch locationInView:self.view]];
+    [self.view addSubview:self.touchToView[@(touch.hash)]];
+    [UIView animateWithDuration:KIFTouchAnimationDuration delay:0 options:UIViewAnimationOptionCurveLinear animations:^{
+        oldView.transform = CGAffineTransformScale(oldView.transform, 0.001, 0.001);
+    } completion:^(BOOL finished) {
+        if(finished) {
+            [oldView removeFromSuperview];
+        }
+    }];
+}
+
+- (void)touchEnded:(nonnull UITouch *)touch
+{
+    [UIView animateWithDuration:KIFTouchAnimationDuration animations:^{
+        self.touchToView[@(touch.hash)].transform = CGAffineTransformScale(self.touchToView[@(touch.hash)].transform, 2, 2);
+        self.touchToView[@(touch.hash)].alpha = 0.0;
+    } completion:^(BOOL finished) {
+        if(finished) {
+            [self.touchToView[@(touch.hash)] removeFromSuperview];
+            self.touchToView[@(touch.hash)] = nil;
+        }
+    }];
+}
+
+@end


### PR DESCRIPTION
Adds a touch visualizer to see where touches are being sent to. Currently it has a default look and feel. We can have a configuration object that can get set if we feel in the future we want customizability over the visualization of touches.

This is an explicit opt-in feature similar to printing the view hierarchy.