### PR TITLE
Fix Issue #1181 - `dismissPopover` does not work on iOS 14

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -960,8 +960,12 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
     if (!window) {
         [self failWithError:[NSError KIFErrorWithFormat:@"Failed to find any dimming views in the application"] stopTest:YES];
     }
-    UIView *dimmingView = [[window subviewsWithClassNamePrefix:@"UIDimmingView"] lastObject];
-    [dimmingView tapAtPoint:CGPointMake(50.0f, 50.0f)];
+    UIView *touchView = [[window subviewsWithClassNamePrefix:@"UIDimmingView"] lastObject];
+    
+    if (!touchView) {
+        touchView = [[window subviewsWithClassNamePrefix:@"_UITouchFallbackView"] lastObject];
+    }
+    [touchView tapAtPoint:CGPointMake(50.0f, 50.0f)];
     KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, tapDelay, false);
 }
 


### PR DESCRIPTION
`UIDimmingView` looks to be replaced with `_UITouchFallbackView` in iOS 14. This PR allows us to fallback to `_UITouchFallbackView` when `UIDImmingView` isn't found.