### PR TITLE
Exclude KIFEventVisualizer from printing hierarchy

### DIFF
--- a/Additions/UIView-Debugging.m
+++ b/Additions/UIView-Debugging.m
@@ -6,6 +6,7 @@
 //
 
 #import "UIView-Debugging.h"
+#import "KIFEventVisualizer.h"
 
 @implementation UIView (Debugging)
 
@@ -16,6 +17,11 @@
     } else {
         //more than one window, also print some information about each window
         for (UIWindow* window in windows) {
+            // ignore the event visualizer window
+            // We don't want to create the visualizer by calling `sharedVisualizer` so check to see if it's there first.
+            if([KIFEventVisualizer isVisualizerCreated] && [KIFEventVisualizer sharedVisualizer].window == window) {
+                continue;
+            }
             printf("Window level %f", window.windowLevel);
             if(window.isKeyWindow) printf(" (key window)");
             printf("\n");

--- a/Visualizer/KIFEventVisualizer.h
+++ b/Visualizer/KIFEventVisualizer.h
@@ -2,8 +2,10 @@
 
 @interface KIFEventVisualizer : NSObject
 
++ (BOOL)isVisualizerCreated;
 + (nonnull instancetype)sharedVisualizer;
 
+@property (strong, nonatomic, readonly, nonnull) UIWindow *window;
 - (void)visualizeEvent:(nonnull UIEvent *)event;
 
 // Unavailable.

--- a/Visualizer/KIFEventVisualizer.m
+++ b/Visualizer/KIFEventVisualizer.m
@@ -5,14 +5,32 @@
 #import "KIFEventVisualizer.h"
 #import "KIFTouchVisualizerViewCoordinator.h"
 
+static BOOL __isKIFVisualizerCreated = NO;
+
+@interface KIFEventVisualizerWindow : UIWindow
+@end
+
+@implementation KIFEventVisualizerWindow
+
+- (UIWindowLevel)windowLevel
+{
+    return 100000099;
+}
+
+@end
+
 @interface KIFEventVisualizer()
 
 @property (strong, nonatomic, readonly) KIFTouchVisualizerViewCoordinator *coordinator;
-@property (strong, nonatomic, readonly) UIWindow *window;
 
 @end
 
 @implementation KIFEventVisualizer
+
++ (BOOL)isVisualizerCreated
+{
+    return __isKIFVisualizerCreated;
+}
 
 + (instancetype)sharedVisualizer
 {
@@ -20,6 +38,7 @@
     static KIFEventVisualizer *sharedVisualizer = nil;
     dispatch_once(&onceToken, ^{
         sharedVisualizer = [[KIFEventVisualizer alloc] initPrivate];
+        __isKIFVisualizerCreated = YES;
     });
     
     return sharedVisualizer;
@@ -29,9 +48,8 @@
 {
     self = [super init];
     
-    _window = [[UIWindow alloc] init];
+    _window = [[KIFEventVisualizerWindow alloc] init];
     _window.userInteractionEnabled = NO;
-    _window.windowLevel = UIWindowLevelAlert + 1;
     _window.hidden = NO;
     _window.backgroundColor = UIColor.clearColor;
     _coordinator = [[KIFTouchVisualizerViewCoordinator alloc] initWithView:_window];


### PR DESCRIPTION
Also add event visualizer to be above input views.

Input views are at 1000001 and if you set a window level higher than 1000000 it will still max out at `1000000`. So override the window level to always return higher than that.

Made it higher than `1000002` just incase there are other windows