### PR TITLE
Fix pull to refresh displacement to not go outside of the touchable view and drag straight down.

### DIFF
--- a/Classes/KIFUITestActor.m
+++ b/Classes/KIFUITestActor.m
@@ -1164,8 +1164,9 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
     // Can handle only the touchable space.
     CGRect elementFrame = [viewToSwipe convertRect:viewToSwipe.bounds toView:[UIApplication sharedApplication].keyWindow.rootViewController.view];
     CGPoint swipeStart = CGPointCenteredInRect(elementFrame);
-    CGPoint swipeDisplacement = CGPointMake(CGRectGetMidX(elementFrame), CGRectGetMaxY(elementFrame));
-
+    // make the displacement go just slightly under where the view ends.
+    CGPoint swipeDisplacement = CGPointMake(0, CGRectGetMaxY(viewToSwipe.bounds) - swipeStart.y - (CGRectGetMaxY(viewToSwipe.bounds) * 0.05));
+    
     [viewToSwipe dragFromPoint:swipeStart displacement:swipeDisplacement steps:kNumberOfPointsInSwipePath];
 }
 


### PR DESCRIPTION
Before the pul to refresh mechanism went diagonal and would go far off screen because we were using the views MaxY as a displacement rather than the difference between the start of the swipe and the end of the view.