### PR TITLE
Have the KIF visualizer not become first responder in the responder chain

### DIFF
--- a/Visualizer/KIFEventVisualizer.m
+++ b/Visualizer/KIFEventVisualizer.m
@@ -17,6 +17,11 @@ static BOOL __isKIFVisualizerCreated = NO;
     return 100000099;
 }
 
+- (BOOL)becomeFirstResponder
+{
+    return NO;
+}
+
 @end
 
 @interface KIFEventVisualizer()


### PR DESCRIPTION
This fixes an issue in the responder chain where textfields would sometimes not become the first responder if the window was not present