### PR TITLE
Wait for keyboard input tasks to finish before continuing typing

### DIFF
--- a/Sources/KIF/Classes/KIFTypist.m
+++ b/Sources/KIF/Classes/KIFTypist.m
@@ -13,10 +13,15 @@
 #import "CGGeometry-KIFAdditions.h"
 #import "UIAccessibilityElement-KIFAdditions.h"
 
+@interface UIKeyboardTaskQueue: NSObject
+- (void)waitUntilAllTasksAreFinished;
+@end
+
 @interface UIKeyboardImpl : NSObject
 + (UIKeyboardImpl *)sharedInstance;
 - (void)addInputString:(NSString *)string;
 - (void)deleteFromInput;
+@property(readonly, nonatomic) UIKeyboardTaskQueue *taskQueue;
 @property(getter=isInHardwareKeyboardMode) BOOL inHardwareKeyboardMode;
 @property(retain) UIResponder<UIKeyInput> * delegate;
 @end
@@ -89,6 +94,7 @@ static NSTimeInterval keystrokeDelay = 0.01f;
         [[UIKeyboardImpl sharedInstance] addInputString:characterString];
     }
     
+    [[[UIKeyboardImpl sharedInstance] taskQueue] waitUntilAllTasksAreFinished];
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, keystrokeDelay, false);
     return YES;
 }

--- a/Sources/KIF/Classes/KIFTypist.m
+++ b/Sources/KIF/Classes/KIFTypist.m
@@ -26,7 +26,7 @@
 @property(retain) UIResponder<UIKeyInput> * delegate;
 @end
 
-static NSTimeInterval keystrokeDelay = 0.01f;
+static NSTimeInterval keystrokeDelay = 0.001f;
 
 @interface KIFTypist()
 @property (nonatomic, assign) BOOL keyboardHidden;


### PR DESCRIPTION
Making sure that the keyboard "flushes" on each keystroke to account for slower devices/simulators that may take longer to run or if a device is doing a lot of other processes and is slowing down the machine the keystroke will still get processed before "moving on" with the test, possibly causing errors within the test.