### PR TITLE
Readd xcattachment screenshots

### DIFF
--- a/Sources/KIF/Additions/XCTestCase-KIFAdditions.m
+++ b/Sources/KIF/Additions/XCTestCase-KIFAdditions.m
@@ -81,10 +81,6 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
 {
     [[UIApplication sharedApplication] writeScreenshotForLine:[exception.userInfo[@"LineNumberKey"] unsignedIntegerValue] inFile:exception.userInfo[@"FilenameKey"] description:nil error:NULL];
 
-    // Per #1084, something broke in this code starting with Xcode 10.
-    // For now, this will be disabled and can be fixed later by anyone
-    // that relies on this functionality.
-#if defined(__IPHONE_11_0) && !defined(__IPHONE_12_0)
     if (@available(iOS 11.0, *)) {
         //semaphore will make sure the screenshot will be captured. otherwise it will crash on getting screenshot!
         dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
@@ -97,9 +93,7 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
         }];
         
         dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-    }
-#endif
-    
+    }   
 }
 
 - (void)printViewHierarchyIfOptedIn;


### PR DESCRIPTION
We only officially support Xcode 11+ so we can update re-add xcattachment screenshots everywhere