### PR TITLE
Add first responder timeout

### DIFF
--- a/Sources/KIF/Classes/KIFTestActor.h
+++ b/Sources/KIF/Classes/KIFTestActor.h
@@ -174,6 +174,19 @@ typedef void (^KIFTestCompletionBlock)(KIFTestStepResult result, NSError *error)
 + (void)setStepDelay:(NSTimeInterval)newStepDelay;
 
 /*!
+ @method firstResponderTimeout
+ @abstract The maximum amount of time that we wait on views becoming first responders.
+ @discussion To change the default value of the first responder timeout property, call +firstResponderTimeout: with a different value.
+ */
++ (NSTimeInterval)firstResponderTimeout;
+
+/*!
+ @method setStepDelay:
+ @abstract Sets the amount of time that execution blocks use before trying again to met desired conditions.
+ */
++ (void)setFirstResponderTimeout:(NSTimeInterval)firstResponderTimeout;
+
+/*!
  @abstract Fails the test.
  @discussion Mostly useful for test debugging or as a placeholder when building new tests.
  */

--- a/Sources/KIF/Classes/KIFTestActor.m
+++ b/Sources/KIF/Classes/KIFTestActor.m
@@ -136,6 +136,8 @@ static NSTimeInterval KIFTestStepDefaultAnimationStabilizationTimeout = 0.5;
 static NSTimeInterval KIFTestStepDefaultMainThreadDispatchStabilizationTimeout = 0.5;
 static NSTimeInterval KIFTestStepDefaultTimeout = 10.0;
 static NSTimeInterval KIFTestStepDelay = 0.1;
+static NSTimeInterval KIFTestStepFirstResponderTimeout = 0.5;
+
 
 + (NSTimeInterval)defaultAnimationWaitingTimeout
 {
@@ -187,6 +189,17 @@ static NSTimeInterval KIFTestStepDelay = 0.1;
 {
     KIFTestStepDelay = newStepDelay;
 }
+
++ (NSTimeInterval)firstResponderTimeout;
+{
+    return KIFTestStepFirstResponderTimeout;
+}
+
++ (void)setFirstResponderTimeout:(NSTimeInterval)firstResponderTimeout;
+{
+    KIFTestStepFirstResponderTimeout = firstResponderTimeout;
+}
+
 
 #pragma mark Generic tests
 

--- a/Sources/KIF/Classes/KIFUITestActor.m
+++ b/Sources/KIF/Classes/KIFUITestActor.m
@@ -349,7 +349,7 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
 
         KIFTestWaitCondition(![view canBecomeFirstResponder] || ![view isProbablyTappable] || [view isDescendantOfFirstResponder] || accessibilityElementDisappeared, error, @"Failed to make the view into the first responder: %@", view);
         return KIFTestStepResultSuccess;
-    } timeout:0.5];
+    } timeout:[KIFTestActor firstResponderTimeout]];
 }
 
 - (void)tapScreenAtPoint:(CGPoint)screenPoint


### PR DESCRIPTION
Have a settable timeout to allow users to increase it to account for slower devices/simulators that may take longer to run or if a device is doing a lot of other processes and is slowing down the machine.