### PR TITLE
Make UIView.isNavigationItemView public

### DIFF
--- a/Sources/KIF/Additions/UIView-KIFAdditions.h
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.h
@@ -121,4 +121,11 @@ typedef CGPoint KIFDisplacement;
  */
 @property (nonatomic, readonly) UIWindow *windowOrIdentityWindow;
 
+/*!
+ @method isNavigationItemView:
+ @abstract Determines if the view is a navigation item view.
+ @note Useful for when traversing a view hierarchy to retrieve navigation items.
+ */
+- (BOOL)isNavigationItemView;
+
 @end


### PR DESCRIPTION
Hey there, first of all, very nice work with `KIF`!! It has been a pleasure to work with it.

In case you agree and like it, this would be a tiny contribution to make `UIView.isNavigationItemView()` public / declared on `UIView-KIFAdditions.h`.

The idea is that with that users don't have to re-write the same logic that is done on `isNavigationItemView()` to find navigation items based on internal system classes, which can come in handy when not able to find navigation items via their `accessibilityLabel` - e.g. when back button is title-less.

Does it make sense, or do you see any problems with making it public?

Thanks!