### PR TITLE
Fixed table view scroll behavior

### DIFF
--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -297,7 +297,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
             {
                 [scrollView setContentOffset:scrollContentOffset];
             } else {
-                [tableView scrollRectToVisible:initialPosition animated:NO];
+                [tableView setContentOffset:initialPosition.origin];
             }
             CFRunLoopRunInMode(UIApplicationCurrentRunMode, delay, false);
         } else if ([self isKindOfClass:[UICollectionView class]]) {


### PR DESCRIPTION
Old implementation does not restore the initial offset in the table view after a view search