### PR TITLE
Removed setIsTap to avoid unrecognized selector sent to instance issue on iOS 15

### DIFF
--- a/Sources/KIF/Additions/UITouch-KIFAdditions.m
+++ b/Sources/KIF/Additions/UITouch-KIFAdditions.m
@@ -68,7 +68,6 @@ typedef struct {
     [self setPhase:UITouchPhaseBegan];
     
     if ([self respondsToSelector:@selector(_setIsFirstTouchForView:)]) {
-        [self setIsTap:YES];
         [self _setIsFirstTouchForView:YES];
     } else {
         [self _setIsTapToClick:YES];


### PR DESCRIPTION
Hi there!

This is a fix for this issue I've created [here](https://github.com/kif-framework/KIF/issues/1233)