### PR TITLE
Audit timeouts and use executionBlockTimeout as default timeout

### DIFF
--- a/Sources/KIF/Classes/KIFUIViewTestActor.m
+++ b/Sources/KIF/Classes/KIFUIViewTestActor.m
@@ -604,7 +604,7 @@ NSString *const inputFieldTestString = @"Testing";
         [self tryRunningBlock:^KIFTestStepResult(NSError **error) {
             KIFTestWaitCondition([self.actor tryFindingAccessibilityElement:&foundElement view:&foundView withElementMatchingPredicate:self.predicate tappable:tappable error:error], error, @"Waiting on view matching %@", self.predicate.kifPredicateDescription);
             return KIFTestStepResultSuccess;
-        } complete:nil timeout:1.0 error:&error];
+        } complete:nil timeout:self.executionBlockTimeout error:&error];
     }
 
     if (foundView && foundElement) {


### PR DESCRIPTION
This audits the use of timeouts and uses the consistent `executionBlockTimeout` where magic numbers are specified. This makes it consistent that when a timeout is specified it is used throughout KIF.