### PR TITLE
Fix #1240 waitForView on label in tableview not working

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
           - { xcode_version: '10.3', simulator: 'name=iPhone 8,OS=12.4' }
           - { xcode_version: '11.7', simulator: 'name=iPhone SE (2nd generation),OS=13.7' }
           - { xcode_version: '12.2', simulator: 'name=iPhone SE (2nd generation),OS=14.2' }
+          - { xcode_version: '13.0', simulator: 'name=iPad (5th generation),OS=15.0' }
+
 
     steps:
     - name: Checkout Project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,6 @@ jobs:
           - { xcode_version: '10.3', simulator: 'name=iPhone 8,OS=12.4' }
           - { xcode_version: '11.7', simulator: 'name=iPhone SE (2nd generation),OS=13.7' }
           - { xcode_version: '12.2', simulator: 'name=iPhone SE (2nd generation),OS=14.2' }
-          - { xcode_version: '13.0', simulator: 'name=iPad (5th generation),OS=15.0' }
-
 
     steps:
     - name: Checkout Project
@@ -58,3 +56,40 @@ jobs:
     - name: Build & Test
       run: ./scripts/ci.sh "${{ matrix.run-config['simulator'] }}"
 
+  build_xcode13:
+    runs-on: macos-11
+    strategy:
+      matrix:
+        run-config:
+          - { xcode_version: '13.0', simulator: 'name=iPad Pro (12.9-inch) (5th generation),OS=15.0' }
+
+    steps:
+    - name: Checkout Project
+      uses: actions/checkout@v1
+
+    - name: Brew Update
+      run:  brew update
+
+    - name: Install Bundler
+      run: gem install bundler
+
+    - name: Install Core Utils
+      run: if [ -z "$(brew ls --versions coreutils)" ] ; then brew install coreutils ; fi
+
+    - name: Install XCPretty
+      run: gem install xcpretty --no-document --quiet
+
+    - name: Show Xcode versions
+      run: ls -al /Applications/Xcode*
+
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.run-config['xcode_version'] }}.app
+
+    - name: Current Xcode Selected
+      run: xcode-select -p
+
+    - name: List Simulators
+      run:  xcrun simctl list
+
+    - name: Build & Test
+      run: ./scripts/ci.sh "${{ matrix.run-config['simulator'] }}"

--- a/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -32,9 +32,15 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     while (element && ![element isKindOfClass:[UIView class]]) {
         // Sometimes accessibilityContainer will return a view that's too far up the view hierarchy
         // UIAccessibilityElement instances will sometimes respond to view, so try to use that and then fall back to accessibilityContainer
-        id view = [element respondsToSelector:@selector(view)] ? [(id)element view]
-        : [element respondsToSelector:@selector(tableViewCell)] ? [(id)element tableViewCell]
-        : nil;
+        id view = nil;
+        
+        if([element respondsToSelector:@selector(view)]) {
+            view = [(id)element view];
+        } else if([element respondsToSelector:@selector(tableViewCell)]) {
+            view = [(id)element tableViewCell];
+        } else if([element isKindOfClass:NSClassFromString(@"UIAccessibilityElementMockView")]) {
+            view = [element valueForKey:@"view"];
+        }
         
         if (view) {
             element = view;

--- a/Test Host/TableViewController.m
+++ b/Test Host/TableViewController.m
@@ -34,23 +34,19 @@
     return YES;
 }
 
-// Work around a bug on iOS9 that accessibility trait Selected doesn't get set
+// Work around a bug on iOS9+ that accessibility trait Selected doesn't get set
 - (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath;
 {
-    if ([[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] == NSOrderedSame) {
-        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-        [cell setAccessibilityTraits:cell.accessibilityTraits | UIAccessibilityTraitSelected];
-    }
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+    [cell setAccessibilityTraits:cell.accessibilityTraits | UIAccessibilityTraitSelected];
 
     return indexPath;
 }
 
 - (NSIndexPath *)tableView:(UITableView *)tableView willDeselectRowAtIndexPath:(NSIndexPath *)indexPath;
 {
-    if ([[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] == NSOrderedSame) {
-        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-        [cell setAccessibilityTraits:cell.accessibilityTraits ^ UIAccessibilityTraitSelected];
-    }
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+    [cell setAccessibilityTraits:cell.accessibilityTraits ^ UIAccessibilityTraitSelected];
     
     return indexPath;
 }


### PR DESCRIPTION
`UIAccessibilityElementMockView` does not respond to the selector `view` anymore, which causes the tableview to be returned when looking for a subview in the hierarchy.  

This checks the class name to see if it's a `UIAccessibilityElementMockView` then will get the view via `valueForKey:`

Fixes #1240 