### PR TITLE
Remove use of XCUI for taking screenshots

### DIFF
--- a/KIF.podspec
+++ b/KIF.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license                 = 'Apache 2.0'
   s.authors                 = 'Michael Thole', 'Eric Firestone', 'Jim Puls', 'Brian Nickel'
   s.source                  = { :git => "https://github.com/kif-framework/KIF.git", :tag => "v#{ s.version.to_s }" }
-  s.platform                = :ios, '9.0'
+  s.platform                = :ios, '10.0'
   s.frameworks              = 'CoreGraphics', 'QuartzCore', 'IOKit', 'WebKit', 'XCTest'
   s.default_subspec         = 'Core'
   s.requires_arc            = true

--- a/Sources/KIF/Additions/XCTestCase-KIFAdditions.m
+++ b/Sources/KIF/Additions/XCTestCase-KIFAdditions.m
@@ -86,14 +86,30 @@ static inline void Swizzle(Class c, SEL orig, SEL new)
         dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
         
         [XCTContext runActivityNamed:(@"screenshot") block:^(id<XCTActivity>  _Nonnull activity) {
-            XCUIScreenshot *screenShot = [[XCUIScreen mainScreen] screenshot];
-            XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenShot];
+            XCTAttachment *attachment = [XCTAttachment attachmentWithImage:[self _snapshotScreen]];
+            attachment.name = @"Screenshot";
             [activity addAttachment:(attachment)];
             dispatch_semaphore_signal(semaphore);
         }];
         
         dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
     }   
+}
+
+- (UIImage *)_snapshotScreen
+{
+    UIView *view = [[UIScreen mainScreen] snapshotViewAfterScreenUpdates:YES];
+    [view layoutIfNeeded];
+
+    CGRect bounds = view.bounds;
+    NSAssert1(CGRectGetWidth(bounds), @"Zero width for view %@", view);
+    NSAssert1(CGRectGetHeight(bounds), @"Zero height for view %@", view);
+
+    UIGraphicsImageRenderer *graphicsImageRenderer = [[UIGraphicsImageRenderer alloc] initWithSize:bounds.size];
+
+    return [graphicsImageRenderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        [view drawViewHierarchyInRect:bounds afterScreenUpdates:YES];
+    }];
 }
 
 - (void)printViewHierarchyIfOptedIn;


### PR DESCRIPTION
XCUI is more locked down with the latest release of Xcode 13 + iOS 15. with this latest release we cannot do certain actions from XCUI including screenshots. 

This changes our use XCUI to take screenshots on failures to manually snapshotting the main screen on failures.