### PR TITLE
Remove hasTapGestureRecognizer

### DIFF
--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -765,27 +765,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 // Is this view currently on screen?
 - (BOOL)isTappable;
 {
-    return ([self hasTapGestureRecognizer] ||
-            [self isTappableInRect:self.bounds]);
-}
-
-- (BOOL)hasTapGestureRecognizer
-{
-    __block BOOL hasTapGestureRecognizer = NO;
-    
-    [self.gestureRecognizers enumerateObjectsUsingBlock:^(id obj,
-                                                          NSUInteger idx,
-                                                          BOOL *stop) {
-        if ([obj isKindOfClass:[UITapGestureRecognizer class]]) {
-            hasTapGestureRecognizer = YES;
-            
-            if (stop != NULL) {
-                *stop = YES;
-            }
-        }
-    }];
-    
-    return hasTapGestureRecognizer;
+    return [self isTappableInRect:self.bounds];
 }
 
 - (BOOL)isTappableInRect:(CGRect)rect;


### PR DESCRIPTION
`isTappable` checks to see if a view is on screen or tappable by the user. If a view has a gesture recognizer it doesn't make it tappable if it's off screen or hidden by another view. 

This takes out that check as it doesn't accurately represent if a view is actually tappable.

This still passes the tests that were introduced when this check was added so there should be no regression in functionality.