### PR TITLE
Check that we have the same view after scrolling

### DIFF
--- a/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -219,6 +219,15 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
                 // Give the scroll view a small amount of time to perform the scroll.
                 CFTimeInterval delay = animationEnabled ? 0.3 : 0.05;
                 KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, delay, false);
+
+                // Because of cell reuse the first found view could be different after we scroll.
+                // Find the same element's view to ensure that after we have scrolled we get the same view back.
+                UIView *checkedView = [UIAccessibilityElement viewContainingAccessibilityElement:element];
+                // intentionally doing a memory address check vs a isEqual check because
+                // we want to ensure that the memory address hasn't changed after scroll.
+                if(view != checkedView) {
+                    view = checkedView;
+                }
             }
         }
         


### PR DESCRIPTION
The actual view can be changed due to cell reuse after scrolling. This change ensures that once we scroll we have the same view as before we did so the action being taken is correct