### PR TITLE
Add identifier to printing view hierarchy

### DIFF
--- a/Sources/KIF/Additions/UIView-Debugging.m
+++ b/Sources/KIF/Additions/UIView-Debugging.m
@@ -89,7 +89,9 @@
     NSString* identifier = self.accessibilityIdentifier;
     if(label != nil) {
         printf(", label: %s", label.UTF8String);
-    } else if(identifier != nil) {
+    } 
+    
+    if(identifier != nil) {
         printf(", identifier: %s", identifier.UTF8String);
     }
 }


### PR DESCRIPTION
Allows for better visibility when you are debugging the views. Folks can sometimes have a label and an identifier, however be looking up an identifier. This allows for better understanding of if that identifier is on screen.