### PR TITLE
Check full view when scrolling through Collectionview

### DIFF
--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -786,6 +786,12 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     if ([hitView isKindOfClass:[UIControl class]] && [self isDescendantOfView:hitView]) {
         return YES;
     }
+
+    // Similar to the above with UIControl's a view with a tap gesture may be forwarding
+    // on their taps to a subview.
+    if ([hitView hasTapGestureRecognizer] && [self isDescendantOfView:hitView]) {
+        return YES;
+    }
     
     // Button views in the nav bar (a private class derived from UINavigationItemView), do not return
     // themselves in a -hitTest:. Instead they return the nav bar.
@@ -794,6 +800,25 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     }
     
     return [hitView isDescendantOfView:self];
+}
+
+- (BOOL)hasTapGestureRecognizer
+{
+    __block BOOL hasTapGestureRecognizer = NO;
+
+    [self.gestureRecognizers enumerateObjectsUsingBlock:^(id obj,
+                                                          NSUInteger idx,
+                                                          BOOL *stop) {
+        if ([obj isKindOfClass:[UITapGestureRecognizer class]]) {
+            hasTapGestureRecognizer = YES;
+
+            if (stop != NULL) {
+                *stop = YES;
+            }
+        }
+    }];
+
+    return hasTapGestureRecognizer;
 }
 
 - (CGPoint)tappablePointInRect:(CGRect)rect;


### PR DESCRIPTION
This checks the full collectionview on each iteration of a cell, without scrolling, to ensure we don't miss an accessibility element that is on screen but is not in the cell.

**Why**
To look through a collection we iterate through the cells and look for the element in the cell. This is a good approximation for collectionviews as they can scroll horizontal or vertical so we can't assume to only scroll a single direction. However, our current implementation would only stop once the cell matched the accessibility attributes passed in. This would miss other elements on the screen like supplementary or decoration views that were on screen. This change instead does a non-scrolling lookup of the full view on each cell iteration to determine if the element is on screen.