### PR TITLE
Fix bug with table view elements that are matched but offscreen

### DIFF
--- a/Sources/KIF/Classes/KIFUITestActor.m
+++ b/Sources/KIF/Classes/KIFUITestActor.m
@@ -326,17 +326,7 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
 
         // If the element isn't immediately tappable, try checking if it is contained within scroll views that can be scrolled to make it tappable.
         if (isnan(tappablePointInElement.x)) {
-            UIView *container = view;
-
-            do {
-                if ([container isKindOfClass:UIScrollView.class]) {
-                    UIScrollView *containerScrollView = (UIScrollView *)container;
-                    CGRect rect = [view convertRect:view.frame toView:containerScrollView];
-                    [containerScrollView scrollRectToVisible:rect animated:NO];
-                }
-
-                container = container.superview;
-            } while (container != nil);
+            [self _scrollViewToTappablePointIfNeeded:view];
 
             tappablePointInElement = [self tappablePointInElement:element andView:view];
         }
@@ -423,6 +413,12 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
         KIFTestWaitCondition(view.isUserInteractionActuallyEnabled, error, @"View is not enabled for interaction: %@", view);
 
         CGPoint tappablePointInElement = [self tappablePointInElement:element andView:view];
+        // If the element isn't immediately tappable, try checking if it is contained within scroll views that can be scrolled to make it tappable.
+        if (isnan(tappablePointInElement.x)) {
+            [self _scrollViewToTappablePointIfNeeded:view];
+
+            tappablePointInElement = [self tappablePointInElement:element andView:view];
+        }
         
         // This is mostly redundant of the test in _accessibilityElementWithLabel:
         KIFTestWaitCondition(!isnan(tappablePointInElement.x), error, @"View is not tappable: %@", view);
@@ -1587,6 +1583,13 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
         KIFTestWaitCondition(view.isUserInteractionActuallyEnabled, error, @"View is not enabled for interaction: %@", view);
 
         CGPoint stepperPointToTap = [self tappablePointInElement:element andView:view];
+        
+        // If the element isn't immediately tappable, try checking if it is contained within scroll views that can be scrolled to make it tappable.
+        if (isnan(stepperPointToTap.x)) {
+            [self _scrollViewToTappablePointIfNeeded:view];
+
+            stepperPointToTap = [self tappablePointInElement:element andView:view];
+        }
 
         switch (stepperDirection)
         {
@@ -1597,6 +1600,7 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
                 stepperPointToTap.x -= CGRectGetWidth(view.frame) / 4;
                 break;
         }
+        
 
         // This is mostly redundant of the test in _accessibilityElementWithLabel:
         KIFTestWaitCondition(!isnan(stepperPointToTap.x), error, @"View is not tappable: %@", view);
@@ -1647,6 +1651,21 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
         case KIFSwipeDirectionDown:
             return CGPointMake(kKIFMinorSwipeDisplacement, UIScreen.mainScreen.majorSwipeDisplacement);
     }
+}
+
+- (void)_scrollViewToTappablePointIfNeeded:(UIView *)view
+{
+    UIView *container = view;
+
+    do {
+        if ([container isKindOfClass:UIScrollView.class]) {
+            UIScrollView *containerScrollView = (UIScrollView *)container;
+            CGRect rect = [view convertRect:view.frame toView:containerScrollView];
+            [containerScrollView scrollRectToVisible:rect animated:NO];
+        }
+
+        container = container.superview;
+    } while (container != nil);
 }
 
 + (BOOL)testActorAnimationsEnabled;

--- a/Sources/KIF/Classes/KIFUITestActor.m
+++ b/Sources/KIF/Classes/KIFUITestActor.m
@@ -323,6 +323,23 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
         KIFTestWaitCondition(view.isUserInteractionActuallyEnabled, error, @"View is not enabled for interaction: %@", view);
 
         CGPoint tappablePointInElement = [self tappablePointInElement:element andView:view];
+
+        // If the element isn't immediately tappable, try checking if it is contained within scroll views that can be scrolled to make it tappable.
+        if (isnan(tappablePointInElement.x)) {
+            UIView *container = view;
+
+            do {
+                if ([container isKindOfClass:UIScrollView.class]) {
+                    UIScrollView *containerScrollView = (UIScrollView *)container;
+                    CGRect rect = [view convertRect:view.frame toView:containerScrollView];
+                    [containerScrollView scrollRectToVisible:rect animated:NO];
+                }
+
+                container = container.superview;
+            } while (container != nil);
+
+            tappablePointInElement = [self tappablePointInElement:element andView:view];
+        }
         
         // This is mostly redundant of the test in _accessibilityElementWithLabel:
         KIFTestWaitCondition(!isnan(tappablePointInElement.x), error, @"View is not tappable: %@", view);


### PR DESCRIPTION
This re-introduces https://github.com/kif-framework/KIF/pull/1070 where elements off screen in a scrollview need to be scrolled before they are tapped.

In iOS 15 some elements in a tableview are within the scrollview though not on screen, specifically table view footers (not to be confused with table view section footers). This causes an element to be matched and "found" but untappable.  Adding this will make sure that we scroll to the element before tapping it