### PR TITLE
Fix deployment target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "KIF",
     platforms: [
-        .iOS(.v8)
+        .iOS(.v9)
     ],
     products: [
         .library(


### PR DESCRIPTION
Tiny PR to remove a warning that get generated by consumers of KIF via SPM, which warns out that the supported deployment targets start from >= 9.0.

<img width="514" alt="Screen Shot 2022-03-28 at 17 42 05" src="https://user-images.githubusercontent.com/18131704/160435880-0134df0c-6616-43fa-8d88-ca1f3d6cd204.png">
