### PR TITLE
fix(iOS): fix iOS 15.5 `NSPredicate` error.

### DIFF
--- a/KIF Tests/CompositionTests_ViewTestActor.m
+++ b/KIF Tests/CompositionTests_ViewTestActor.m
@@ -23,13 +23,17 @@
 {
     UIAccessibilityElement *element = [viewTester usingLabel:label].element;
     if ((element.accessibilityTraits & UIAccessibilityTraitSelected) == UIAccessibilityTraitNone) {
-        [[[viewTester usingLabel:label] usingPredicate:[NSPredicate predicateWithFormat:@"(accessibilityTraits & %i) == %i", UIAccessibilityTraitSelected, UIAccessibilityTraitNone]] tap];
+        [[[viewTester usingLabel:label] usingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+            return ([evaluatedObject accessibilityTraits] & UIAccessibilityTraitSelected) == UIAccessibilityTraitNone;
+        }]] tap];
     }
 }
 
 - (void)tapViewWithAccessibilityHint:(NSString *)hint
 {
-    [[viewTester usingPredicate:[NSPredicate predicateWithFormat:@"accessibilityHint like %@", hint]] tap];
+    [[viewTester usingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return [[evaluatedObject accessibilityHint] containsString:hint];
+    }]] tap];
 }
 
 @end

--- a/Sources/KIF/Classes/KIFUITestActor-ConditionalTests.m
+++ b/Sources/KIF/Classes/KIFUITestActor-ConditionalTests.m
@@ -60,7 +60,9 @@
         [self failWithError:[NSError KIFErrorWithFormat:@"Running test on platform that does not support accessibilityIdentifier"] stopTest:YES];
     }
     
-    return [self tryFindingAccessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", identifier] tappable:mustBeTappable error:error];
+    return [self tryFindingAccessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return [[evaluatedObject accessibilityIdentifier] isEqualToString:identifier];
+    }] tappable:mustBeTappable error:error];
 }
 
 - (BOOL)tryFindingAccessibilityElement:(out UIAccessibilityElement * __autoreleasing *)element view:(out UIView * __autoreleasing *)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error

--- a/Sources/KIF/Classes/KIFUITestActor.m
+++ b/Sources/KIF/Classes/KIFUITestActor.m
@@ -128,13 +128,17 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
         [self failWithError:[NSError KIFErrorWithFormat:@"Running test on platform that does not support accessibilityIdentifier"] stopTest:YES];
     }
 
-    [self waitForAccessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", identifier] tappable:mustBeTappable];
+    [self waitForAccessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return [[evaluatedObject accessibilityIdentifier] isEqualToString:identifier];
+    }] tappable:mustBeTappable];
 }
 
 - (void)waitForAccessibilityElement:(UIAccessibilityElement *__autoreleasing *)element view:(out UIView *__autoreleasing *)view withIdentifier:(NSString *)identifier fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable
 {
     [self runBlock:^KIFTestStepResult(NSError **error) {
-        return [UIAccessibilityElement accessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", identifier] fromRootView:fromView tappable:mustBeTappable error:error] ? KIFTestStepResultSuccess : KIFTestStepResultWait;
+        return [UIAccessibilityElement accessibilityElement:element view:view withElementMatchingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+            return [[evaluatedObject accessibilityIdentifier] isEqualToString:identifier];
+        }] fromRootView:fromView tappable:mustBeTappable error:error] ? KIFTestStepResultSuccess : KIFTestStepResultWait;
     }];
 }
 

--- a/Sources/KIF/Classes/KIFUIViewTestActor.m
+++ b/Sources/KIF/Classes/KIFUIViewTestActor.m
@@ -107,7 +107,9 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (instancetype)usingTraits:(UIAccessibilityTraits)accessibilityTraits;
 {
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"(accessibilityTraits & %@) == %@", @(accessibilityTraits), @(accessibilityTraits)];
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return ([evaluatedObject accessibilityTraits] & accessibilityTraits) == accessibilityTraits;
+    }];
     predicate.kifPredicateDescription = [NSString stringWithFormat:@"Accessibility traits including \"%@\"", [UIAccessibilityElement stringFromAccessibilityTraits:accessibilityTraits]];
     
     return [self usingPredicate:predicate];
@@ -115,7 +117,9 @@ NSString *const inputFieldTestString = @"Testing";
 
 - (instancetype)usingAbsenceOfTraits:(UIAccessibilityTraits)accessibilityTraits;
 {
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"(accessibilityTraits & %@) != %@", @(accessibilityTraits), @(accessibilityTraits)];
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return ([evaluatedObject accessibilityTraits] & accessibilityTraits) != accessibilityTraits;
+    }];
     predicate.kifPredicateDescription = [NSString stringWithFormat:@"Accessibility traits excluding \"%@\"", [UIAccessibilityElement stringFromAccessibilityTraits:accessibilityTraits]];
 
     return [self usingPredicate:predicate];

--- a/Sources/KIF/IdentifierTests/KIFUITestActor-IdentifierTests.m
+++ b/Sources/KIF/IdentifierTests/KIFUITestActor-IdentifierTests.m
@@ -37,7 +37,9 @@
 
 - (void)waitForAbsenceOfViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", accessibilityIdentifier];
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return [[evaluatedObject accessibilityIdentifier] isEqualToString:accessibilityIdentifier];
+    }];
     [self waitForAbsenceOfViewWithElementMatchingPredicate:predicate];
 }
 
@@ -189,9 +191,11 @@
     }];
 }
 
-- (BOOL) tryFindingViewWithAccessibilityIdentifier:(NSString *) accessibilityIdentifier
+- (BOOL) tryFindingViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"accessibilityIdentifier = %@", accessibilityIdentifier];
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return [[evaluatedObject accessibilityIdentifier] isEqualToString:accessibilityIdentifier];
+    }];
     return [UIAccessibilityElement accessibilityElement:nil view:nil withElementMatchingPredicate:predicate tappable:NO error:nil];
 }
 


### PR DESCRIPTION
This PR resolves #1260.

I'm not using KIF, but I fixed a similar issue in wix/Detox ([here](https://github.com/wix/Detox/pull/3420)) and one of our issues regarding this error was mentioned by one of your users ([here](https://github.com/kif-framework/KIF/issues/1260)).

I was able to reproduce the error mentioned in #1260 with your tests suite, using Xcode 13.4 and iOS 15.5 Simulator.

After applying the same solution I used for Detox (replacing predicate-with-format with predicate-with-block), all tests were passed.