### PR TITLE
Fix ios 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,43 @@ jobs:
     - name: Validate podspec
       run: pod lib lint
 
+  build_xcode14:
+    runs-on: macos-12
+    strategy:
+      matrix:
+        run-config:
+          - { xcode_version: '14.1', simulator: 'name=iPad Pro (12.9-inch) (5th generation),OS=16.1' }
+    steps: &build_steps
+    - name: Checkout Project
+      uses: actions/checkout@v1
+
+    - name: Brew Update
+      run:  brew update
+
+    - name: Install Bundler
+      run: gem install bundler
+
+    - name: Install Core Utils
+      run: if [ -z "$(brew ls --versions coreutils)" ] ; then brew install coreutils ; fi
+
+    - name: Install XCPretty
+      run: gem install xcpretty --no-document --quiet
+
+    - name: Show Xcode versions
+      run: ls -al /Applications/Xcode*
+
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.run-config['xcode_version'] }}.app
+
+    - name: Current Xcode Selected
+      run: xcode-select -p
+
+    - name: List Simulators
+      run:  xcrun simctl list
+
+    - name: Build & Test
+      run: ./scripts/ci.sh "${{ matrix.run-config['simulator'] }}"
+
   build:
     runs-on: macos-11
     strategy:
@@ -23,38 +60,7 @@ jobs:
           - { xcode_version: '11.7', simulator: 'name=iPhone SE (2nd generation),OS=13.7' }
           - { xcode_version: '12.5.1', simulator: 'name=iPhone SE (2nd generation),OS=14.5' }
           - { xcode_version: '13.0', simulator: 'name=iPad Pro (12.9-inch) (5th generation),OS=15.0' }
-
-
-    steps:
-    - name: Checkout Project
-      uses: actions/checkout@v1
-
-    - name: Brew Update
-      run:  brew update
-
-    - name: Install Bundler
-      run: gem install bundler
-
-    - name: Install Core Utils
-      run: if [ -z "$(brew ls --versions coreutils)" ] ; then brew install coreutils ; fi
-
-    - name: Install XCPretty
-      run: gem install xcpretty --no-document --quiet
-
-    - name: Show Xcode versions
-      run: ls -al /Applications/Xcode*
-
-    - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.run-config['xcode_version'] }}.app
-
-    - name: Current Xcode Selected
-      run: xcode-select -p
-
-    - name: List Simulators
-      run:  xcrun simctl list
-
-    - name: Build & Test
-      run: ./scripts/ci.sh "${{ matrix.run-config['simulator'] }}"
+    steps: *build_steps
 
   build_xcode10:
     runs-on: macos-10.15
@@ -63,34 +69,4 @@ jobs:
         run-config:
           - { xcode_version: '10.3', simulator: 'name=iPad (5th generation),OS=12.4' }
           - { xcode_version: '10.3', simulator: 'name=iPhone 8,OS=12.4' }
-
-    steps:
-    - name: Checkout Project
-      uses: actions/checkout@v1
-
-    - name: Brew Update
-      run:  brew update
-
-    - name: Install Bundler
-      run: gem install bundler
-
-    - name: Install Core Utils
-      run: if [ -z "$(brew ls --versions coreutils)" ] ; then brew install coreutils ; fi
-
-    - name: Install XCPretty
-      run: gem install xcpretty --no-document --quiet
-
-    - name: Show Xcode versions
-      run: ls -al /Applications/Xcode*
-
-    - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.run-config['xcode_version'] }}.app
-
-    - name: Current Xcode Selected
-      run: xcode-select -p
-
-    - name: List Simulators
-      run:  xcrun simctl list
-
-    - name: Build & Test
-      run: ./scripts/ci.sh "${{ matrix.run-config['simulator'] }}"
+    steps: *build_steps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         run-config:
           - { xcode_version: '14.1', simulator: 'name=iPad Pro (12.9-inch) (5th generation),OS=16.1' }
-          - { xcode_version: '14.1', simulator: 'name=iPhone SE (3nd generation),OS=16.1' }
+          - { xcode_version: '14.1', simulator: 'name=iPhone SE (2nd generation),OS=16.1' }
     steps:
     - name: Checkout Project
       uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         run-config:
           - { xcode_version: '14.1', simulator: 'name=iPad Pro (12.9-inch) (5th generation),OS=16.1' }
+          - { xcode_version: '14.1', simulator: 'name=iPhone SE (3nd generation),OS=16.1' }
     steps:
     - name: Checkout Project
       uses: actions/checkout@v1
@@ -57,47 +58,8 @@ jobs:
     strategy:
       matrix:
         run-config:
-          - { xcode_version: '11.7', simulator: 'name=iPhone SE (2nd generation),OS=13.7' }
-          - { xcode_version: '12.5.1', simulator: 'name=iPhone SE (2nd generation),OS=14.5' }
+          - { xcode_version: '13.0', simulator: 'name=iPhone SE (2nd generation),OS=15.0' }
           - { xcode_version: '13.0', simulator: 'name=iPad Pro (12.9-inch) (5th generation),OS=15.0' }
-    steps:
-    - name: Checkout Project
-      uses: actions/checkout@v1
-
-    - name: Brew Update
-      run:  brew update
-
-    - name: Install Bundler
-      run: gem install bundler
-
-    - name: Install Core Utils
-      run: if [ -z "$(brew ls --versions coreutils)" ] ; then brew install coreutils ; fi
-
-    - name: Install XCPretty
-      run: gem install xcpretty --no-document --quiet
-
-    - name: Show Xcode versions
-      run: ls -al /Applications/Xcode*
-
-    - name: Select Xcode
-      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.run-config['xcode_version'] }}.app
-
-    - name: Current Xcode Selected
-      run: xcode-select -p
-
-    - name: List Simulators
-      run:  xcrun simctl list
-
-    - name: Build & Test
-      run: ./scripts/ci.sh "${{ matrix.run-config['simulator'] }}"
-
-  build_xcode10:
-    runs-on: macos-10.15
-    strategy:
-      matrix:
-        run-config:
-          - { xcode_version: '10.3', simulator: 'name=iPad (5th generation),OS=12.4' }
-          - { xcode_version: '10.3', simulator: 'name=iPhone 8,OS=12.4' }
     steps:
     - name: Checkout Project
       uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         run-config:
           - { xcode_version: '14.1', simulator: 'name=iPad Pro (12.9-inch) (5th generation),OS=16.1' }
-    steps: &build_steps
+    steps:
     - name: Checkout Project
       uses: actions/checkout@v1
 
@@ -60,7 +60,36 @@ jobs:
           - { xcode_version: '11.7', simulator: 'name=iPhone SE (2nd generation),OS=13.7' }
           - { xcode_version: '12.5.1', simulator: 'name=iPhone SE (2nd generation),OS=14.5' }
           - { xcode_version: '13.0', simulator: 'name=iPad Pro (12.9-inch) (5th generation),OS=15.0' }
-    steps: *build_steps
+    steps:
+    - name: Checkout Project
+      uses: actions/checkout@v1
+
+    - name: Brew Update
+      run:  brew update
+
+    - name: Install Bundler
+      run: gem install bundler
+
+    - name: Install Core Utils
+      run: if [ -z "$(brew ls --versions coreutils)" ] ; then brew install coreutils ; fi
+
+    - name: Install XCPretty
+      run: gem install xcpretty --no-document --quiet
+
+    - name: Show Xcode versions
+      run: ls -al /Applications/Xcode*
+
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.run-config['xcode_version'] }}.app
+
+    - name: Current Xcode Selected
+      run: xcode-select -p
+
+    - name: List Simulators
+      run:  xcrun simctl list
+
+    - name: Build & Test
+      run: ./scripts/ci.sh "${{ matrix.run-config['simulator'] }}"
 
   build_xcode10:
     runs-on: macos-10.15
@@ -69,4 +98,33 @@ jobs:
         run-config:
           - { xcode_version: '10.3', simulator: 'name=iPad (5th generation),OS=12.4' }
           - { xcode_version: '10.3', simulator: 'name=iPhone 8,OS=12.4' }
-    steps: *build_steps
+    steps:
+    - name: Checkout Project
+      uses: actions/checkout@v1
+
+    - name: Brew Update
+      run:  brew update
+
+    - name: Install Bundler
+      run: gem install bundler
+
+    - name: Install Core Utils
+      run: if [ -z "$(brew ls --versions coreutils)" ] ; then brew install coreutils ; fi
+
+    - name: Install XCPretty
+      run: gem install xcpretty --no-document --quiet
+
+    - name: Show Xcode versions
+      run: ls -al /Applications/Xcode*
+
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.run-config['xcode_version'] }}.app
+
+    - name: Current Xcode Selected
+      run: xcode-select -p
+
+    - name: List Simulators
+      run:  xcrun simctl list
+
+    - name: Build & Test
+      run: ./scripts/ci.sh "${{ matrix.run-config['simulator'] }}"

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -166,10 +166,8 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
         UIAccessibilityElement *element = [view accessibilityElementMatchingBlock:matchBlock];
         
         if (!element) {
-            if([view isKindOfClass:NSClassFromString(@"_UIRemoteKeyboardPlaceholderView")]) {
-                UIView* fallbackView = [view valueForKey:@"_fallbackView"];
-                element = [fallbackView accessibilityElementMatchingBlock:matchBlock];
-            }
+            UIView* fallbackView = [self tryGetiOS16KeyboardFallbackViewFromParentView:view];
+            element = [fallbackView accessibilityElementMatchingBlock:matchBlock];
         }
         
         if (!element) {
@@ -383,11 +381,9 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
             [result addObject:view];
         }
         
-        if([NSStringFromClass([view class]) isEqualToString:@"_UIRemoteKeyboardPlaceholderView"]) {
-            UIView* fallbackView = [view valueForKey:@"_fallbackView"];
-            if ([NSStringFromClass([fallbackView class]) hasPrefix:prefix]) {
-                [result addObject:fallbackView];
-            }
+        UIView* fallbackView = [self tryGetiOS16KeyboardFallbackViewFromParentView:view];
+        if ([NSStringFromClass([fallbackView class]) hasPrefix:prefix]) {
+            [result addObject:fallbackView];
         }
     }
     
@@ -396,8 +392,8 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
         NSArray *matchingSubviews = [view subviewsWithClassNamePrefix:prefix];
         [result addObjectsFromArray:matchingSubviews];
         
-        if([NSStringFromClass([view class]) isEqualToString:@"_UIRemoteKeyboardPlaceholderView"]) {
-            UIView* fallbackView = [view valueForKey:@"_fallbackView"];
+        UIView* fallbackView = [self tryGetiOS16KeyboardFallbackViewFromParentView:view];
+        if (fallbackView) {
             NSArray *matchingSubviews = [fallbackView subviewsWithClassNamePrefix:prefix];
             [result addObjectsFromArray:matchingSubviews];
         }
@@ -431,8 +427,8 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                 break;
             }
             
-            if([NSStringFromClass(klass) isEqualToString:@"_UIRemoteKeyboardPlaceholderView"]) {
-                UIView* fallbackView = [view valueForKey:@"_fallbackView"];
+            UIView* fallbackView = [self tryGetiOS16KeyboardFallbackViewFromParentView:view];
+            if (fallbackView) {
                 Class klass = [fallbackView class];
                 while (klass) {
                     if ([NSStringFromClass(klass) hasPrefix:prefix]) {
@@ -1057,5 +1053,13 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     }
 }
 
+-(UIView*)tryGetiOS16KeyboardFallbackViewFromParentView:(UIView*) parentView {
+    if([parentView isKindOfClass:NSClassFromString(@"_UIRemoteKeyboardPlaceholderView")]) {
+        UIView* fallbackView = [parentView valueForKey:@"_fallbackView"];
+        return fallbackView;
+    }
+    
+    return nil;
+}
 
 @end

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -164,6 +164,14 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     // UITableViewCell is such an offender.
     for (UIView *view in [self.subviews reverseObjectEnumerator]) {
         UIAccessibilityElement *element = [view accessibilityElementMatchingBlock:matchBlock];
+        
+        if (!element) {
+            if([view isKindOfClass:NSClassFromString(@"_UIRemoteKeyboardPlaceholderView")]) {
+                UIView* fallbackView = [view valueForKey:@"_fallbackView"];
+                element = [fallbackView accessibilityElementMatchingBlock:matchBlock];
+            }
+        }
+        
         if (!element) {
             continue;
         }
@@ -374,12 +382,25 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
         if ([NSStringFromClass([view class]) hasPrefix:prefix]) {
             [result addObject:view];
         }
+        
+        if([NSStringFromClass([view class]) isEqualToString:@"_UIRemoteKeyboardPlaceholderView"]) {
+            UIView* fallbackView = [view valueForKey:@"_fallbackView"];
+            if ([NSStringFromClass([fallbackView class]) hasPrefix:prefix]) {
+                [result addObject:fallbackView];
+            }
+        }
     }
     
     // Now traverse the subviews of the subviews, adding matches.
     for (UIView *view in self.subviews) {
         NSArray *matchingSubviews = [view subviewsWithClassNamePrefix:prefix];
         [result addObjectsFromArray:matchingSubviews];
+        
+        if([NSStringFromClass([view class]) isEqualToString:@"_UIRemoteKeyboardPlaceholderView"]) {
+            UIView* fallbackView = [view valueForKey:@"_fallbackView"];
+            NSArray *matchingSubviews = [fallbackView subviewsWithClassNamePrefix:prefix];
+            [result addObjectsFromArray:matchingSubviews];
+        }
     }
 
     return result;
@@ -403,14 +424,30 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     // First traverse the next level of subviews, adding matches
     for (UIView *view in self.subviews) {
         Class klass = [view class];
+
         while (klass) {
             if ([NSStringFromClass(klass) hasPrefix:prefix]) {
                 [result addObject:view];
                 break;
             }
             
+            if([NSStringFromClass(klass) isEqualToString:@"_UIRemoteKeyboardPlaceholderView"]) {
+                UIView* fallbackView = [view valueForKey:@"_fallbackView"];
+                Class klass = [fallbackView class];
+                while (klass) {
+                    if ([NSStringFromClass(klass) hasPrefix:prefix]) {
+                        [result addObject:fallbackView];
+                        break;
+                    }
+                    
+                    klass = [klass superclass];
+                }
+            }
+            
             klass = [klass superclass];
         }
+        
+        
     }
     
     // Now traverse the subviews of the subviews, adding matches

--- a/Sources/KIF/Classes/KIFSystemTestActor.m
+++ b/Sources/KIF/Classes/KIFSystemTestActor.m
@@ -58,7 +58,7 @@
 
 - (void)simulateDeviceRotationToOrientation:(UIDeviceOrientation)orientation
 {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 16000
+#ifdef __IPHONE_16_0
     if (@available(iOS 16.0, *)) {
         NSSet<UIScene *> *scenes = [[UIApplication sharedApplication] connectedScenes];
         UIWindowScene* windowScene;
@@ -103,7 +103,7 @@
     } else {
 #endif
         [[UIDevice currentDevice] setValue:@(orientation) forKey:@"orientation"];
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 16000
+#ifdef __IPHONE_16_0
     }
 #endif
 }

--- a/Sources/KIF/Classes/KIFSystemTestActor.m
+++ b/Sources/KIF/Classes/KIFSystemTestActor.m
@@ -58,7 +58,50 @@
 
 - (void)simulateDeviceRotationToOrientation:(UIDeviceOrientation)orientation
 {
-    [[UIDevice currentDevice] setValue:@(orientation) forKey:@"orientation"];
+    if (@available(iOS 16.0, *)) {
+        NSSet<UIScene *> *scenes = [[UIApplication sharedApplication] connectedScenes];
+        UIWindowScene* windowScene;
+        for (UIScene* scene in scenes) {
+            if([scene isKindOfClass:[UIWindowScene class]]) {
+                windowScene = (UIWindowScene*) scene;
+                break;
+            }
+        }
+        
+        if (windowScene) {
+            UIInterfaceOrientationMask orientationMask;
+            switch (orientation) {
+                case UIDeviceOrientationUnknown:
+                    orientationMask = UIInterfaceOrientationMaskAll;
+                    break;
+                case UIDeviceOrientationPortrait:
+                    orientationMask = UIInterfaceOrientationMaskPortrait;
+                    break;
+                case UIDeviceOrientationPortraitUpsideDown:
+                    orientationMask = UIInterfaceOrientationMaskPortraitUpsideDown;
+                    break;
+                case UIDeviceOrientationLandscapeLeft:
+                    orientationMask = UIInterfaceOrientationMaskLandscapeLeft;
+                    break;
+                case UIDeviceOrientationLandscapeRight:
+                    orientationMask = UIInterfaceOrientationMaskLandscapeRight;
+                    break;
+                case UIDeviceOrientationFaceUp:
+                    orientationMask = UIInterfaceOrientationMaskAll;
+                    break;
+                case UIDeviceOrientationFaceDown:
+                    orientationMask = UIInterfaceOrientationMaskAll;
+                    break;
+            }
+            
+            UIWindowSceneGeometryPreferencesIOS* preferences = [[UIWindowSceneGeometryPreferencesIOS alloc]initWithInterfaceOrientations:orientationMask];
+            [windowScene requestGeometryUpdateWithPreferences:preferences errorHandler:^(NSError * _Nonnull error) {
+                NSLog(@"error: %@", error);
+            }];
+        }
+    } else {
+        [[UIDevice currentDevice] setValue:@(orientation) forKey:@"orientation"];
+    }
 }
 
 

--- a/Sources/KIF/Classes/KIFSystemTestActor.m
+++ b/Sources/KIF/Classes/KIFSystemTestActor.m
@@ -96,7 +96,7 @@
             
             UIWindowSceneGeometryPreferencesIOS* preferences = [[UIWindowSceneGeometryPreferencesIOS alloc]initWithInterfaceOrientations:orientationMask];
             [windowScene requestGeometryUpdateWithPreferences:preferences errorHandler:^(NSError * _Nonnull error) {
-                NSLog(@"error: %@", error);
+                [self failWithError:[NSError KIFErrorWithUnderlyingError:error format:@"Could not rotate the screen"] stopTest:YES];
             }];
         }
     } else {

--- a/Sources/KIF/Classes/KIFSystemTestActor.m
+++ b/Sources/KIF/Classes/KIFSystemTestActor.m
@@ -58,6 +58,7 @@
 
 - (void)simulateDeviceRotationToOrientation:(UIDeviceOrientation)orientation
 {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 16000
     if (@available(iOS 16.0, *)) {
         NSSet<UIScene *> *scenes = [[UIApplication sharedApplication] connectedScenes];
         UIWindowScene* windowScene;
@@ -100,8 +101,11 @@
             }];
         }
     } else {
+#endif
         [[UIDevice currentDevice] setValue:@(orientation) forKey:@"orientation"];
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 16000
     }
+#endif
 }
 
 

--- a/Sources/KIF/Classes/KIFUITestActor.m
+++ b/Sources/KIF/Classes/KIFUITestActor.m
@@ -835,10 +835,15 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
         // Find all pickers in view. Either UIDatePickerView or UIPickerView
         NSArray *datePickerViews = [[[UIApplication sharedApplication] datePickerWindow] subviewsWithClassNameOrSuperClassNamePrefix:@"UIPickerView"];
         NSArray *pickerViews = [[[UIApplication sharedApplication] pickerViewWindow] subviewsWithClassNameOrSuperClassNamePrefix:@"UIPickerView"];
+        
+        NSArray *iOS16DatePickerViews = [[[UIApplication sharedApplication] datePickerWindow] subviewsWithClassNameOrSuperClassNamePrefix:@"UIDatePicker"];
 
         // Grab one picker and assume it is datePicker and then test our hypothesis later!
         pickerView = [datePickerViews lastObject];
         if ([pickerView respondsToSelector:@selector(setDate:animated:)] || [pickerView isKindOfClass:NSClassFromString(@"_UIDatePickerView")]) {
+            pickerType = KIFUIDatePicker;
+        }else if([[iOS16DatePickerViews lastObject] respondsToSelector:@selector(setDate:animated:)]) {
+            pickerView = [[iOS16DatePickerViews lastObject] valueForKey:@"_pickerView"];
             pickerType = KIFUIDatePicker;
         } else {
             pickerView = [pickerViews lastObject];


### PR DESCRIPTION
Fix for iOS 16. 

- Adding the pickerView into the inputView of a textfield is handle different than the other iOS versions. On iOS 16, it is part of the property `_fallbackView` from `_UIRemoteKeyboardPlaceholderView`, but it is not part of the UI hierarchy (I don't know why). So in the parts that checked for elements, I added another validation for the `_UIRemoteKeyboardPlaceholderView`
- UIDatePicker is not a subclass of UIPickerView. And it has doesn't has an UIPickerView as subview. The hierarchy is UIDatePicker -> _UIDatePickerView ->  ... -> UIPickerColumnView ... But it has an _UIPickerView property that works if used.
- `[[UIDevice currentDevice] setValue:@(orientation) forKey:@"orientation"]` doesn't work anymore. We need to use `requestGeometryUpdateWithPreferences` from UIWindowScene.

I'm not 100% familiar with the code, so I may be missing some context, so please let me know if there is anything I should fix.