### PR TITLE
Fix occasional CI failures on the iPhone simulator

### DIFF
--- a/KIF Tests/AccessibilityIdentifierTests.m
+++ b/KIF Tests/AccessibilityIdentifierTests.m
@@ -17,6 +17,7 @@
 
 - (void)beforeEach
 {
+    UIPasteboard.generalPasteboard.string = nil;
     [tester tapViewWithAccessibilityLabel:@"Tapping"];
 }
 

--- a/KIF Tests/AccessibilityIdentifierTests_ViewTestActor.m
+++ b/KIF Tests/AccessibilityIdentifierTests_ViewTestActor.m
@@ -17,6 +17,7 @@
 
 - (void)beforeEach
 {
+    UIPasteboard.generalPasteboard.string = nil;
     [[viewTester usingLabel:@"Tapping"] tap];
 }
 

--- a/KIF Tests/LongPressTests.m
+++ b/KIF Tests/LongPressTests.m
@@ -15,6 +15,7 @@
 
 - (void)beforeEach
 {
+    UIPasteboard.generalPasteboard.string = nil;
     [tester tapViewWithAccessibilityLabel:@"Tapping"];
 }
 

--- a/KIF Tests/LongPressTests_ViewTestActor.m
+++ b/KIF Tests/LongPressTests_ViewTestActor.m
@@ -16,6 +16,7 @@
 
 - (void)beforeEach
 {
+    UIPasteboard.generalPasteboard.string = nil;
     [[viewTester usingLabel:@"Tapping"] tap];
 }
 

--- a/KIF Tests/TypingTests.m
+++ b/KIF Tests/TypingTests.m
@@ -16,6 +16,7 @@
 
 - (void)beforeEach
 {
+    UIPasteboard.generalPasteboard.string = nil;
     [tester tapViewWithAccessibilityLabel:@"Tapping"];
 }
 

--- a/KIF Tests/TypingTests_ViewTestActor.m
+++ b/KIF Tests/TypingTests_ViewTestActor.m
@@ -17,6 +17,7 @@
 
 - (void)beforeEach
 {
+    UIPasteboard.generalPasteboard.string = nil;
     [[viewTester usingLabel:@"Tapping"] tap];
 }
 


### PR DESCRIPTION
In iOS, the edit menu is designed to display two commands and a "Forward" or "Back" page button when there are more than two commands available.

If the pasteboard already contains a string, the edit menu will show "Paste" and "Select" commands. The "Select All" command can be accessed on the next page.

Executing a case that taps the "Cut" command will result in the failure of all subsequent cases that require tapping the "Select All" command.

One solution to this is to clear the pasteboard before the "Select All" cases.