### PR TITLE
PullToRefreshTests can exit before the greetingView is finished animating out

### DIFF
--- a/KIF Tests/AccessibilityIdentifierPullToRefreshTests.m
+++ b/KIF Tests/AccessibilityIdentifierPullToRefreshTests.m
@@ -37,4 +37,9 @@
 	[tester waitForAbsenceOfViewWithAccessibilityLabel:@"Bingo!"];
 }
 
+- (void)afterEach
+{
+    [tester waitForAnimationsToFinish];
+}
+
 @end


### PR DESCRIPTION
I was able to reproduce this issue one time on my local machine. There is a small time window where Bingo is no longer present on the screen, but the greeting view has not yet completely finished animating out. When this happens, the tap for the subsequent test `AccessibilityIdentifierTests testClearingAndEnteringTextIntoViewWithAccessibilityLabel` will fail, because it won't have successfully opened the `Tapping` tests screen.