### PR TITLE
iOS 17 - fix black screenshots after using a keyboard

### DIFF
--- a/Sources/KIF/Additions/UIApplication-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIApplication-KIFAdditions.m
@@ -188,8 +188,10 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
 			continue;
 		}
 
-        if (window == keyboardWindow) {
-            continue;
+        if (@available(iOS 17.0, *)) {
+            if (window == keyboardWindow) {
+                continue;
+            }
         }
 
         if ([window respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {

--- a/Sources/KIF/Additions/UIApplication-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIApplication-KIFAdditions.m
@@ -178,13 +178,19 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
         }
         return NO;
     }
-    
+
+    UIWindow *keyboardWindow = [self keyboardWindow];
+
     UIGraphicsBeginImageContextWithOptions([[windows objectAtIndex:0] bounds].size, YES, 0);
     for (UIWindow *window in windows) {
 		//avoid https://github.com/kif-framework/KIF/issues/679
 		if (window.hidden) {
 			continue;
 		}
+
+        if (window == keyboardWindow) {
+            continue;
+        }
 
         if ([window respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {
             [window drawViewHierarchyInRect:window.bounds afterScreenUpdates:YES];


### PR DESCRIPTION
On iOS 17 Simulator, we cannot render a keyboard window and get a fully black screenshot image.
As a workaround, this PR suppress rendering the keyboard window

## conditions for reproduce

* call `writeScreenshotForLine` after using a keyboard
    * the keyboard window renders black pixels even when the keyboard is hidden on iOS 17 Simulator

iOS 16.4 Simulator does not reproduce the issue, for both builds on Xcode 14.3.1 or Xcode 15.0. It seems to depend on the runtime simulator version.

## expected result

Either the keyboard window is not rendered, or, it renders the keyboard image over the app window as same as displayed on the Simulator

## actual result

a fully black screenshot image will be rendered