### PR TITLE
Introducing tryFindingViewInFrame() to avoid scroll

### DIFF
--- a/KIF Tests/AccessibilityIdentifierTests.m
+++ b/KIF Tests/AccessibilityIdentifierTests.m
@@ -96,6 +96,27 @@
     }
 }
 
+- (void)testTryFindingOutOfFrameViewWithAccessibilityIdentifier
+{
+    if (![tester tryFindingViewWithAccessibilityIdentifier:@"outOfFrameView"])
+    {
+        [tester fail];
+    }
+}
+
+- (void)testTryFindingViewInFrameWithAccessibilityIdentifier
+{
+    if (![tester tryFindingViewInFrameWithAccessibilityIdentifier:@"idGreeting"])
+    {
+        [tester fail];
+    }
+
+    if ([tester tryFindingViewInFrameWithAccessibilityIdentifier:@"outOfFrameView"])
+    {
+        [tester fail];
+    }
+}
+
 - (void) testTappingStepperIncrement
 {
     UILabel *uiLabel = (UILabel *)[tester waitForViewWithAccessibilityIdentifier:@"tapViewController.stepperValue"];

--- a/KIF Tests/AccessibilityIdentifierTests_ViewTestActor.m
+++ b/KIF Tests/AccessibilityIdentifierTests_ViewTestActor.m
@@ -94,6 +94,28 @@
     }
 }
 
+- (void)testTryFindingTappableViewInFrameWithAccessibilityIdentifier
+{
+    if (![[[viewTester usingCurrentFrame] usingIdentifier:@"idGreeting"] tryFindingTappableView])
+    {
+        [tester fail];
+    }
+
+    if ([[[viewTester usingCurrentFrame] usingIdentifier:@"outOfFrameView"] tryFindingTappableView])
+    {
+        [tester fail];
+    }
+}
+
+- (void)testTryFindingOccludedTappableViewInFrameWithAccessibilityIdentifier
+{
+
+    if ([[[viewTester usingCurrentFrame] usingIdentifier:@"occludedView"] tryFindingTappableView])
+    {
+        [tester fail];
+    }
+}
+
 - (void)afterEach
 {
     [[[viewTester usingLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];

--- a/KIF Tests/AccessibilityIdentifierTests_ViewTestActor.m
+++ b/KIF Tests/AccessibilityIdentifierTests_ViewTestActor.m
@@ -73,6 +73,27 @@
     [[viewTester usingIdentifier:@"idGreeting"] clearAndEnterText:@"Yo"];
 }
 
+- (void)testTryFindingOutOfFrameViewWithAccessibilityIdentifier
+{
+    if (![[viewTester usingIdentifier:@"outOfFrameView"] tryFindingView])
+    {
+        [tester fail];
+    }
+}
+
+- (void)testTryFindingViewInFrameWithAccessibilityIdentifier
+{
+    if (![[[viewTester usingCurrentFrame] usingIdentifier:@"idGreeting"] tryFindingView])
+    {
+        [tester fail];
+    }
+
+    if ([[[viewTester usingCurrentFrame] usingIdentifier:@"outOfFrameView"] tryFindingView])
+    {
+        [tester fail];
+    }
+}
+
 - (void)afterEach
 {
     [[[viewTester usingLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];

--- a/KIF Tests/TappingTests_ViewTestActor.m
+++ b/KIF Tests/TappingTests_ViewTestActor.m
@@ -80,5 +80,18 @@
     [[viewTester usingLabel:@"A\nB\nC\n\n"] tap];
 }
 
+//TODO: simone scionti - this test will be modified to simulate the breaking circumstances
+- (void)testIsSearchBarTappableUsingPlaceholderLabel
+{
+    if ([[[viewTester usingCurrentFrame] usingLabel:@"out of frame"] tryFindingTappableView])
+    {
+        [tester fail];
+    }
+
+    if (![[[viewTester usingCurrentFrame] usingLabel:@"Search"] tryFindingTappableView])
+    {
+        [tester fail];
+    }
+}
 
 @end

--- a/KIF Tests/TappingTests_ViewTestActor.m
+++ b/KIF Tests/TappingTests_ViewTestActor.m
@@ -80,18 +80,5 @@
     [[viewTester usingLabel:@"A\nB\nC\n\n"] tap];
 }
 
-//TODO: simone scionti - this test will be modified to simulate the breaking circumstances
-- (void)testIsSearchBarTappableUsingPlaceholderLabel
-{
-    if ([[[viewTester usingCurrentFrame] usingLabel:@"out of frame"] tryFindingTappableView])
-    {
-        [tester fail];
-    }
-
-    if (![[[viewTester usingCurrentFrame] usingLabel:@"Search"] tryFindingTappableView])
-    {
-        [tester fail];
-    }
-}
 
 @end

--- a/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.h
+++ b/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.h
@@ -93,6 +93,17 @@
 + (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error;
 
 /*!
+ @abstract Finds an accessibility element and view where the element passes the predicate, optionally passing a tappability test.
+ @param foundElement The found accessibility element or @c nil if the method returns @c NO.  Can be @c NULL.
+ @param foundView The first matching view for @c foundElement as determined by the accessibility API or @c nil if the view is hidden or fails the tappability test. Can be @c NULL.
+ @param predicate The predicate to test the accessibility element on.
+ @param error A reference to an error object to be populated when no matching element or view is found.  Can be @c NULL.
+ @param disableScroll Disable scropp while looking for the view
+ @result @c YES if the element and view were found.  Otherwise @c NO.
+ */
++ (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error disableScroll:(BOOL)scrollDisabled;
+
+/*!
  @abstract Finds and attempts to make visible a view for a given accessibility element.
  @discussion If the element is found, off screen, and is inside a scroll view, this method will attempt to programmatically scroll the view onto the screen before performing any logic as to if the view is tappable.
  
@@ -102,6 +113,18 @@
  @return The first matching view as determined by the accessibility API or nil if the view is hidden or fails the tappability test.
  */
 + (UIView *)viewContainingAccessibilityElement:(UIAccessibilityElement *)element tappable:(BOOL)mustBeTappable error:(NSError **)error;
+
+/*!
+ @abstract Finds and attempts to make visible a view for a given accessibility element.
+ @discussion If the element is found, off screen, and is inside a scroll view, this method will attempt to programmatically scroll the view onto the screen before performing any logic as to if the view is tappable.
+
+ @param element The accessibility element.
+ @param mustBeTappable If @c YES, a tappability test will be performed.
+ @param error A reference to an error object to be populated when no element is found.  Can be @c NULL.
+ @param disableScroll Disable scropp while looking for the view
+ @return The first matching view as determined by the accessibility API or nil if the view is hidden or fails the tappability test.
+ */
++ (UIView *)viewContainingAccessibilityElement:(UIAccessibilityElement *)element tappable:(BOOL)mustBeTappable error:(NSError **)error disableScroll:(BOOL)scrollDisabled;
 
 /*!
  @abstract Returns a human readable string of UIAccessiblityTrait names, derived from UIAccessibilityConstants.h.

--- a/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.h
+++ b/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.h
@@ -98,7 +98,7 @@
  @param foundView The first matching view for @c foundElement as determined by the accessibility API or @c nil if the view is hidden or fails the tappability test. Can be @c NULL.
  @param predicate The predicate to test the accessibility element on.
  @param error A reference to an error object to be populated when no matching element or view is found.  Can be @c NULL.
- @param disableScroll Disable scroll performing the search only in the current visible frame.
+ @param scrollDisabled Disable scroll performing the search only in the current visible frame.
  @result @c YES if the element and view were found.  Otherwise @c NO.
  */
 + (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error disableScroll:(BOOL)scrollDisabled;
@@ -121,7 +121,7 @@
  @param element The accessibility element.
  @param mustBeTappable If @c YES, a tappability test will be performed.
  @param error A reference to an error object to be populated when no element is found.  Can be @c NULL.
- @param disableScroll Disable scroll performing the search only in the current visible frame.
+ @param scrollDisabled Disable scroll performing the search only in the current visible frame.
  @return The first matching view as determined by the accessibility API or nil if the view is hidden or fails the tappability test.
  */
 + (UIView *)viewContainingAccessibilityElement:(UIAccessibilityElement *)element tappable:(BOOL)mustBeTappable error:(NSError **)error disableScroll:(BOOL)scrollDisabled;

--- a/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.h
+++ b/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.h
@@ -98,7 +98,7 @@
  @param foundView The first matching view for @c foundElement as determined by the accessibility API or @c nil if the view is hidden or fails the tappability test. Can be @c NULL.
  @param predicate The predicate to test the accessibility element on.
  @param error A reference to an error object to be populated when no matching element or view is found.  Can be @c NULL.
- @param disableScroll Disable scropp while looking for the view
+ @param disableScroll Disable scroll performing the search only in the current visible frame.
  @result @c YES if the element and view were found.  Otherwise @c NO.
  */
 + (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error disableScroll:(BOOL)scrollDisabled;
@@ -121,7 +121,7 @@
  @param element The accessibility element.
  @param mustBeTappable If @c YES, a tappability test will be performed.
  @param error A reference to an error object to be populated when no element is found.  Can be @c NULL.
- @param disableScroll Disable scropp while looking for the view
+ @param disableScroll Disable scroll performing the search only in the current visible frame.
  @return The first matching view as determined by the accessibility API or nil if the view is hidden or fails the tappability test.
  */
 + (UIView *)viewContainingAccessibilityElement:(UIAccessibilityElement *)element tappable:(BOOL)mustBeTappable error:(NSError **)error disableScroll:(BOOL)scrollDisabled;

--- a/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -99,7 +99,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 
     if (!element) {
         if (error) {
-            *error = [self errorForFailingPredicate:predicate];
+            *error = [self errorForFailingPredicate:predicate disableScroll:scrollDisabled];
         }
         return NO;
     }
@@ -276,9 +276,9 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     return view;
 }
 
-+ (NSError *)errorForFailingPredicate:(NSPredicate*)failingPredicate;
++ (NSError *)errorForFailingPredicate:(NSPredicate*)failingPredicate disableScroll:(BOOL) scrollDisabled;
 {
-    NSPredicate *closestMatchingPredicate = [self findClosestMatchingPredicate:failingPredicate];
+    NSPredicate *closestMatchingPredicate = [self findClosestMatchingPredicate:failingPredicate disableScroll:scrollDisabled];
     if (closestMatchingPredicate) {
         return [NSError KIFErrorWithFormat:@"Found element with %@ but not %@", \
                 closestMatchingPredicate.kifPredicateDescription, \
@@ -287,7 +287,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     return [NSError KIFErrorWithFormat:@"Could not find element with %@", failingPredicate.kifPredicateDescription];
 }
 
-+ (NSPredicate *)findClosestMatchingPredicate:(NSPredicate *)aPredicate;
++ (NSPredicate *)findClosestMatchingPredicate:(NSPredicate *)aPredicate disableScroll:(BOOL) scrollDisabled;
 {
     if (!aPredicate) {
         return nil;
@@ -295,7 +295,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     
     UIAccessibilityElement *match = [[UIApplication sharedApplication] accessibilityElementMatchingBlock:^BOOL (UIAccessibilityElement *element) {
         return [aPredicate evaluateWithObject:element];
-    }];
+    } disableScroll:scrollDisabled];
     if (match) {
         return aPredicate;
     }
@@ -313,7 +313,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
             if (predicateMinusOneCondition) {
                 UIAccessibilityElement *match = [[UIApplication sharedApplication] accessibilityElementMatchingBlock:^BOOL (UIAccessibilityElement *element) {
                     return [predicateMinusOneCondition evaluateWithObject:element];
-                }];
+                } disableScroll:scrollDisabled];
                 if (match) {
                     return predicateMinusOneCondition;
                 }

--- a/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -59,12 +59,17 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 
 + (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError **)error
 {
+    return [self accessibilityElement:foundElement view:foundView withLabel:label value:value traits:traits fromRootView:fromView tappable:mustBeTappable error:error disableScroll:NO];
+}
+
++ (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withLabel:(NSString *)label value:(NSString *)value traits:(UIAccessibilityTraits)traits fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError **)error disableScroll:(BOOL)scrollDisabled
+{
     UIAccessibilityElement *element = [self accessibilityElementWithLabel:label value:value traits:traits fromRootView:fromView error:error];
     if (!element) {
         return NO;
     }
     
-    UIView *view = [self viewContainingAccessibilityElement:element tappable:mustBeTappable error:error];
+    UIView *view = [self viewContainingAccessibilityElement:element tappable:mustBeTappable error:error disableScroll:scrollDisabled];
     if (!view) {
         return NO;
     }
@@ -83,10 +88,15 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 
 + (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error;
 {
+    return [self accessibilityElement:foundElement view:foundView withElementMatchingPredicate:predicate tappable:mustBeTappable error:error disableScroll:NO];
+}
+
++ (BOOL)accessibilityElement:(out UIAccessibilityElement **)foundElement view:(out UIView **)foundView withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error disableScroll:(BOOL)scrollDisabled;
+{
     UIAccessibilityElement *element = [[UIApplication sharedApplication] accessibilityElementMatchingBlock:^BOOL(UIAccessibilityElement *element) {
         return [predicate evaluateWithObject:element];
-    }];
-    
+    } disableScroll: scrollDisabled];
+
     if (!element) {
         if (error) {
             *error = [self errorForFailingPredicate:predicate];
@@ -94,7 +104,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
         return NO;
     }
     
-    UIView *view = [UIAccessibilityElement viewContainingAccessibilityElement:element tappable:mustBeTappable error:error];
+    UIView *view = [UIAccessibilityElement viewContainingAccessibilityElement:element tappable:mustBeTappable error:error disableScroll:scrollDisabled];
     if (!view) {
         return NO;
     }
@@ -106,10 +116,15 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 
 + (BOOL)accessibilityElement:(out UIAccessibilityElement *__autoreleasing *)foundElement view:(out UIView *__autoreleasing *)foundView withElementMatchingPredicate:(NSPredicate *)predicate fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError *__autoreleasing *)error
 {
+    return [self accessibilityElement: foundElement view:foundView withElementMatchingPredicate:predicate tappable:mustBeTappable error:error disableScroll:NO];
+}
+
++ (BOOL)accessibilityElement:(out UIAccessibilityElement *__autoreleasing *)foundElement view:(out UIView *__autoreleasing *)foundView withElementMatchingPredicate:(NSPredicate *)predicate fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError *__autoreleasing *)error disableScroll:(BOOL)scrollDisabled
+{
     UIAccessibilityElement *element = [fromView accessibilityElementMatchingBlock:^BOOL(UIAccessibilityElement *element) {
         return [predicate evaluateWithObject:element];
-    }];
-    
+    } disableScroll:scrollDisabled];
+
     if (!element) {
         if (error) {
             *error = [NSError KIFErrorWithFormat:@"Could not find view matching: %@", predicate];
@@ -117,7 +132,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
         return NO;
     }
     
-    UIView *view = [UIAccessibilityElement viewContainingAccessibilityElement:element tappable:mustBeTappable error:error];
+    UIView *view = [UIAccessibilityElement viewContainingAccessibilityElement:element tappable:mustBeTappable error:error disableScroll:scrollDisabled];
     if (!view) {
         return NO;
     }
@@ -162,7 +177,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     return nil;
 }
 
-+ (UIView *)viewContainingAccessibilityElement:(UIAccessibilityElement *)element tappable:(BOOL)mustBeTappable error:(NSError **)error;
++ (UIView *)viewContainingAccessibilityElement:(UIAccessibilityElement *)element tappable:(BOOL)mustBeTappable error:(NSError **)error disableScroll:(BOOL)scrollDisabled;
 {
     // Small safety mechanism.  If someone calls this method after a failing call to accessibilityElementWithLabel:..., we don't want to wipe out the error message.
     if (!element && error && *error) {
@@ -178,60 +193,62 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
         return nil;
     }
 
-    // Scroll the view (and superviews) to be visible if necessary
-    UIView *superview = view;
-    while (superview) {
-        if ([superview isKindOfClass:[UIScrollView class]]) {
-            UIScrollView *scrollView = (UIScrollView *)superview;
-            BOOL animationEnabled = [KIFUITestActor testActorAnimationsEnabled];
-            
-            if (((UIAccessibilityElement *)view == element) && ![view isKindOfClass:[UITableViewCell class]]) {
-                [scrollView scrollViewToVisible:view animated:animationEnabled];
-            } else {
-                if ([view isKindOfClass:[UITableViewCell class]] && [scrollView.superview isKindOfClass:[UITableView class]]) {
-                    UITableViewCell *cell = (UITableViewCell *)view;
-                    UITableView *tableView = (UITableView *)scrollView.superview;
-                    NSIndexPath *indexPath = [tableView indexPathForCell:cell];
-                    [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:animationEnabled];
+    if(!scrollDisabled) {
+        // Scroll the view (and superviews) to be visible if necessary
+        UIView *superview = view;
+        while (superview) {
+            if ([superview isKindOfClass:[UIScrollView class]]) {
+                UIScrollView *scrollView = (UIScrollView *)superview;
+                BOOL animationEnabled = [KIFUITestActor testActorAnimationsEnabled];
+
+                if (((UIAccessibilityElement *)view == element) && ![view isKindOfClass:[UITableViewCell class]]) {
+                    [scrollView scrollViewToVisible:view animated:animationEnabled];
                 } else {
-                    CGRect elementFrame = [view.window convertRect:element.accessibilityFrame toView:scrollView];
-                    CGRect visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y, CGRectGetWidth(scrollView.bounds), CGRectGetHeight(scrollView.bounds));
+                    if ([view isKindOfClass:[UITableViewCell class]] && [scrollView.superview isKindOfClass:[UITableView class]]) {
+                        UITableViewCell *cell = (UITableViewCell *)view;
+                        UITableView *tableView = (UITableView *)scrollView.superview;
+                        NSIndexPath *indexPath = [tableView indexPathForCell:cell];
+                        [tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionNone animated:animationEnabled];
+                    } else {
+                        CGRect elementFrame = [view.window convertRect:element.accessibilityFrame toView:scrollView];
+                        CGRect visibleRect = CGRectMake(scrollView.contentOffset.x, scrollView.contentOffset.y, CGRectGetWidth(scrollView.bounds), CGRectGetHeight(scrollView.bounds));
 
-                    UIEdgeInsets contentInset;
-#ifdef __IPHONE_11_0
-                        if (@available(iOS 11.0, *)) {
-                            contentInset = scrollView.adjustedContentInset;
-                        } else {
+                        UIEdgeInsets contentInset;
+    #ifdef __IPHONE_11_0
+                            if (@available(iOS 11.0, *)) {
+                                contentInset = scrollView.adjustedContentInset;
+                            } else {
+                                contentInset = scrollView.contentInset;
+                            }
+    #else
                             contentInset = scrollView.contentInset;
-                        }
-#else
-                        contentInset = scrollView.contentInset;
-#endif
-                    visibleRect = UIEdgeInsetsInsetRect(visibleRect, contentInset);
+    #endif
+                        visibleRect = UIEdgeInsetsInsetRect(visibleRect, contentInset);
 
-                    // Only call scrollRectToVisible if the element isn't already visible
-                    // iOS 8 will sometimes incorrectly scroll table views so the element scrolls out of view
-                    if (!CGRectContainsRect(visibleRect, elementFrame)) {
-                        [scrollView scrollRectToVisible:elementFrame animated:animationEnabled];
+                        // Only call scrollRectToVisible if the element isn't already visible
+                        // iOS 8 will sometimes incorrectly scroll table views so the element scrolls out of view
+                        if (!CGRectContainsRect(visibleRect, elementFrame)) {
+                            [scrollView scrollRectToVisible:elementFrame animated:animationEnabled];
+                        }
+                    }
+
+                    // Give the scroll view a small amount of time to perform the scroll.
+                    CFTimeInterval delay = animationEnabled ? 0.3 : 0.05;
+                    KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, delay, false);
+
+                    // Because of cell reuse the first found view could be different after we scroll.
+                    // Find the same element's view to ensure that after we have scrolled we get the same view back.
+                    UIView *checkedView = [UIAccessibilityElement viewContainingAccessibilityElement:element];
+                    // intentionally doing a memory address check vs a isEqual check because
+                    // we want to ensure that the memory address hasn't changed after scroll.
+                    if(view != checkedView) {
+                        view = checkedView;
                     }
                 }
-
-                // Give the scroll view a small amount of time to perform the scroll.
-                CFTimeInterval delay = animationEnabled ? 0.3 : 0.05;
-                KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, delay, false);
-
-                // Because of cell reuse the first found view could be different after we scroll.
-                // Find the same element's view to ensure that after we have scrolled we get the same view back.
-                UIView *checkedView = [UIAccessibilityElement viewContainingAccessibilityElement:element];
-                // intentionally doing a memory address check vs a isEqual check because
-                // we want to ensure that the memory address hasn't changed after scroll.
-                if(view != checkedView) {
-                    view = checkedView;
-                }
             }
+
+            superview = superview.superview;
         }
-        
-        superview = superview.superview;
     }
 
     if ([[UIApplication sharedApplication] isIgnoringInteractionEvents]) {

--- a/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -116,7 +116,7 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 
 + (BOOL)accessibilityElement:(out UIAccessibilityElement *__autoreleasing *)foundElement view:(out UIView *__autoreleasing *)foundView withElementMatchingPredicate:(NSPredicate *)predicate fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError *__autoreleasing *)error
 {
-    return [self accessibilityElement: foundElement view:foundView withElementMatchingPredicate:predicate tappable:mustBeTappable error:error disableScroll:NO];
+    return [self accessibilityElement:foundElement view:foundView withElementMatchingPredicate:predicate fromRootView:fromView tappable:mustBeTappable error:error disableScroll:NO];
 }
 
 + (BOOL)accessibilityElement:(out UIAccessibilityElement *__autoreleasing *)foundElement view:(out UIView *__autoreleasing *)foundView withElementMatchingPredicate:(NSPredicate *)predicate fromRootView:(UIView *)fromView tappable:(BOOL)mustBeTappable error:(out NSError *__autoreleasing *)error disableScroll:(BOOL)scrollDisabled

--- a/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -177,6 +177,11 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     return nil;
 }
 
++ (UIView *)viewContainingAccessibilityElement:(UIAccessibilityElement *)element tappable:(BOOL)mustBeTappable error:(NSError **)error;
+{
+    return [self viewContainingAccessibilityElement:element tappable:mustBeTappable error:error disableScroll:NO];
+}
+
 + (UIView *)viewContainingAccessibilityElement:(UIAccessibilityElement *)element tappable:(BOOL)mustBeTappable error:(NSError **)error disableScroll:(BOOL)scrollDisabled;
 {
     // Small safety mechanism.  If someone calls this method after a failing call to accessibilityElementWithLabel:..., we don't want to wipe out the error message.

--- a/Sources/KIF/Additions/UIApplication-KIFAdditions.h
+++ b/Sources/KIF/Additions/UIApplication-KIFAdditions.h
@@ -53,7 +53,7 @@ CF_EXPORT SInt32 KIFRunLoopRunInModeRelativeToAnimationSpeed(CFStringRef mode, C
  @abstract Finds an accessibility element where @c matchBlock returns @c YES, across all windows in the application starting at the fronmost window.
  @discussion This method should be used if @c accessibilityElementWithLabel:accessibilityValue:traits: does not meet your requirements.  For example, if you are searching for an element that begins with a pattern or if of a certain view type.
  @param matchBlock  A block to be performed on each element to see if it passes.
- @param disableScroll  Disable scroll performing the search only in the current visible frame.
+ @param scrollDisabled  Disable scroll performing the search only in the current visible frame.
  */
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock disableScroll:(BOOL)scrollDisabled;
 

--- a/Sources/KIF/Additions/UIApplication-KIFAdditions.h
+++ b/Sources/KIF/Additions/UIApplication-KIFAdditions.h
@@ -53,7 +53,7 @@ CF_EXPORT SInt32 KIFRunLoopRunInModeRelativeToAnimationSpeed(CFStringRef mode, C
  @abstract Finds an accessibility element where @c matchBlock returns @c YES, across all windows in the application starting at the fronmost window.
  @discussion This method should be used if @c accessibilityElementWithLabel:accessibilityValue:traits: does not meet your requirements.  For example, if you are searching for an element that begins with a pattern or if of a certain view type.
  @param matchBlock  A block to be performed on each element to see if it passes.
- @param disableScroll  Disable the scroll while looking for the element
+ @param disableScroll  Disable scroll performing the search only in the current visible frame.
  */
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock disableScroll:(BOOL)scrollDisabled;
 

--- a/Sources/KIF/Additions/UIApplication-KIFAdditions.h
+++ b/Sources/KIF/Additions/UIApplication-KIFAdditions.h
@@ -49,6 +49,13 @@ CF_EXPORT SInt32 KIFRunLoopRunInModeRelativeToAnimationSpeed(CFStringRef mode, C
  @param matchBlock  A block to be performed on each element to see if it passes.
  */
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock;
+/*!
+ @abstract Finds an accessibility element where @c matchBlock returns @c YES, across all windows in the application starting at the fronmost window.
+ @discussion This method should be used if @c accessibilityElementWithLabel:accessibilityValue:traits: does not meet your requirements.  For example, if you are searching for an element that begins with a pattern or if of a certain view type.
+ @param matchBlock  A block to be performed on each element to see if it passes.
+ @param disableScroll  Disable the scroll while looking for the element
+ */
+- (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock disableScroll:(BOOL)scrollDisabled;
 
 /*!
  @returns The window containing the keyboard or @c nil if the keyboard is not visible.

--- a/Sources/KIF/Additions/UIApplication-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIApplication-KIFAdditions.m
@@ -63,8 +63,13 @@ static const void *KIFRunLoopModesKey = &KIFRunLoopModesKey;
 
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock;
 {
+    return [self accessibilityElementMatchingBlock:matchBlock disableScroll:NO];
+}
+
+- (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock disableScroll:(BOOL)scrollDisabled;
+{
     for (UIWindow *window in [self.windowsWithKeyWindow reverseObjectEnumerator]) {
-        UIAccessibilityElement *element = [window accessibilityElementMatchingBlock:matchBlock];
+        UIAccessibilityElement *element = [window accessibilityElementMatchingBlock:matchBlock disableScroll:scrollDisabled];
         if (element) {
             return element;
         }

--- a/Sources/KIF/Additions/UIView-KIFAdditions.h
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.h
@@ -35,7 +35,7 @@ typedef CGPoint KIFDisplacement;
  @method accessibilityElementMatchingBlock:
  @abstract Finds the descendent accessibility element that matches the conditions defined by the match block.
  @param matchBlock A block which returns YES for matching elements.
- @param disableScroll Disable scroll performing the search only in the current visible frame.
+ @param scrollDisabled Disable scroll performing the search only in the current visible frame.
  @result The matching accessibility element.
  */
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock disableScroll:(BOOL)scrollDisabled;

--- a/Sources/KIF/Additions/UIView-KIFAdditions.h
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.h
@@ -31,6 +31,14 @@ typedef CGPoint KIFDisplacement;
  @result The matching accessibility element.
  */
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock;
+/*!
+ @method accessibilityElementMatchingBlock:
+ @abstract Finds the descendent accessibility element that matches the conditions defined by the match block.
+ @param matchBlock A block which returns YES for matching elements.
+ @param disableScroll disable the scroll interactions while loooking for the element
+ @result The matching accessibility element.
+ */
+- (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock disableScroll:(BOOL)scrollDisabled;
 
 - (UIView *)subviewWithClassNamePrefix:(NSString *)prefix __deprecated;
 - (NSArray *)subviewsWithClassNamePrefix:(NSString *)prefix;

--- a/Sources/KIF/Additions/UIView-KIFAdditions.h
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.h
@@ -35,7 +35,7 @@ typedef CGPoint KIFDisplacement;
  @method accessibilityElementMatchingBlock:
  @abstract Finds the descendent accessibility element that matches the conditions defined by the match block.
  @param matchBlock A block which returns YES for matching elements.
- @param disableScroll disable the scroll interactions while loooking for the element
+ @param disableScroll Disable scroll performing the search only in the current visible frame.
  @result The matching accessibility element.
  */
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock disableScroll:(BOOL)scrollDisabled;

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -873,8 +873,8 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 // Is this view currently on screen?
 - (BOOL)isTappable;
 {
-    return ([self hasTapGestureRecognizerAndIsControlEnabled] ||
-            [self isTappableInRect:self.bounds]);
+    return ([self isTappableInRect:self.bounds] || ([self hasTapGestureRecognizerAndIsControlEnabled] &&
+            [self isTappableInRect:self.bounds]));
 }
 
 - (BOOL)hasTapGestureRecognizerAndIsControlEnabled

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -132,7 +132,12 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock;
 {
-    return [self accessibilityElementMatchingBlock:matchBlock notHidden:YES];
+    return [self accessibilityElementMatchingBlock:matchBlock disableScroll:NO];
+}
+
+- (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock disableScroll:(BOOL)scrollDisabled;
+{
+    return [self accessibilityElementMatchingBlock:matchBlock notHidden:YES disableScroll:scrollDisabled];
 }
 
 - (BOOL)isPossiblyVisibleInWindow
@@ -176,7 +181,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     }
 }
 
-- (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock notHidden:(BOOL)notHidden;
+- (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock notHidden:(BOOL)notHidden disableScroll:(BOOL)scrollDisabled;
 {
     if (notHidden && self.hidden) {
         return nil;
@@ -204,11 +209,11 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     // rather than the real subviews it contains. We want the real views if possible.
     // UITableViewCell is such an offender.
     for (UIView *view in [self.subviews reverseObjectEnumerator]) {
-        UIAccessibilityElement *element = [view accessibilityElementMatchingBlock:matchBlock];
-        
+        UIAccessibilityElement *element = [view accessibilityElementMatchingBlock:matchBlock disableScroll:scrollDisabled];
+
         if (!element) {
             UIView* fallbackView = [self tryGetiOS16KeyboardFallbackViewFromParentView:view];
-            element = [fallbackView accessibilityElementMatchingBlock:matchBlock];
+            element = [fallbackView accessibilityElementMatchingBlock:matchBlock disableScroll:scrollDisabled];
         }
         
         if (!element) {
@@ -272,7 +277,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
         }
     }
     
-    if (!matchingButOccludedElement && self.window) {
+    if (!scrollDisabled && !matchingButOccludedElement && self.window) {
         CGPoint scrollContentOffset = {-1.0, -1.0};
         UIScrollView *scrollView = nil;
         if ([self isKindOfClass:[UITableView class]]) {
@@ -325,7 +330,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                         [tableView scrollRectToVisible:sectionRect animated:NO];
 
                         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-                        UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock notHidden:NO];
+                        UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:scrollDisabled];
 
                         // Skip this cell if it isn't the one we're looking for
                         if (!element) {
@@ -335,7 +340,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 
                     // Note: using KIFRunLoopRunInModeRelativeToAnimationSpeed here may cause tests to stall
                     CFRunLoopRunInMode(UIApplicationCurrentRunMode, delay, false);
-                    return [self accessibilityElementMatchingBlock:matchBlock];
+                    return [self accessibilityElementMatchingBlock:matchBlock disableScroll:scrollDisabled];
                 }
             }
 
@@ -373,8 +378,8 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                             [collectionView.delegate collectionView:collectionView willDisplayCell:cell forItemAtIndexPath:indexPath];
                         }
                         
-                        UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock notHidden:NO];
-                        
+                        UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:scrollDisabled];
+
                         // Remove the cell from the collection view so that it doesn't stick around
                         [cell removeFromSuperview];
                         
@@ -392,7 +397,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                     CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.5, false);
                     
                     // Now try finding the element again
-                    return [self accessibilityElementMatchingBlock:matchBlock];
+                    return [self accessibilityElementMatchingBlock:matchBlock disableScroll:scrollDisabled];
                 }
             }
         }

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -873,7 +873,8 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 // Is this view currently on screen?
 - (BOOL)isTappable;
 {
-    return [self isTappableInRect:self.bounds];
+    return ([self isTappableInRect:self.bounds] || ([self hasTapGestureRecognizerAndIsControlEnabled] &&
+            [self isTappableInRect:self.bounds]));
 }
 
 - (BOOL)hasTapGestureRecognizerAndIsControlEnabled

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -873,8 +873,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 // Is this view currently on screen?
 - (BOOL)isTappable;
 {
-    return ([self isTappableInRect:self.bounds] || ([self hasTapGestureRecognizerAndIsControlEnabled] &&
-            [self isTappableInRect:self.bounds]));
+    return [self isTappableInRect:self.bounds];
 }
 
 - (BOOL)hasTapGestureRecognizerAndIsControlEnabled

--- a/Sources/KIF/Classes/KIFUITestActor-ConditionalTests.h
+++ b/Sources/KIF/Classes/KIFUITestActor-ConditionalTests.h
@@ -65,4 +65,6 @@
 
 - (BOOL)tryFindingAccessibilityElement:(out UIAccessibilityElement **)element view:(out UIView **)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error;
 
+- (BOOL)tryFindingAccessibilityElement:(out UIAccessibilityElement **)element view:(out UIView **)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error disableScroll:(BOOL) scrollDisabled;
+
 @end

--- a/Sources/KIF/Classes/KIFUITestActor-ConditionalTests.m
+++ b/Sources/KIF/Classes/KIFUITestActor-ConditionalTests.m
@@ -67,8 +67,13 @@
 
 - (BOOL)tryFindingAccessibilityElement:(out UIAccessibilityElement * __autoreleasing *)element view:(out UIView * __autoreleasing *)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error
 {
+    [self tryFindingAccessibilityElement:element view:view withElementMatchingPredicate:predicate tappable:mustBeTappable error:error disableScroll:NO];
+}
+
+- (BOOL)tryFindingAccessibilityElement:(out UIAccessibilityElement * __autoreleasing *)element view:(out UIView * __autoreleasing *)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error disableScroll:(BOOL)scrollDisabled
+{
     return [self tryRunningBlock:^KIFTestStepResult(NSError *__autoreleasing *error) {
-        return [UIAccessibilityElement accessibilityElement:element view:view withElementMatchingPredicate:predicate tappable:mustBeTappable error:error] ? KIFTestStepResultSuccess : KIFTestStepResultWait;
+        return [UIAccessibilityElement accessibilityElement:element view:view withElementMatchingPredicate:predicate tappable:mustBeTappable error:error disableScroll:scrollDisabled] ? KIFTestStepResultSuccess : KIFTestStepResultWait;
     } complete:nil timeout:1.0 error:error];
 }
 

--- a/Sources/KIF/Classes/KIFUITestActor-ConditionalTests.m
+++ b/Sources/KIF/Classes/KIFUITestActor-ConditionalTests.m
@@ -67,7 +67,7 @@
 
 - (BOOL)tryFindingAccessibilityElement:(out UIAccessibilityElement * __autoreleasing *)element view:(out UIView * __autoreleasing *)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error
 {
-    [self tryFindingAccessibilityElement:element view:view withElementMatchingPredicate:predicate tappable:mustBeTappable error:error disableScroll:NO];
+    return [self tryFindingAccessibilityElement:element view:view withElementMatchingPredicate:predicate tappable:mustBeTappable error:error disableScroll:NO];
 }
 
 - (BOOL)tryFindingAccessibilityElement:(out UIAccessibilityElement * __autoreleasing *)element view:(out UIView * __autoreleasing *)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable error:(out NSError **)error disableScroll:(BOOL)scrollDisabled

--- a/Sources/KIF/Classes/KIFUITestActor.h
+++ b/Sources/KIF/Classes/KIFUITestActor.h
@@ -248,7 +248,7 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
  @param view To be populated with the matching view when found.  Can be NULL.
  @param predicate The predicate to match.
  @param mustBeTappable If YES, only an element that can be tapped on will be returned.
- @param disableScroll If YES, disable scroll performing the search only in the current visible frame.
+ @param scrollDisabled If YES, disable scroll performing the search only in the current visible frame.
  */
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable disableScroll:(BOOL)scrollDisabled;
 

--- a/Sources/KIF/Classes/KIFUITestActor.h
+++ b/Sources/KIF/Classes/KIFUITestActor.h
@@ -240,6 +240,19 @@ typedef NS_ENUM(NSUInteger, KIFPullToRefreshTiming) {
 - (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable;
 
 /*!
+ @abstract Waits for an accessibility element and its containing view based on a predicate.
+ @discussion This method provides a more verbose API for achieving what is available in the waitForView/waitForTappableView family of methods, exposing both the found element and its containing view.  The results can be used in other methods such as @c tapAccessibilityElement:inView:
+
+ This method provides more flexability than @c waitForAccessibilityElement:view:withLabel:value:traits:tappable: but less precise error messages.  This message will tell you why the method failed but not whether or not the element met some of the criteria.
+ @param element To be populated with the matching accessibility element when found.  Can be NULL.
+ @param view To be populated with the matching view when found.  Can be NULL.
+ @param predicate The predicate to match.
+ @param mustBeTappable If YES, only an element that can be tapped on will be returned.
+ @param disableScroll If YES, disable scroll performing the search only in the current visible frame.
+ */
+- (void)waitForAccessibilityElement:(UIAccessibilityElement **)element view:(out UIView **)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable disableScroll:(BOOL)scrollDisabled;
+
+/*!
  @abstract Waits until an accessibility element is no longer present.
  @discussion The accessibility element matching the given predicate is found in the view hierarchy. If the element is found, then the step will attempt to wait until it isn't. Note that the associated view does not necessarily have to be visible on the screen, and may be behind another view or offscreen. Views with their hidden property set to YES are considered absent.
  @param predicate The predicate to match.

--- a/Sources/KIF/Classes/KIFUITestActor.m
+++ b/Sources/KIF/Classes/KIFUITestActor.m
@@ -144,8 +144,13 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
 
 - (void)waitForAccessibilityElement:(UIAccessibilityElement * __autoreleasing *)element view:(out UIView * __autoreleasing *)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable
 {
+    [self waitForAccessibilityElement:element view:view withElementMatchingPredicate:predicate tappable:mustBeTappable disableScroll:NO];
+}
+
+- (void)waitForAccessibilityElement:(UIAccessibilityElement * __autoreleasing *)element view:(out UIView * __autoreleasing *)view withElementMatchingPredicate:(NSPredicate *)predicate tappable:(BOOL)mustBeTappable disableScroll:(BOOL) scrollDisabled
+{
     [self runBlock:^KIFTestStepResult(NSError **error) {
-        return [UIAccessibilityElement accessibilityElement:element view:view withElementMatchingPredicate:predicate tappable:mustBeTappable error:error] ? KIFTestStepResultSuccess : KIFTestStepResultWait;
+        return [UIAccessibilityElement accessibilityElement:element view:view withElementMatchingPredicate:predicate tappable:mustBeTappable error:error disableScroll:scrollDisabled] ? KIFTestStepResultSuccess : KIFTestStepResultWait;
     }];
 }
 

--- a/Sources/KIF/Classes/KIFUIViewTestActor.h
+++ b/Sources/KIF/Classes/KIFUIViewTestActor.h
@@ -39,6 +39,14 @@ extern NSString *const inputFieldTestString;
  */
 - (instancetype)validateEnteredText:(BOOL)validateEnteredText;
 
+/*!
+ @abstract Controls if we want to disable the automatic scroll while looking for an element.
+ @discussion This method limits the search in the current frame for each operation that searches for an element.
+
+ @return The message reciever, these methods are intended to be chained together.
+ */
+- (instancetype)usingCurrentFrame;
+
 #pragma mark - Searching for Accessibility Elements
 
 /*!

--- a/Sources/KIF/Classes/KIFUIViewTestActor.m
+++ b/Sources/KIF/Classes/KIFUIViewTestActor.m
@@ -25,6 +25,7 @@
 @property (nonatomic, strong, readonly) KIFUITestActor *actor;
 @property (nonatomic, strong, readwrite) NSPredicate *predicate;
 @property (nonatomic, assign) BOOL validateEnteredText;
+@property (nonatomic, assign) BOOL disablingAutomaticScroll;
 
 @end
 
@@ -40,6 +41,7 @@ NSString *const inputFieldTestString = @"Testing";
     self = [super initWithFile:file line:line delegate:delegate];
     NSParameterAssert(self);
     _validateEnteredText = YES;
+    _disablingAutomaticScroll = NO;
     return self;
 }
 
@@ -48,6 +50,12 @@ NSString *const inputFieldTestString = @"Testing";
 - (instancetype)validateEnteredText:(BOOL)validateEnteredText;
 {
     self.validateEnteredText = validateEnteredText;
+    return self;
+}
+
+- (instancetype)usingCurrentFrame;
+{
+    self.disablingAutomaticScroll = YES;
     return self;
 }
 
@@ -636,11 +644,11 @@ NSString *const inputFieldTestString = @"Testing";
     __block UIAccessibilityElement *foundElement = nil;
 
     if (requiresMatch) {
-        [self.actor waitForAccessibilityElement:&foundElement view:&foundView withElementMatchingPredicate:self.predicate tappable:tappable];
+        [self.actor waitForAccessibilityElement:&foundElement view:&foundView withElementMatchingPredicate:self.predicate tappable:tappable disableScroll:self.disablingAutomaticScroll];
     } else {
         NSError *error;
         [self tryRunningBlock:^KIFTestStepResult(NSError **error) {
-            KIFTestWaitCondition([self.actor tryFindingAccessibilityElement:&foundElement view:&foundView withElementMatchingPredicate:self.predicate tappable:tappable error:error], error, @"Waiting on view matching %@", self.predicate.kifPredicateDescription);
+            KIFTestWaitCondition([self.actor tryFindingAccessibilityElement:&foundElement view:&foundView withElementMatchingPredicate:self.predicate tappable:tappable error:error disableScroll:self.disablingAutomaticScroll], error, @"Waiting on view matching %@", self.predicate.kifPredicateDescription);
             return KIFTestStepResultSuccess;
         } complete:nil timeout:1.0 error:&error];
     }

--- a/Sources/KIF/IdentifierTests/KIFUITestActor-IdentifierTests.h
+++ b/Sources/KIF/IdentifierTests/KIFUITestActor-IdentifierTests.h
@@ -86,6 +86,13 @@
 - (BOOL) tryFindingViewWithAccessibilityIdentifier:(NSString *) accessibilityIdentifier;
 
 /*!
+ @abstract returns YES or NO if the element is visible in the current frame (without scrolling).
+ @discussion if the element described by the accessibility identifier is visible, the method returns true.
+ @param accessibilityIdentifier The accessibility identifier of the element to query for
+ */
+- (BOOL) tryFindingViewInFrameWithAccessibilityIdentifier:(NSString *) accessibilityIdentifier;
+
+/*!
  @abstract Swipes a particular view in the view hierarchy in the given direction.
  @discussion This step will get the view with the specified accessibility identifier and swipe the screen in the given direction from the view's center.
  @param identifier The accessibility identifier of the view to swipe.

--- a/Sources/KIF/IdentifierTests/KIFUITestActor-IdentifierTests.m
+++ b/Sources/KIF/IdentifierTests/KIFUITestActor-IdentifierTests.m
@@ -196,7 +196,6 @@
     NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
         return [[evaluatedObject accessibilityIdentifier] isEqualToString:accessibilityIdentifier];
     }];
-    // Simone - we don't want scrolling if we are in this method!!
     return [UIAccessibilityElement accessibilityElement:nil view:nil withElementMatchingPredicate:predicate tappable:NO error:nil disableScroll:YES];
 }
 

--- a/Sources/KIF/IdentifierTests/KIFUITestActor-IdentifierTests.m
+++ b/Sources/KIF/IdentifierTests/KIFUITestActor-IdentifierTests.m
@@ -191,6 +191,15 @@
     }];
 }
 
+- (BOOL) tryFindingViewInFrameWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
+{
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+        return [[evaluatedObject accessibilityIdentifier] isEqualToString:accessibilityIdentifier];
+    }];
+    // Simone - we don't want scrolling if we are in this method!!
+    return [UIAccessibilityElement accessibilityElement:nil view:nil withElementMatchingPredicate:predicate tappable:NO error:nil disableScroll:YES];
+}
+
 - (BOOL) tryFindingViewWithAccessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
     NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {

--- a/Test Host/Base.lproj/MainStoryboard.storyboard
+++ b/Test Host/Base.lproj/MainStoryboard.storyboard
@@ -1588,7 +1588,7 @@
                                     <outlet property="delegate" destination="21" id="nKd-AR-TdK"/>
                                 </connections>
                             </textField>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Hello" borderStyle="roundedRect" placeholder="out of frame" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Qs0-rL-Yva" userLabel="Out of frame view">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Hello" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Qs0-rL-Yva" userLabel="Out of frame view">
                                 <rect key="frame" x="131" y="2000" width="152" height="29"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 <accessibility key="accessibilityConfiguration" hint="" label="Greeting">
@@ -1752,14 +1752,6 @@ Line Break
                                 </accessibility>
                                 <state key="normal" title="Test Suite"/>
                             </button>
-                            <searchBar contentMode="redraw" fixedFrame="YES" placeholder="Search" translatesAutoresizingMaskIntoConstraints="NO" id="2Mb-bR-KrW">
-                                <rect key="frame" x="0.0" y="322" width="414" height="44"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <textInputTraits key="textInputTraits"/>
-                                <connections>
-                                    <outlet property="delegate" destination="21" id="zHR-uq-6kB"/>
-                                </connections>
-                            </searchBar>
                         </subviews>
                         <color key="backgroundColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>

--- a/Test Host/Base.lproj/MainStoryboard.storyboard
+++ b/Test Host/Base.lproj/MainStoryboard.storyboard
@@ -1588,7 +1588,7 @@
                                     <outlet property="delegate" destination="21" id="nKd-AR-TdK"/>
                                 </connections>
                             </textField>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Hello" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Qs0-rL-Yva" userLabel="Out of frame view">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Hello" borderStyle="roundedRect" placeholder="out of frame" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Qs0-rL-Yva" userLabel="Out of frame view">
                                 <rect key="frame" x="131" y="2000" width="152" height="29"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 <accessibility key="accessibilityConfiguration" hint="" label="Greeting">
@@ -1752,6 +1752,14 @@ Line Break
                                 </accessibility>
                                 <state key="normal" title="Test Suite"/>
                             </button>
+                            <searchBar contentMode="redraw" fixedFrame="YES" placeholder="Search" translatesAutoresizingMaskIntoConstraints="NO" id="2Mb-bR-KrW">
+                                <rect key="frame" x="0.0" y="322" width="414" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <connections>
+                                    <outlet property="delegate" destination="21" id="zHR-uq-6kB"/>
+                                </connections>
+                            </searchBar>
                         </subviews>
                         <color key="backgroundColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>

--- a/Test Host/Base.lproj/MainStoryboard.storyboard
+++ b/Test Host/Base.lproj/MainStoryboard.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="3">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1573,6 +1573,21 @@
                                     <outlet property="delegate" destination="21" id="nKd-AR-TdK"/>
                                 </connections>
                             </textField>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Hello" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Qs0-rL-Yva" userLabel="Out of frame view">
+                                <rect key="frame" x="131" y="2000" width="152" height="29"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                <accessibility key="accessibilityConfiguration" hint="" label="Greeting">
+                                    <accessibilityTraits key="traits" updatesFrequently="YES"/>
+                                </accessibility>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="outOfFrameView"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <outlet property="delegate" destination="21" id="dFE-jj-aQ0"/>
+                                </connections>
+                            </textField>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U8w-Z0-PnT">
                                 <rect key="frame" x="174" y="533" width="218" height="46"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
@@ -2151,16 +2166,16 @@ Line Break
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBrownColor">
-            <color red="0.63529411764705879" green="0.51764705882352946" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.63529411759999999" green="0.51764705879999995" blue="0.36862745099999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemPurpleColor">
-            <color red="0.68627450980392157" green="0.32156862745098042" blue="0.87058823529411766" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.68627450980000004" green="0.32156862749999998" blue="0.87058823529999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Test Host/Base.lproj/MainStoryboard.storyboard
+++ b/Test Host/Base.lproj/MainStoryboard.storyboard
@@ -1540,7 +1540,7 @@
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Hello" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qfF-gg-VsM" userLabel="Occluded view">
                                 <rect key="frame" x="63" y="136" width="111" height="29"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                <accessibility key="accessibilityConfiguration" hint="" label="Greeting">
+                                <accessibility key="accessibilityConfiguration" hint="">
                                     <accessibilityTraits key="traits" updatesFrequently="YES"/>
                                 </accessibility>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -1591,7 +1591,7 @@
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Hello" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Qs0-rL-Yva" userLabel="Out of frame view">
                                 <rect key="frame" x="131" y="2000" width="152" height="29"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                <accessibility key="accessibilityConfiguration" hint="" label="Greeting">
+                                <accessibility key="accessibilityConfiguration" hint="">
                                     <accessibilityTraits key="traits" updatesFrequently="YES"/>
                                 </accessibility>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -2187,10 +2187,10 @@ Line Break
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBrownColor">
-            <color red="0.63529411764705879" green="0.51764705882352946" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.63529411759999999" green="0.51764705879999995" blue="0.36862745099999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemPurpleColor">
-            <color red="0.68627450980392157" green="0.32156862745098042" blue="0.87058823529411766" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.68627450980000004" green="0.32156862749999998" blue="0.87058823529999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Test Host/Base.lproj/MainStoryboard.storyboard
+++ b/Test Host/Base.lproj/MainStoryboard.storyboard
@@ -1537,6 +1537,21 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="804"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Hello" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qfF-gg-VsM" userLabel="Occluded view">
+                                <rect key="frame" x="63" y="136" width="111" height="29"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                <accessibility key="accessibilityConfiguration" hint="" label="Greeting">
+                                    <accessibilityTraits key="traits" updatesFrequently="YES"/>
+                                </accessibility>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="occludedView"/>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <outlet property="delegate" destination="21" id="BDy-eE-hmG"/>
+                                </connections>
+                            </textField>
                             <segmentedControl opaque="NO" contentMode="scaleAspectFit" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="rjj-Hu-dUx">
                                 <rect key="frame" x="63" y="37" width="156" height="29"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinY="YES" flexibleMaxY="YES"/>
@@ -2172,10 +2187,10 @@ Line Break
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBrownColor">
-            <color red="0.63529411759999999" green="0.51764705879999995" blue="0.36862745099999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.63529411764705879" green="0.51764705882352946" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemPurpleColor">
-            <color red="0.68627450980000004" green="0.32156862749999998" blue="0.87058823529999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.68627450980392157" green="0.32156862745098042" blue="0.87058823529411766" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
# Description
This MR introduces the method `tryFindingViewInFrame(withAccessibilityIdentifier: )` that allows to check the visibility of an element **in the current frame** as it is showed to the user, without any additional interaction.
The method usingCurrentFrame() has been added in the new `KIFUIViewTestActor` to maintain parity with `KIFUITestActor`.

### Why?
In some UITests we want to ensure an element is visible in the **current frame**. 

When the element we want to assert is visible is inside a `scrollView`,`tableView` or `collectionView` the method `tryFindingView(withAccessibilityIdentifier: )` causes a scroll to the offset where the element is placed, making it visible even if it wasn't. This behaviour does not allow to have reliable visibility checks (eg. if an element exists but is not actually visible, the method returns true).

**EDIT:** this MR also fixes a bug: under some conditions a control was considered `tappable` when just `enabled` and having a `TapGestureRecognizer`, even when it was occluded by another element. 