### PR TITLE
Speed up unnecessarily and unintentionally slow `waitForAnimationsToFinish` calls

### DIFF
--- a/Sources/KIF/Additions/CALayer-KIFAdditions.h
+++ b/Sources/KIF/Additions/CALayer-KIFAdditions.h
@@ -25,6 +25,7 @@
  @abstract Calls a block on the layer itself and on all its descendent layers.
  @param block The block that will be called on the layers. Stop the traversation
  of the layers by assigning YES to the stop-parameter of the block.
+ We will not recurse into hidden layers.
  */
 - (void)performBlockOnDescendentLayers:(void (^)(CALayer *layer, BOOL *stop))block;
 

--- a/Sources/KIF/Additions/CALayer-KIFAdditions.m
+++ b/Sources/KIF/Additions/CALayer-KIFAdditions.m
@@ -27,25 +27,31 @@
 {
     __block BOOL result = NO;
     [self performBlockOnDescendentLayers:^(CALayer *layer, BOOL *stop) {
-      // explicitly exclude _UIParallaxMotionEffect as it is used in alertviews, and we don't want every alertview to be paused
-      // explicitly exclude UITextSelectionViewCaretBlinkAnimation as it is used in textfields, and we don't want every view with textfields to be paused
-      BOOL hasAnimation = layer.animationKeys.count != 0 && ![layer.animationKeys containsObject:@"_UIParallaxMotionEffect"] && ![layer.animationKeys containsObject:@"UITextSelectionViewCaretBlinkAnimation"];
-      if (hasAnimation && !layer.hidden) {
-          double currentTime = CACurrentMediaTime() * [layer KIF_absoluteSpeed];
+        // explicitly exclude _UIParallaxMotionEffect as it is used in alertviews, and we don't want every alertview to be paused
+        // explicitly exclude UITextSelectionViewCaretBlinkAnimation as it is used in textfields, and we don't want every view with textfields to be paused
+        BOOL hasAnimation = layer.animationKeys.count != 0 && ![layer.animationKeys containsObject:@"_UIParallaxMotionEffect"] && ![layer.animationKeys containsObject:@"UITextSelectionViewCaretBlinkAnimation"];
 
-          [layer.animationKeys enumerateObjectsUsingBlock:^(NSString *animationKey, NSUInteger idx, BOOL *innerStop) {
-              CAAnimation *animation = [layer animationForKey:animationKey];
-              double beginTime = [animation beginTime];
-              double completionTime = [animation KIF_completionTime];
+        // Ignore the animation of the KIF touch visualizer circle as it does not affect any view behavior
+        if ([NSStringFromClass(layer.delegate.class) isEqualToString:@"KIFTouchVisualizerView"]) {
+            hasAnimation = NO;
+        }
 
-              // Ignore long running animations (> 1 minute duration)
-              if (currentTime >= beginTime && completionTime < currentTime + 60 && currentTime < completionTime) {
-                  result = YES;
-                  *innerStop = YES;
-                  *stop = YES;
-              }
-          }];
-      }
+        if (hasAnimation && !layer.hidden) {
+            double currentTime = CACurrentMediaTime() * [layer KIF_absoluteSpeed];
+
+            [layer.animationKeys enumerateObjectsUsingBlock:^(NSString *animationKey, NSUInteger idx, BOOL *innerStop) {
+                CAAnimation *animation = [layer animationForKey:animationKey];
+                double beginTime = [animation beginTime];
+                double completionTime = [animation KIF_completionTime];
+
+                // Ignore long running animations (> 1 minute duration)
+                if (currentTime >= beginTime && completionTime < currentTime + 60 && currentTime < completionTime) {
+                    result = YES;
+                    *innerStop = YES;
+                    *stop = YES;
+                }
+            }];
+        }
     }];
     return result;
 }

--- a/Sources/KIF/Additions/CALayer-KIFAdditions.m
+++ b/Sources/KIF/Additions/CALayer-KIFAdditions.m
@@ -38,8 +38,8 @@
               double beginTime = [animation beginTime];
               double completionTime = [animation KIF_completionTime];
 
-              // Ignore infinitely repeating animations
-              if (currentTime >= beginTime && completionTime != HUGE_VALF && currentTime < completionTime) {
+              // Ignore long running animations (> 1 minute duration)
+              if (currentTime >= beginTime && completionTime < currentTime + 60 && currentTime < completionTime) {
                   result = YES;
                   *innerStop = YES;
                   *stop = YES;
@@ -58,6 +58,10 @@
 
 - (void)performBlockOnDescendentLayers:(void (^)(CALayer *, BOOL *))block stop:(BOOL *)stop
 {
+    if (self.isHidden) {
+        return;
+    }
+
     block(self, stop);
     if (*stop) {
         return;


### PR DESCRIPTION
- [x] Wait until after #1300 lands to land this change

We identified 3 issues where calls to `waitForAnimationsToFinish` would wait longer than we'd expect:

1. We're traversing through hidden views, which will sometimes finds animations on elements that aren't visible on the screen.
2. We're ignoring infinitely repeating animations, but not really long animations. In some cases this might be just a huge value that someone made up or it could be a slow animation. In either case, we probably don't want to wait for those to complete implicitly.
3. The `KIFTouchVisualizerView` was added to show where touch events are happening, but they animate in a separate window and have an alpha fade for .75s. Every tap action then will wait for a minimum of .75s after the tap for that animation to complete, which was unintentional. Credit to @amorde for finding and testing this issue.

This does alter test timing slightly, and even if your code doesn't explicitly use `waitForAnimationsToFinish`, it is also called automatically called after UI actions, such as tapping the screen. If you have [tweaked the timeouts](https://github.com/kif-framework/KIF/blob/8757ba89034d7a590e383558908a44cc61c702bf/Sources/KIF/Classes/KIFTestActor.m#L134-L139) to be faster and more aggressive, you might encounter some race conditions. You might be able to work around some of this temporarily by increasing the `KIFTestStepDefaultAnimationStabilizationTimeout` to .75s or 1s, but that will also slow down the execution of all of your tests (likely back to the speed before this change lands). 

This change has turned up quite a few race conditions in our tests, but nothing that seemed like it wasn't something that shouldn't have more explicit validation of the screen state.

I recommend reviewing this with whitespace diffs ignored.

CC: @amorde @dnkoutso