### PR TITLE
added performAccessibilityActivateWithExpectedResult

### DIFF
--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		ACA242E42C3DA55400E6F1B6 /* CustomActionTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = ACA242E32C3DA55400E6F1B6 /* CustomActionTests_ViewTestActor.m */; };
 		ACA242E72C3DB47400E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = ACA242E52C3DB46A00E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.m */; };
 		ACA242E92C3DB4EA00E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = ACA242E82C3DB4B000E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		ACDB72682CA3146B00D9796E /* AccessibilityViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ACDB72672CA3146B00D9796E /* AccessibilityViewController.m */; };
+		ACDB726A2CA314A800D9796E /* AccessibilityActivationTests_ViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = ACDB72692CA314A800D9796E /* AccessibilityActivationTests_ViewTestActor.m */; };
 		AE62FCD01A1D20E5002B10DA /* WebViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AE62FCCF1A1D20E5002B10DA /* WebViewTests.m */; };
 		AE62FCD61A1D2447002B10DA /* WebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AE62FCD51A1D2447002B10DA /* WebViewController.m */; };
 		AE62FCD81A1D2667002B10DA /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = AE62FCD71A1D2667002B10DA /* index.html */; };
@@ -321,6 +323,8 @@
 		ACA242E32C3DA55400E6F1B6 /* CustomActionTests_ViewTestActor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomActionTests_ViewTestActor.m; sourceTree = "<group>"; };
 		ACA242E52C3DB46A00E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIAccessibilityCustomAction+KIFAdditions.m"; sourceTree = "<group>"; };
 		ACA242E82C3DB4B000E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIAccessibilityCustomAction+KIFAdditions.h"; sourceTree = "<group>"; };
+		ACDB72672CA3146B00D9796E /* AccessibilityViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccessibilityViewController.m; sourceTree = "<group>"; };
+		ACDB72692CA314A800D9796E /* AccessibilityActivationTests_ViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccessibilityActivationTests_ViewTestActor.m; sourceTree = "<group>"; };
 		AE62FCCF1A1D20E5002B10DA /* WebViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WebViewTests.m; sourceTree = "<group>"; };
 		AE62FCD51A1D2447002B10DA /* WebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WebViewController.m; sourceTree = "<group>"; };
 		AE62FCD71A1D2667002B10DA /* index.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
@@ -633,6 +637,7 @@
 		EB60ECC6177F8C83005A041A /* TestHost */ = {
 			isa = PBXGroup;
 			children = (
+				ACDB72672CA3146B00D9796E /* AccessibilityViewController.m */,
 				3812FB601A1212A700335733 /* AnimationViewController.m */,
 				2CDEE1CA181DBED200DF6E63 /* PickerController.m */,
 				CD19A99E1F46482200BF0325 /* CustomPickerController.m */,
@@ -713,6 +718,7 @@
 		FA8DA74D1A77117A00E0C644 /* KIFUIViewTestActor Tests */ = {
 			isa = PBXGroup;
 			children = (
+				ACDB72692CA314A800D9796E /* AccessibilityActivationTests_ViewTestActor.m */,
 				FA4915641A7827D000A78E57 /* PickerTests_ViewTestActor.m */,
 				B66B1BF5202BCF2000D0E4B2 /* AutocorrectTests_ViewTestActor.m */,
 				CD4E91F11F479FF2005D530C /* CustomPickerTests_ViewTestActor.m */,
@@ -987,6 +993,7 @@
 				FA8A3C5D1A772CD100206350 /* WaitForAbscenceTests_ViewTestActor.m in Sources */,
 				FA8A3C5B1A77281900206350 /* WebViewTests_ViewTestActor.m in Sources */,
 				EABD46B11857A0F300A5F081 /* SearchFieldTests.m in Sources */,
+				ACDB726A2CA314A800D9796E /* AccessibilityActivationTests_ViewTestActor.m in Sources */,
 				EABD46B21857A0F300A5F081 /* CascadingFailureTests.m in Sources */,
 				EABD46B31857A0F300A5F081 /* CompositionTests.m in Sources */,
 				CD4E91F01F479A8C005D530C /* CustomPickerTests.m in Sources */,
@@ -1057,6 +1064,7 @@
 				EB60ED02177F9032005A041A /* TapViewController.m in Sources */,
 				2CDEE1CB181DBED200DF6E63 /* PickerController.m in Sources */,
 				EB60ED03177F9032005A041A /* TestSuiteViewController.m in Sources */,
+				ACDB72682CA3146B00D9796E /* AccessibilityViewController.m in Sources */,
 				D9EA274318F05A6700D87E57 /* ScrollViewController.m in Sources */,
 				8EAA1EE229D3AF7A008F6029 /* OffscreenViewController.m in Sources */,
 				3812FB611A1212A700335733 /* AnimationViewController.m in Sources */,

--- a/Sources/KIF/Classes/KIFUIViewTestActor.h
+++ b/Sources/KIF/Classes/KIFUIViewTestActor.h
@@ -200,6 +200,11 @@ extern NSString *const inputFieldTestString;
  */
 - (void)activateCustomActionWithName:(NSString *)name expectedResult:(BOOL)expectedResult;
 
+/*!
+ @abstract Activates a found element via `accessibilityActivate()`.
+ @param expectedResult The expected boolean return from activation of the element.
+ */
+- (void)performAccessibilityActivateWithExpectedResult:(BOOL)expectedResult;
 
 #pragma mark Waiting & Finding
 

--- a/Sources/KIF/Classes/KIFUIViewTestActor.m
+++ b/Sources/KIF/Classes/KIFUIViewTestActor.m
@@ -403,6 +403,8 @@ NSString *const inputFieldTestString = @"Testing";
     [self.actor swipeFromEdge:edge];
 }
 
+#pragma mark - Accesibility Actions
+
 - (void)activateCustomActionWithName:(NSString *)name;{
     [self activateCustomActionWithName:name expectedResult:YES];
 }
@@ -414,12 +416,29 @@ NSString *const inputFieldTestString = @"Testing";
         
         [self runBlock:^KIFTestStepResult(NSError **error) {
             if([[found.element KIF_customActionWithName:name] KIF_activate] == expectedResult) {
+                [self waitForAnimationsToFinish];
                 return KIFTestStepResultSuccess;
             }
+            [self waitForAnimationsToFinish];
             return KIFTestStepResultFailure;
         }];
     }
+}
 
+- (void)performAccessibilityActivateWithExpectedResult:(BOOL)expectedResult;
+{
+    @autoreleasepool {
+        KIFUIObject *found = [self _predicateSearchWithRequiresMatch:YES mustBeTappable:NO];
+        
+        [self runBlock:^KIFTestStepResult(NSError **error) {
+            if([found.element accessibilityActivate] == expectedResult) {
+                [self waitForAnimationsToFinish];
+                return KIFTestStepResultSuccess;
+            }
+            [self waitForAnimationsToFinish];
+            return KIFTestStepResultFailure;
+        }];
+    }
 }
 
 #pragma mark - Scroll/Table/CollectionView Actions

--- a/TestHost/AccessibilityViewController.m
+++ b/TestHost/AccessibilityViewController.m
@@ -1,0 +1,149 @@
+//
+//  AccessibilityViewController.m
+//  Test Host
+//
+//  Created by Alex Odawa on 17/09/2024.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AccessibilityViewController_AccessibilityView : UIView
+@property (nonatomic, assign) BOOL activationReturnValue;
+@property (nonatomic, assign) int activationCount;
+
+@property (nonatomic, strong) UILabel *label;
+@property (nonatomic, strong) UISwitch *activationSwitch;
+
+
+@end
+
+
+@implementation AccessibilityViewController_AccessibilityView
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
+    self.isAccessibilityElement = YES;
+    self.accessibilityLabel = @"AccessibilityView";
+    
+    
+    self.activationReturnValue = YES;
+
+    self.label = [[UILabel alloc] initWithFrame: CGRectZero];
+    [self addSubview:self.label];
+
+    self.backgroundColor = [UIColor systemTealColor];
+    self.label.text = @"Returns YES";
+    
+    
+    self.activationSwitch = [[UISwitch alloc] initWithFrame: CGRectZero];
+    [self addSubview: self.activationSwitch];
+
+    [self.activationSwitch setOn:self.activationReturnValue];
+    [self.activationSwitch addTarget: self action: @selector(toggleReturnValue) forControlEvents: UIControlEventValueChanged];
+    self.activationSwitch.accessibilityLabel = @"AccessibilitySwitch";
+
+    return self;
+}
+
+- (void)toggleReturnValue {
+    self.activationReturnValue = !self.activationReturnValue;
+    
+    if (self.activationReturnValue == YES) {
+        self.backgroundColor = [UIColor systemTealColor];
+        self.label.text = @"Returns YES";
+    } else {
+        self.backgroundColor = [UIColor systemTealColor];
+        self.label.text = @"Returns NO";
+    }
+    [self setNeedsLayout];
+}
+
+-(void)layoutSubviews {
+    [super layoutSubviews];
+    [self.label sizeToFit];
+    self.label.frame = CGRectMake((self.frame.size.width - self.label.frame.size.width) / 2,
+                                  (self.frame.size.height - self.label.frame.size.height) / 2,
+                                  self.label.frame.size.width,
+                                  self.label.frame.size.height);
+    
+    [self.activationSwitch sizeToFit];
+    self.activationSwitch.frame = CGRectMake((self.frame.size.width - self.activationSwitch.frame.size.width) / 2,
+                                             CGRectGetMaxY(self.label.frame) + 10 ,
+                                             self.activationSwitch.frame.size.width,
+                                             self.activationSwitch.frame.size.width);
+}
+
+- (BOOL)accessibilityActivate {
+    self.activationCount += 1;
+    self.accessibilityValue = [NSString stringWithFormat:@"Activated: %i", self.activationCount];
+    return self.activationReturnValue;
+}
+
+@end
+
+@interface AccessibilityViewController : UIViewController
+@property (weak, nonatomic) IBOutlet AccessibilityViewController_AccessibilityView *accessibilityView;
+
+@end
+
+@implementation AccessibilityViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+    self.accessibilityView.accessibilityCustomActions = [self customActions];
+}
+
+
+- (NSArray *)customActions
+{
+    NSArray *actions = @[self.customActionWithoutArgument, self.customActionWithArgument, self.customActionThatFails];
+    if (@available(iOS 13.0, *)) {
+        return [actions arrayByAddingObject: self.customActionWithBlock];
+    }
+    return actions;
+}
+
+- (UIAccessibilityCustomAction *)customActionWithBlock
+{
+    if (@available(iOS 13.0, *)) {
+        return [[UIAccessibilityCustomAction alloc] initWithName: @"Action With block handler"
+                                                   actionHandler:^BOOL(UIAccessibilityCustomAction * _Nonnull customAction) {
+            return YES;
+        }];
+    } else {
+        return  nil;
+    }
+}
+
+- (UIAccessibilityCustomAction *)customActionWithoutArgument
+{
+    return [[UIAccessibilityCustomAction alloc] initWithName:@"Action without argument" target:self selector:@selector(customActionHandlerWithoutArgument)];
+}
+
+- (UIAccessibilityCustomAction *)customActionWithArgument
+{
+    return [[UIAccessibilityCustomAction alloc] initWithName:@"Action with argument" target:self selector:@selector(customActionHandlerWithArgument:)];
+}
+
+- (UIAccessibilityCustomAction *)customActionThatFails
+{
+    return [[UIAccessibilityCustomAction alloc] initWithName:@"Action that fails" target:self selector:@selector(customActionThatFails)];
+}
+
+- (BOOL)customActionHandlerWithoutArgument
+{
+    return YES;
+}
+
+- (BOOL)customActionHandlerWithArgument:(UIAccessibilityCustomAction *)action
+{
+    return YES;
+}
+
+- (BOOL)customActionHandlerThatFails
+{
+    return NO;
+}
+
+@end

--- a/TestHost/Base.lproj/MainStoryboard.storyboard
+++ b/TestHost/Base.lproj/MainStoryboard.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -268,12 +268,32 @@
                                             <segue destination="wfS-d5-u9A" kind="push" id="KGl-dR-pvj"/>
                                         </connections>
                                     </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="eBH-6d-MCS" userLabel="Cell">
+                                        <rect key="frame" x="0.0" y="534" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="eBH-6d-MCS" id="pFd-sC-VuX">
+                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Accessibility" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wWK-QL-AY7" userLabel="Background">
+                                                    <rect key="frame" x="12" y="11" width="176" height="24"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                                    <color key="textColor" systemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="fPv-az-BYM" kind="push" id="T9l-gh-58A"/>
+                                        </connections>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Modal Views" id="BQ9-XW-OMR">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="aZL-Y3-JTh" style="IBUITableViewCellStyleDefault" id="mMs-db-L2N">
-                                        <rect key="frame" x="0.0" y="612" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="656" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="mMs-db-L2N" id="2wX-T8-gI5">
                                             <rect key="frame" x="0.0" y="0.0" width="383.5" height="44"/>
@@ -291,7 +311,7 @@
                                         <color key="backgroundColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="LBl-IG-qRp" userLabel="Cell">
-                                        <rect key="frame" x="0.0" y="656" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="700" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LBl-IG-qRp" id="sV5-Dt-8Xm">
                                             <rect key="frame" x="0.0" y="0.0" width="383.5" height="44"/>
@@ -311,7 +331,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="Iob-Ej-M2H" style="IBUITableViewCellStyleDefault" id="agW-My-ENo">
-                                        <rect key="frame" x="0.0" y="700" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="744" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="agW-My-ENo" id="WtX-aN-VEy">
                                             <rect key="frame" x="0.0" y="0.0" width="383.5" height="44"/>
@@ -329,7 +349,7 @@
                                         <color key="backgroundColor" red="1" green="0.99997437000274658" blue="0.99999129772186279" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="ccr-xP-4ye" style="IBUITableViewCellStyleDefault" id="BI1-7X-aTq">
-                                        <rect key="frame" x="0.0" y="744" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="788" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="BI1-7X-aTq" id="PZl-6O-yUK">
                                             <rect key="frame" x="0.0" y="0.0" width="383.5" height="44"/>
@@ -2142,6 +2162,35 @@ Line Break
             </objects>
             <point key="canvasLocation" x="1305.7971014492755" y="971.65178571428567"/>
         </scene>
+        <!--Accessibility View Controller-->
+        <scene sceneID="Kfp-q8-qL5">
+            <objects>
+                <viewController id="fPv-az-BYM" customClass="AccessibilityViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="shx-5S-eMw"/>
+                        <viewControllerLayoutGuide type="bottom" id="u8z-PF-PIc"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="HtV-3z-P6p" customClass="AccessibilityViewController_AccessibilityView">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="804"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Qj-vC-6qF">
+                                <rect key="frame" x="72" y="367" width="240" height="128"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemPurpleColor"/>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="4hs-zD-BI5"/>
+                    <connections>
+                        <outlet property="accessibilityView" destination="HtV-3z-P6p" id="fRH-1a-uNU"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="N4E-Ay-Je9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1967" y="1449"/>
+        </scene>
         <!--Animation View Controller-->
         <scene sceneID="odg-A0-FBB">
             <objects>
@@ -2187,10 +2236,10 @@ Line Break
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBrownColor">
-            <color red="0.63529411759999999" green="0.51764705879999995" blue="0.36862745099999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.63529411764705879" green="0.51764705882352946" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemPurpleColor">
-            <color red="0.68627450980000004" green="0.32156862749999998" blue="0.87058823529999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.68627450980392157" green="0.32156862745098042" blue="0.87058823529411766" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/TestHost/TapViewController.m
+++ b/TestHost/TapViewController.m
@@ -29,7 +29,6 @@
     self.lineBreakLabel.accessibilityLabel = @"A\nB\nC\n\n";
 	self.stepper.isAccessibilityElement = YES;
 	self.stepper.accessibilityLabel = @"theStepper";
-    self.stepper.accessibilityCustomActions = self.customActions;
 }
 
 - (void)memoryWarningNotification:(NSNotification *)notification
@@ -96,56 +95,7 @@
 }
 
 
-- (NSArray *)customActions
-{
-    NSArray *actions = @[self.customActionWithoutArgument, self.customActionWithArgument, self.customActionThatFails];
-    if (@available(iOS 13.0, *)) {
-        return [actions arrayByAddingObject: self.customActionWithBlock];
-    }
-    return actions;
-}
 
-- (UIAccessibilityCustomAction *)customActionWithBlock
-{
-    if (@available(iOS 13.0, *)) {
-        return [[UIAccessibilityCustomAction alloc] initWithName: @"Action With block handler"
-                                                   actionHandler:^BOOL(UIAccessibilityCustomAction * _Nonnull customAction) {
-            return YES;
-        }];
-    } else {
-        return  nil;
-    }
-}
-
-- (UIAccessibilityCustomAction *)customActionWithoutArgument
-{
-    return [[UIAccessibilityCustomAction alloc] initWithName:@"Action without argument" target:self selector:@selector(customActionHandlerWithoutArgument)];
-}
-
-- (UIAccessibilityCustomAction *)customActionWithArgument
-{
-    return [[UIAccessibilityCustomAction alloc] initWithName:@"Action with argument" target:self selector:@selector(customActionHandlerWithArgument:)];
-}
-
-- (UIAccessibilityCustomAction *)customActionThatFails
-{
-    return [[UIAccessibilityCustomAction alloc] initWithName:@"Action that fails" target:self selector:@selector(customActionThatFails)];
-}
-
-- (BOOL)customActionHandlerWithoutArgument
-{
-    return YES;
-}
-
-- (BOOL)customActionHandlerWithArgument:(UIAccessibilityCustomAction *)action
-{
-    return YES;
-}
-
-- (BOOL)customActionHandlerThatFails
-{
-    return NO;
-}
 
 #pragma mark - <UIImagePickerControllerDelegate>
 

--- a/Tests/AccessibilityActivationTests_ViewTestActor.m
+++ b/Tests/AccessibilityActivationTests_ViewTestActor.m
@@ -1,0 +1,36 @@
+//
+//  AccessibilityActivateTests_ViewTestActor.m
+//  KIF Tests
+//
+//  Created by Alex Odawa on 09/07/2024.
+//
+
+#import <KIF/KIF.h>
+
+@interface AccessibilityActivateTests_ViewTestActor : KIFTestCase
+@end
+
+
+@implementation AccessibilityActivateTests_ViewTestActor
+
+- (void)beforeEach
+{
+    [[viewTester usingLabel:@"Accessibility"] tap];
+}
+
+- (void)afterEach
+{
+    [[[viewTester usingLabel:@"Test Suite"] usingTraits:UIAccessibilityTraitButton] tap];
+}
+
+- (void)testAccessibilityActivate
+{
+    [[viewTester usingLabel:@"AccessibilityView"] performAccessibilityActivateWithExpectedResult: YES];
+    [[viewTester usingValue:@"Activated: 1"] waitForView];
+    
+    [[viewTester usingLabel:@"AccessibilitySwitch"] setSwitchOn:false];
+    [[viewTester usingLabel:@"AccessibilityView"] performAccessibilityActivateWithExpectedResult: NO];
+    [[viewTester usingValue:@"Activated: 2"] waitForView];
+}
+
+@end

--- a/Tests/CustomActionTests_ViewTestActor.m
+++ b/Tests/CustomActionTests_ViewTestActor.m
@@ -15,7 +15,7 @@
 
 - (void)beforeEach
 {
-    [[viewTester usingLabel:@"Tapping"] tap];
+    [[viewTester usingLabel:@"Accessibility"] tap];
 }
 
 - (void)afterEach
@@ -26,14 +26,14 @@
 - (void)testCustomActions
 {
     if (@available(iOS 13.0, *)) {
-        [[viewTester usingLabel:@"theStepper"] activateCustomActionWithName:@"Action With block handler"];
+        [[viewTester usingLabel:@"AccessibilityView"] activateCustomActionWithName:@"Action With block handler"];
     }
     
     for (NSString *name in @[@"Action without argument", @"Action with argument"]) {
-        [[viewTester usingLabel:@"theStepper"] activateCustomActionWithName:name];
+        [[viewTester usingLabel:@"AccessibilityView"] activateCustomActionWithName:name];
     }
     
-    [[viewTester usingLabel:@"theStepper"] activateCustomActionWithName:@"Action that fails" expectedResult:NO];
+    [[viewTester usingLabel:@"AccessibilityView"] activateCustomActionWithName:@"Action that fails" expectedResult:NO];
 }
 
 @end


### PR DESCRIPTION
Some of my recent accessibility work in our design system results in accessibility elements that abstract away the interactivity of some underlying controls. These elements subsume the interactivity of their children and re-expose the functionality via `accessibilityActivate()`.

Unfortunately this breaks KIF matching resulting in the need for an escape hatch to allow activation of elements with greater complexity.

performAccessibilityActivateWithExpectedResult calls accessibilityElement() on the found element and compares its result to the expectation. 