### PR TITLE
Use accessibilityActivationPoint when determining where to tap elements.

### DIFF
--- a/Sources/KIF/Classes/KIFUITestActor.m
+++ b/Sources/KIF/Classes/KIFUITestActor.m
@@ -1673,6 +1673,14 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
 
 - (CGPoint) tappablePointInElement:(UIAccessibilityElement *)element andView:(UIView *)view
 {
+    // AccessibilityActivationPoint indicates where on the element assistive technologies should issue a tap event to activate the element.
+    // In the case where the property has not been explicitly set. The default value is the midpoint of the accessibility frame.
+    UIView *hitView = [view.window hitTest:element.accessibilityActivationPoint withEvent:nil];
+    if ([view isTappableWithHitTestResultView:hitView]) {
+        return [view.window convertPoint:element.accessibilityActivationPoint toView:view];
+    }
+    
+    // If the element's AccessibilityActivationPoint is not tappable, attempt to find a suitable tappable point within the element's frame.
     CGRect elementFrame = [self elementFrameForElement:element andView:view];
     CGPoint tappablePoint = [view tappablePointInRect:elementFrame];
 

--- a/TestHost/AccessibilityViewController.m
+++ b/TestHost/AccessibilityViewController.m
@@ -11,9 +11,9 @@
 @property (nonatomic, assign) BOOL activationReturnValue;
 @property (nonatomic, assign) int activationCount;
 
-@property (nonatomic, strong) UILabel *label;
+@property (nonatomic, strong) UILabel *topLabel;
+@property (nonatomic, strong) UILabel *swtichLabel;
 @property (nonatomic, strong) UISwitch *activationSwitch;
-
 
 @end
 
@@ -24,16 +24,16 @@
     self = [super initWithCoder:coder];
     self.isAccessibilityElement = YES;
     self.accessibilityLabel = @"AccessibilityView";
-    
-    
+        
     self.activationReturnValue = YES;
-
-    self.label = [[UILabel alloc] initWithFrame: CGRectZero];
-    [self addSubview:self.label];
-
-    self.backgroundColor = [UIColor systemTealColor];
-    self.label.text = @"Returns YES";
     
+    self.topLabel = [[UILabel alloc] initWithFrame: CGRectZero];
+    self.topLabel.text = @"Awaiting activation or tap";
+    [self addSubview:self.topLabel];
+
+    self.swtichLabel = [[UILabel alloc] initWithFrame: CGRectZero];
+    self.swtichLabel.text = @"Returns YES";
+    [self addSubview:self.swtichLabel];
     
     self.activationSwitch = [[UISwitch alloc] initWithFrame: CGRectZero];
     [self addSubview: self.activationSwitch];
@@ -50,33 +50,52 @@
     
     if (self.activationReturnValue == YES) {
         self.backgroundColor = [UIColor systemTealColor];
-        self.label.text = @"Returns YES";
+        self.swtichLabel.text = @"Returns YES";
     } else {
         self.backgroundColor = [UIColor systemTealColor];
-        self.label.text = @"Returns NO";
+        self.swtichLabel.text = @"Returns NO";
     }
     [self setNeedsLayout];
 }
 
 -(void)layoutSubviews {
     [super layoutSubviews];
-    [self.label sizeToFit];
-    self.label.frame = CGRectMake((self.frame.size.width - self.label.frame.size.width) / 2,
-                                  (self.frame.size.height - self.label.frame.size.height) / 2,
-                                  self.label.frame.size.width,
-                                  self.label.frame.size.height);
+    [self.topLabel sizeToFit];
+    self.topLabel.frame = CGRectMake(20,
+                                     20,
+                                     self.topLabel.frame.size.width,
+                                     self.topLabel.frame.size.height);
+    
+    [self.swtichLabel sizeToFit];
+    self.swtichLabel.frame = CGRectMake(20,
+                                        CGRectGetMaxY(self.topLabel.frame) + 40,
+                                        self.swtichLabel.frame.size.width,
+                                        self.swtichLabel.frame.size.height);
     
     [self.activationSwitch sizeToFit];
-    self.activationSwitch.frame = CGRectMake((self.frame.size.width - self.activationSwitch.frame.size.width) / 2,
-                                             CGRectGetMaxY(self.label.frame) + 10 ,
+    self.activationSwitch.frame = CGRectMake(20,
+                                             CGRectGetMaxY(self.swtichLabel.frame) + 10 ,
                                              self.activationSwitch.frame.size.width,
                                              self.activationSwitch.frame.size.width);
+    
+}
+
+- (NSString *)accessibilityValue {
+   return self.topLabel.text;
 }
 
 - (BOOL)accessibilityActivate {
     self.activationCount += 1;
-    self.accessibilityValue = [NSString stringWithFormat:@"Activated: %i", self.activationCount];
+    self.topLabel.text = [NSString stringWithFormat:@"Activated: %i", self.activationCount];
+    [self setNeedsLayout];
     return self.activationReturnValue;
+}
+
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    CGPoint location = [[touches anyObject] locationInView: self];
+    self.topLabel.text =  [NSString stringWithFormat:@"Tapped - x:%.04f, y:%.04f", location.x, location.y];
+    [self setNeedsLayout];
 }
 
 @end

--- a/TestHost/Base.lproj/MainStoryboard.storyboard
+++ b/TestHost/Base.lproj/MainStoryboard.storyboard
@@ -2170,13 +2170,13 @@ Line Break
                         <viewControllerLayoutGuide type="top" id="shx-5S-eMw"/>
                         <viewControllerLayoutGuide type="bottom" id="u8z-PF-PIc"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="HtV-3z-P6p" customClass="AccessibilityViewController_AccessibilityView">
+                    <view key="view" contentMode="scaleToFill" id="HtV-3z-P6p">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="804"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Qj-vC-6qF">
-                                <rect key="frame" x="72" y="367" width="240" height="128"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Qj-vC-6qF" customClass="AccessibilityViewController_AccessibilityView">
+                                <rect key="frame" x="20" y="76" width="374" height="657"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" systemColor="systemPurpleColor"/>
                             </view>
                         </subviews>
@@ -2184,12 +2184,12 @@ Line Break
                     </view>
                     <navigationItem key="navigationItem" id="4hs-zD-BI5"/>
                     <connections>
-                        <outlet property="accessibilityView" destination="HtV-3z-P6p" id="fRH-1a-uNU"/>
+                        <outlet property="accessibilityView" destination="1Qj-vC-6qF" id="YDb-m4-vKE"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="N4E-Ay-Je9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1967" y="1449"/>
+            <point key="canvasLocation" x="1966.6666666666667" y="1448.4375"/>
         </scene>
         <!--Animation View Controller-->
         <scene sceneID="odg-A0-FBB">

--- a/Tests/AccessibilityActivationTests_ViewTestActor.m
+++ b/Tests/AccessibilityActivationTests_ViewTestActor.m
@@ -6,6 +6,7 @@
 //
 
 #import <KIF/KIF.h>
+#import <UIKit/UIAccessibility.h>
 
 @interface AccessibilityActivateTests_ViewTestActor : KIFTestCase
 @end
@@ -31,6 +32,19 @@
     [[viewTester usingLabel:@"AccessibilitySwitch"] setSwitchOn:false];
     [[viewTester usingLabel:@"AccessibilityView"] performAccessibilityActivateWithExpectedResult: NO];
     [[viewTester usingValue:@"Activated: 2"] waitForView];
+}
+
+- (void)testAccessibilityActiationPoint
+{
+    UIView *view = [[viewTester usingValue: @"Awaiting activation or tap"] waitForView];
+    [view setAccessibilityActivationPoint: [view.window convertPoint:CGPointMake(25.0, 50.0) fromView:view]];
+    
+    [[viewTester usingLabel: @"AccessibilityView"] tap];
+    [[viewTester usingValue:@"Tapped - x:25.0000, y:50.0000"] waitForView];
+    
+    [view setAccessibilityActivationPoint: [view.window convertPoint:CGPointMake(50.0, 25.0) fromView:view]];
+    [[viewTester usingLabel: @"AccessibilityView"] tap];
+    [[viewTester usingValue:@"Tapped - x:50.0000, y:25.0000"] waitForView];
 }
 
 @end


### PR DESCRIPTION
If a call to `accessibilityActivate()` returns false, VoiceOver (and related assistive technologies) will issue a tap event to the element as a secondary attempt to activate it via the the standard touch pipeline. The `accessibilityActivationPoint` can be set on elements to instruct assistive technologies where specifically on the screen to issue this tap event. 

We should take this property into consideration when deciding the same. This is particularly important when the value is set deliberately. Failing to do so can cause taps to be issued that don't properly activate the element. 

In the case where the property has not been explicitly set. The default value is the midpoint of the accessibility frame, which itself has a default value equivalent to self.frame this makes the change functionally equivalent to the following line which returns the midpoint of the frame. 