### PR TITLE
Xcode 16 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ jobs:
 
     - name: Validate podspec
       run: pod lib lint
-
   build_macos14:
     runs-on: macos-14
     strategy:
@@ -23,7 +22,9 @@ jobs:
           - { xcode_version: '14.3.1', simulator: 'name=iPad Air (5th generation),OS=16.4', run_extra_validations: 'false' }
           - { xcode_version: '14.3.1', simulator: 'name=iPhone 14,OS=16.4', run_extra_validations: 'false' }
           - { xcode_version: '15.4', simulator: 'name=iPad Air (5th generation),OS=17.5', run_extra_validations: 'false' }
-          - { xcode_version: '15.4', simulator: 'name=iPhone 15,OS=17.5', run_extra_validations: 'true' }
+          - { xcode_version: '15.4', simulator: 'name=iPhone 15,OS=17.5', run_extra_validations: 'false' }
+          - { xcode_version: '16.0', simulator: 'name=iPad Air (5th generation),OS=18.0', run_extra_validations: 'false' }
+          - { xcode_version: '16.0', simulator: 'name=iPhone 16,OS=18.0', run_extra_validations: 'true' }
     steps:
     - name: Checkout Project
       uses: actions/checkout@v1

--- a/Sources/KIF/Additions/NSObject+KIFSwizzle.m
+++ b/Sources/KIF/Additions/NSObject+KIFSwizzle.m
@@ -17,6 +17,9 @@
     Method originalMethod = class_getInstanceMethod(class, originalSEL);
     Method swizzledMethod = class_getInstanceMethod(class, swizzledSEL);
 
+    NSAssert(originalMethod != nil, @"The original method for selector '%@' couldn't be found", NSStringFromSelector(originalSEL));
+    NSAssert(swizzledMethod != nil, @"The swizzled method for selector '%@' couldn't be found", NSStringFromSelector(swizzledSEL));
+
     method_exchangeImplementations(originalMethod, swizzledMethod);
 }
 

--- a/Sources/KIF/Additions/UIWindow+KIFSwizzle.m
+++ b/Sources/KIF/Additions/UIWindow+KIFSwizzle.m
@@ -9,23 +9,31 @@
 #import "UIApplication-KIFAdditions.h"
 #import "NSObject+KIFSwizzle.h"
 
+@interface UIWindow ()
+
+- (instancetype)_initWithFrame:(CGRect)rect debugName:(NSString *)debugName windowScene:(UIWindowScene *)windowScene API_AVAILABLE(ios(13));
+
+@end
+
+
 @implementation UIWindow (KIFSwizzle)
 
 + (void)load
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        [self swizzleSEL:@selector(init) withSEL:@selector(swizzle_init)];
-        [self swizzleSEL:@selector(becomeKeyWindow) withSEL:@selector(swizzle_becomeKeyWindow)];
-        if (@available(iOS 13.0, *)) {
-            [self swizzleSEL:@selector(initWithWindowScene:) withSEL:@selector(swizzle_initWithWindowScene:)];
+        if (@available(iOS 13, *)) {
+            [self swizzleSEL:@selector(_initWithFrame:debugName:windowScene:) withSEL:@selector(swizzle__initWithFrame:debugName:windowScene:)];
+        } else {
+            [self swizzleSEL:@selector(init) withSEL:@selector(swizzle_init)];
         }
+        [self swizzleSEL:@selector(becomeKeyWindow) withSEL:@selector(swizzle_becomeKeyWindow)];
     });
 }
 
-- (instancetype)swizzle_initWithWindowScene:(UIWindowScene *)scene API_AVAILABLE(ios(13))
+- (instancetype)swizzle__initWithFrame:(CGRect)rect debugName:(NSString *)debugName windowScene:(UIWindowScene *)windowScene API_AVAILABLE(ios(13))
 {
-    UIWindow *window = [self swizzle_initWithWindowScene:scene];
+    UIWindow *window = [self swizzle__initWithFrame:rect debugName:debugName windowScene:windowScene];
     window.layer.speed = [UIApplication sharedApplication].animationSpeed;
 
     return window;

--- a/Sources/KIF/Classes/KIFUITestActor.m
+++ b/Sources/KIF/Classes/KIFUITestActor.m
@@ -230,9 +230,8 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
             [self waitForTimeInterval:maximumWaitingTimeInterval relativeToAnimationSpeed:YES];
         }
     } else {
-
         // Wait for the view to stabilize and give them a chance to start animations before we wait for them.
-        [self waitForTimeInterval:stabilizationTime relativeToAnimationSpeed:YES];
+        [self waitForTimeInterval:MAX(stabilizationTime / [UIApplication sharedApplication].animationSpeed, 0.25) relativeToAnimationSpeed:NO];
         maximumWaitingTimeInterval -= stabilizationTime;
 
         NSTimeInterval startTime = [NSDate timeIntervalSinceReferenceDate];

--- a/Tests/AccessibilityIdentifierTests.m
+++ b/Tests/AccessibilityIdentifierTests.m
@@ -49,14 +49,14 @@
 - (void)testLongPressingViewWithAccessibilityIdentifier
 {
     [tester tapViewWithAccessibilityIdentifier:@"idGreeting"];
-    [tester longPressViewWithAccessibilityIdentifier:@"idGreeting" duration:2];
+    [tester longPressViewWithAccessibilityIdentifier:@"idGreeting" duration:1];
     [tester tapViewWithAccessibilityLabel:@"Select All"];
 }
 
 - (void)testEnteringTextIntoViewWithAccessibilityIdentifier
 {
     [tester tapViewWithAccessibilityIdentifier:@"idGreeting"];
-    [tester longPressViewWithAccessibilityIdentifier:@"idGreeting" duration:2];
+    [tester longPressViewWithAccessibilityIdentifier:@"idGreeting" duration:1];
     [tester waitForAnimationsToFinish];
     [tester tapViewWithAccessibilityLabel:@"Select All"];
     [tester tapViewWithAccessibilityLabel:@"Cut"];
@@ -77,7 +77,7 @@
 - (void)testSettingTextIntoViewWithAccessibilityIdentifier
 {
     UIView *greetingView = [tester waitForViewWithAccessibilityIdentifier:@"idGreeting"];
-    [tester longPressViewWithAccessibilityIdentifier:@"idGreeting" duration:2];
+    [tester longPressViewWithAccessibilityIdentifier:@"idGreeting" duration:1];
     [tester setText:@"Yo" intoViewWithAccessibilityIdentifier:@"idGreeting"];
     [tester expectView:greetingView toContainText:@"Yo"];
     [tester setText:@"Hello" intoViewWithAccessibilityIdentifier:@"idGreeting"];

--- a/Tests/AccessibilityIdentifierTests_ViewTestActor.m
+++ b/Tests/AccessibilityIdentifierTests_ViewTestActor.m
@@ -49,14 +49,14 @@
 - (void)testLongPressingViewWithAccessibilityIdentifier
 {
     [[viewTester usingIdentifier:@"idGreeting"] tap];
-    [[viewTester usingIdentifier:@"idGreeting"] longPressWithDuration:2];
+    [[viewTester usingIdentifier:@"idGreeting"] longPressWithDuration:1];
     [[viewTester usingLabel:@"Select All"] tap];
 }
 
 - (void)testEnteringTextIntoViewWithAccessibilityIdentifier
 {
     [[viewTester usingIdentifier:@"idGreeting"] tap];
-    [[viewTester usingIdentifier:@"idGreeting"] longPressWithDuration:2];
+    [[viewTester usingIdentifier:@"idGreeting"] longPressWithDuration:1];
     [[viewTester usingLabel:@"Select All"] tap];
     [[viewTester usingLabel:@"Cut"] tap];
     [[viewTester usingIdentifier:@"idGreeting"] enterText:@"Yo"];

--- a/Tests/LongPressTests.m
+++ b/Tests/LongPressTests.m
@@ -28,21 +28,21 @@
 - (void)testLongPressingViewWithAccessibilityLabel
 {
     [tester tapViewWithAccessibilityLabel:@"Greeting"];
-    [tester longPressViewWithAccessibilityLabel:@"Greeting" duration:2];
+    [tester longPressViewWithAccessibilityLabel:@"Greeting" duration:1];
     [tester tapViewWithAccessibilityLabel:@"Select All"];
 }
 
 - (void)testLongPressingViewViewWithTraits
 {
     [tester tapViewWithAccessibilityLabel:@"Greeting"];
-    [tester longPressViewWithAccessibilityLabel:@"Greeting" value:@"Hello" duration:2];
+    [tester longPressViewWithAccessibilityLabel:@"Greeting" value:@"Hello" duration:1];
     [tester tapViewWithAccessibilityLabel:@"Select All"];
 }
 
 - (void)testLongPressingViewViewWithValue
 {
     [tester tapViewWithAccessibilityLabel:@"Greeting"];
-    [tester longPressViewWithAccessibilityLabel:@"Greeting" value:@"Hello" traits:UIAccessibilityTraitUpdatesFrequently duration:2];
+    [tester longPressViewWithAccessibilityLabel:@"Greeting" value:@"Hello" traits:UIAccessibilityTraitUpdatesFrequently duration:1];
     [tester tapViewWithAccessibilityLabel:@"Select All"];
 }
 

--- a/Tests/LongPressTests_ViewTestActor.m
+++ b/Tests/LongPressTests_ViewTestActor.m
@@ -28,21 +28,21 @@
 - (void)testLongPressingViewWithAccessibilityLabel
 {
     [[viewTester usingLabel:@"Greeting"] tap];
-    [[viewTester usingLabel:@"Greeting"] longPressWithDuration:2];
+    [[viewTester usingLabel:@"Greeting"] longPressWithDuration:1];
     [[viewTester usingLabel:@"Select All"] tap];
 }
 
 - (void)testLongPressingViewViewWithTraits
 {
     [[viewTester usingLabel:@"Greeting"] tap];
-    [[[viewTester usingLabel:@"Greeting"] usingValue:@"Hello"] longPressWithDuration:2];
+    [[[viewTester usingLabel:@"Greeting"] usingValue:@"Hello"] longPressWithDuration:1];
     [[viewTester usingLabel:@"Select All"] tap];
 }
 
 - (void)testLongPressingViewViewWithValue
 {
     [[viewTester usingLabel:@"Greeting"] tap];
-    [[[[viewTester usingLabel:@"Greeting"] usingValue:@"Hello"] usingTraits:UIAccessibilityTraitUpdatesFrequently] longPressWithDuration:2];
+    [[[[viewTester usingLabel:@"Greeting"] usingValue:@"Hello"] usingTraits:UIAccessibilityTraitUpdatesFrequently] longPressWithDuration:1];
     [[viewTester usingLabel:@"Select All"] tap];
 }
 

--- a/Tests/TypingTests.m
+++ b/Tests/TypingTests.m
@@ -39,7 +39,7 @@
 - (void)testEnteringTextIntoFirstResponder
 {
     [tester tapViewWithAccessibilityLabel:@"Greeting"];
-    [tester longPressViewWithAccessibilityLabel:@"Greeting" value:@"Hello" duration:2];
+    [tester longPressViewWithAccessibilityLabel:@"Greeting" value:@"Hello" duration:1];
     [tester tapViewWithAccessibilityLabel:@"Select All"];
     [tester enterTextIntoCurrentFirstResponder:@"Yo"];
     [tester waitForViewWithAccessibilityLabel:@"Greeting" value:@"Yo" traits:UIAccessibilityTraitNone];
@@ -53,7 +53,7 @@
 - (void)testEnteringTextIntoViewWithAccessibilityLabel
 {
     [tester tapViewWithAccessibilityLabel:@"Greeting"];
-    [tester longPressViewWithAccessibilityLabel:@"Greeting" value:@"Hello" duration:2];
+    [tester longPressViewWithAccessibilityLabel:@"Greeting" value:@"Hello" duration:1];
     [tester tapViewWithAccessibilityLabel:@"Select All"];
     [tester tapViewWithAccessibilityLabel:@"Cut"];
     [tester enterText:@"Yo" intoViewWithAccessibilityLabel:@"Greeting"];
@@ -110,7 +110,7 @@
 - (void)testSettingTextIntoViewWithAccessibilityLabel
 {
     UIView *greetingView = [tester waitForViewWithAccessibilityLabel:@"Greeting"];
-    [tester longPressViewWithAccessibilityLabel:@"Greeting" duration:2];
+    [tester longPressViewWithAccessibilityLabel:@"Greeting" duration:1];
     [tester setText:@"Yo" intoViewWithAccessibilityLabel:@"Greeting"];
     [tester expectView:greetingView toContainText:@"Yo"];
     [tester setText:@"Hello" intoViewWithAccessibilityLabel:@"Greeting"];

--- a/Tests/TypingTests_ViewTestActor.m
+++ b/Tests/TypingTests_ViewTestActor.m
@@ -40,7 +40,7 @@
 - (void)testEnteringTextIntoFirstResponder
 {
     [tester tapViewWithAccessibilityLabel:@"Greeting"];
-    [[[viewTester usingLabel:@"Greeting"] usingValue:@"Hello"] longPressWithDuration:2];
+    [[[viewTester usingLabel:@"Greeting"] usingValue:@"Hello"] longPressWithDuration:1];
     [[viewTester usingLabel:@"Select All"] tap];
     [[viewTester usingFirstResponder] enterText:@"Yo"];
     [[[viewTester usingLabel:@"Greeting"] usingValue:@"Yo"] waitForView];
@@ -54,7 +54,7 @@
 - (void)testEnteringTextIntoViewWithAccessibilityLabel
 {
     [tester tapViewWithAccessibilityLabel:@"Greeting"];
-    [[[viewTester usingLabel:@"Greeting"] usingValue:@"Hello"] longPressWithDuration:2];
+    [[[viewTester usingLabel:@"Greeting"] usingValue:@"Hello"] longPressWithDuration:1];
     [[viewTester usingLabel:@"Select All"] tap];
     [[viewTester usingLabel:@"Cut"] tap];
     [[viewTester usingLabel:@"Greeting"] enterText:@"Yo"];


### PR DESCRIPTION
Configure KIF CI to run on Xcode 16.0 & iOS 18.0, bringing us to a total of 6 CI configurations. I've moved the one that does the extra validation to the Xcode 16 build part. If I could test iOS 16 w/ Xcode 15, I'd drop support for Xcode 14.3.1, but that isn't set up on GH hosted runners and I think it is worth still testing on iOS 16.

Aside from needing to land the fix for UICollectionView asserts in #1307, `TypingTests testEnteringTextIntoFirstResponder` was also failing on CI and required some behavior changes to get them working reliably. The behavior was that we were attempting to tap "Select All" after a long press, but we weren't waiting long enough for the popover control to appear. Tapping too early was then dismissing the popover rather than actually performing a "Select All" operation.

The KIF framework functional changes are:
* Ensure that all windows (including the UITextEffectsWindow) get layer speed multipliers applied
  * I noticed that the text effects window wasn't matching the speed of the main window when increasing the animation speed. This is mostly a performance optimization, but it also causes issues because we use the layer speed as a scale multiplier for the animation stabilization time.
* Improve detection of in progress animations
  * The test wasn't correctly waiting until the popover control fully appeared with "Slow Animations" setting enabled on the iOS simulator. They also wouldn't behave correctly with the layer speed cranked up to 100x. The change in this commit works more reliably, though it does rely on some non-public Apple APIs.
* Set .25s min for animation stabilization wait time, regardless of layer speed
  * When the animation layer speed is increased to 100x, there is no animation used for presenting the text popover. This is a problem though, because there is still some delay before it is presented. I went back and forth between not scaling the stabilization time or this approach, but this seems like the better route.

I also took this opportunity to speed up the test execution time by a couple seconds by dropping 2 second `longPress` actions to be 1s instead. This wasn't necessary, but I was running some tests that used long presses a lot and it seemed like a nice small improvement.

You can review each of these changes in the individual commits, which I do not plan to squash on merging this PR.