### PR TITLE
Fix UICollectionView cell enumeration hitting asserts in Xcode 16

### DIFF
--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -17,6 +17,9 @@
 #import "KIFUITestActor.h"
 #import <WebKit/WebKit.h>
 
+#define DRAG_TOUCH_DELAY 0.01
+#define CELL_SCROLL_DELAY_STABILIZATION 0.05
+
 double KIFDegreesToRadians(double deg) {
     return (deg) / 180.0 * M_PI;
 }
@@ -310,7 +313,6 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                 }
             }];
 
-            CFTimeInterval delay = 0.05;
             for (NSUInteger section = 0, numberOfSections = [tableView numberOfSections]; section < numberOfSections; section++) {
                 for (NSUInteger row = 0, numberOfRows = [tableView numberOfRowsInSection:section]; row < numberOfRows; row++) {
                     if (!self.window) {
@@ -328,7 +330,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                     }
 
                     @autoreleasepool {
-                        // Scroll to the cell and wait for the animation to complete. Using animations here may not be optimal.
+                        // Scroll to the cell and wait for the animation to complete.
                         CGRect sectionRect = [tableView rectForRowAtIndexPath:indexPath];
                         [tableView scrollRectToVisible:sectionRect animated:NO];
 
@@ -342,24 +344,25 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                     }
 
                     // Note: using KIFRunLoopRunInModeRelativeToAnimationSpeed here may cause tests to stall
-                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, delay, false);
+                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, CELL_SCROLL_DELAY_STABILIZATION, false);
                     return [self accessibilityElementMatchingBlock:matchBlock disableScroll:NO];
                 }
             }
 
 			//if we're in a picker (scrollView), let's make sure we set the position back to how it was last set.
-            if(scrollView != nil && scrollContentOffset.x != -1.0)
+            if (scrollView != nil && scrollContentOffset.x != -1.0)
             {
                 [scrollView setContentOffset:scrollContentOffset];
             } else {
                 [tableView setContentOffset:initialPosition.origin];
             }
-            CFRunLoopRunInMode(UIApplicationCurrentRunMode, delay, false);
+
+            CFRunLoopRunInMode(UIApplicationCurrentRunMode, CELL_SCROLL_DELAY_STABILIZATION, false);
         } else if ([self isKindOfClass:[UICollectionView class]]) {
             UICollectionView *collectionView = (UICollectionView *)self;
-            
+            CGRect initialPosition = CGRectMake(collectionView.contentOffset.x, collectionView.contentOffset.y, collectionView.frame.size.width, collectionView.frame.size.height);
             NSArray *indexPathsForVisibleItems = [collectionView indexPathsForVisibleItems];
-            
+
             for (NSUInteger section = 0, numberOfSections = [collectionView numberOfSections]; section < numberOfSections; section++) {
                 for (NSUInteger item = 0, numberOfItems = [collectionView numberOfItemsInSection:section]; item < numberOfItems; item++) {
                     if (!self.window) {
@@ -373,36 +376,26 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                     }
 
                     @autoreleasepool {
-                        // Get the cell directly from the dataSource because UICollectionView will only vend visible cells
-                        UICollectionViewCell *cell = [collectionView.dataSource collectionView:collectionView cellForItemAtIndexPath:indexPath];
-
-                        // The cell contents might change just prior to being displayed, so we simulate the cell appearing onscreen
-                        if ([collectionView.delegate respondsToSelector:@selector(collectionView:willDisplayCell:forItemAtIndexPath:)]) {
-                            [collectionView.delegate collectionView:collectionView willDisplayCell:cell forItemAtIndexPath:indexPath];
-                        }
-                        
+                        CGRect visibleRect = [collectionView layoutAttributesForItemAtIndexPath:indexPath].frame;
+                        [collectionView scrollRectToVisible:visibleRect animated:NO];
+                        [collectionView layoutIfNeeded];
+                        UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
                         UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:NO];
-
-                        // Remove the cell from the collection view so that it doesn't stick around
-                        [cell removeFromSuperview];
                         
                         // Skip this cell if it isn't the one we're looking for
-                        // Sometimes we get cells with no size here which can cause an endless loop, so we ignore those
-                        if (!element || CGSizeEqualToSize(cell.frame.size, CGSizeZero)) {
+                        if (!element) {
                             continue;
                         }
                     }
                     
-                    // Scroll to the cell and wait for the animation to complete
-                    CGRect frame = [collectionView.collectionViewLayout layoutAttributesForItemAtIndexPath:indexPath].frame;
-                    [collectionView scrollRectToVisible:frame animated:YES];
                     // Note: using KIFRunLoopRunInModeRelativeToAnimationSpeed here may cause tests to stall
-                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, 0.5, false);
-                    
-                    // Now try finding the element again
+                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, CELL_SCROLL_DELAY_STABILIZATION, false);
                     return [self accessibilityElementMatchingBlock:matchBlock disableScroll:NO];
                 }
             }
+
+            [collectionView setContentOffset:initialPosition.origin];
+            CFRunLoopRunInMode(UIApplicationCurrentRunMode, CELL_SCROLL_DELAY_STABILIZATION, false);
         }
     }
 
@@ -591,8 +584,6 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 
     [[UIApplication sharedApplication] kif_sendEvent:event];
 }
-
-#define DRAG_TOUCH_DELAY 0.01
 
 - (void)longPressAtPoint:(CGPoint)point duration:(NSTimeInterval)duration
 {

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -380,6 +380,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                         [collectionView scrollRectToVisible:visibleRect animated:NO];
                         [collectionView layoutIfNeeded];
                         UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
+                        NSAssert(cell, @"UICollectionViewCell returned from 'cellForItemAtIndexPath' is unexpectedly nil!");
                         UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:NO];
                         
                         // Skip this cell if it isn't the one we're looking for
@@ -395,6 +396,7 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
             }
 
             [collectionView setContentOffset:initialPosition.origin];
+            [collectionView layoutIfNeeded];
             CFRunLoopRunInMode(UIApplicationCurrentRunMode, CELL_SCROLL_DELAY_STABILIZATION, false);
         }
     }


### PR DESCRIPTION
In Xcode 16, an assertion was to UICollectionView:

> Expected dequeued view to be returned to the collection view in preparation for display. When the collection view's data source is asked to provide a view for a given index path, ensure that a single view is dequeued and returned to the collection view. Avoid dequeuing views without a request from the collection view. For retrieving an existing view in the collection view, use -[UICollectionView cellForItemAtIndexPath:] or -[UICollectionView supplementaryViewForElementKind:atIndexPath:]. 

Rather than calling `-[UICollectionViewDataSource collectionView:cellForItemAtIndexPath:]` and `[UICollectionViewDelegate collectionView:willDisplayCell:forItemAtIndexPath:]`, instead we will scroll the collection view's content offset to make the offscreen cells be realized by UIKit. If the cell matches the predicate, then we will return the matching element (which should now be on screen). If a match isn't found in any of the cells, scroll back to the original scroll position and keep searching the view hierarchy for a matching element.

One notable thing to call out is that unlike cell enumeration in a UITableView using `cellForRowAtIndexPath:`, the UICollectionView equivalent `cellForItemAtIndexPath:` will return a nil cell unless a layour pass is performed. We could either spin the runloop and let UIKit update on its own or directly call `layoutIfNeeded` on the collection view. We're going with the latter, because it is faster on Xcode 16 and avoids a bunch of unnecessary and distracting redrawing of the screen at each scroll position.

A new API `[viewTester usingCurrentFrame]` was introduced in #1296 that can avoid this logic of implicitly scrolling collection views where that is needed or desired.

Fixes #1303

CC: @jdev7 @danielbarela @ispatel22 - Could you give this change a test locally and see if this addresses the issues you're seeing and see if it surfaces any other problems? I've landed a couple other changes recently, so it is possible that those could also have altered behavior in minor ways (#1296, #1300 and #1301).