### PR TITLE
Wait for animation before tapping

### DIFF
--- a/Sources/KIF/Classes/KIFUITestActor.m
+++ b/Sources/KIF/Classes/KIFUITestActor.m
@@ -546,8 +546,8 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
 {
     // In iOS7, tapping a field that is already first responder moves the cursor to the front of the field
     if (view.window.firstResponder != view) {
-        [self tapAccessibilityElement:element inView:view];
         [self waitForTimeInterval:0.25 relativeToAnimationSpeed:YES];
+        [self tapAccessibilityElement:element inView:view];
     }
 
     [self enterTextIntoCurrentFirstResponder:text fallbackView:view];


### PR DESCRIPTION
### What changed?

Small change, wait for animation to complete before attempting to tap.

### Why?

When the `view.window.firstResponder != view`, it can take a bit time for the view to be tappable. Moving the wait to before attempting to tap it. Without this change, we hit an error when attempting to enter text.

### How is it tested?

Pointed our local breaking tests to this change, and it worked 100 times. Also ran the `ci.sh` script against a device, and nothing failed.

### Demo
```
./KIF/Scripts/ci.sh "name=iPhone 14,OS=16.2"

         Executed 4 tests, with 0 failures (0 unexpected) in 6.431 (7.754) seconds

2024-11-07 16:15:27.179 xcodebuild[2989:1855051] [MT] IDETestOperationsObserverDebug: 13.657 elapsed -- Testing started completed.
2024-11-07 16:15:27.179 xcodebuild[2989:1855051] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
2024-11-07 16:15:27.179 xcodebuild[2989:1855051] [MT] IDETestOperationsObserverDebug: 13.657 sec, +13.657 sec -- end
▸ Test Succeeded
```