### PR TITLE
Fix for collection view scrolling not working in some tests

### DIFF
--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -380,6 +380,11 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                         [collectionView scrollRectToVisible:visibleRect animated:NO];
                         [collectionView layoutIfNeeded];
                         UICollectionViewCell *cell = [collectionView cellForItemAtIndexPath:indexPath];
+                        if (cell == nil) {
+                            [collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionNone animated:NO];
+                            [collectionView layoutIfNeeded];
+                            cell = [collectionView cellForItemAtIndexPath:indexPath];
+                        }
                         NSAssert(cell, @"UICollectionViewCell returned from 'cellForItemAtIndexPath' is unexpectedly nil!");
                         UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:NO];
                         


### PR DESCRIPTION
I observed multiple tests failing where the collection view did not scroll to the indexPath.
I changed the scrolling to use `scrollToItemAtIndexPath` if it fails to get the cell and it fixed the failing tests.
