### PR TITLE
Skip cells that can’t be found

### DIFF
--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -385,7 +385,10 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                             [collectionView layoutIfNeeded];
                             cell = [collectionView cellForItemAtIndexPath:indexPath];
                         }
-                        NSAssert(cell, @"UICollectionViewCell returned from 'cellForItemAtIndexPath' is unexpectedly nil!");
+                        // Skip this cell if it can't be found
+                        if (!cell) {
+                            continue;
+                        }
                         UIAccessibilityElement *element = [cell accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:NO];
                         
                         // Skip this cell if it isn't the one we're looking for


### PR DESCRIPTION
I found many tests that were hitting this assertion.  After trying looping around the run loop and still not finding these cells I'm changing this to just continue if a cell can't be found.