### PR TITLE
Remove Xcode 14.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,6 @@ jobs:
     strategy:
       matrix:
         run-config:
-          - { xcode_version: '14.3.1', simulator: 'name=iPad Air (5th generation),OS=16.4', run_extra_validations: 'false' }
-          - { xcode_version: '14.3.1', simulator: 'name=iPhone 14,OS=16.4', run_extra_validations: 'false' }
           - { xcode_version: '15.4', simulator: 'name=iPad Air (5th generation),OS=17.5', run_extra_validations: 'false' }
           - { xcode_version: '15.4', simulator: 'name=iPhone 15,OS=17.5', run_extra_validations: 'false' }
           - { xcode_version: '16.0', simulator: 'name=iPad Air (5th generation),OS=18.0', run_extra_validations: 'false' }


### PR DESCRIPTION
Xcode 14.3.1 is not available on mac os 14 and the build is failing
Example here: https://github.com/kif-framework/KIF/actions/runs/12056785863/job/33620032419?pr=1313