### PR TITLE
Revert the change causing KIF performance regression

### DIFF
--- a/KIF.podspec
+++ b/KIF.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = "KIF"
-  s.version                 = "3.11.0"
+  s.version                 = "3.11.1"
   s.summary                 = "Keep It Functional - iOS UI acceptance testing in an XCUnit harness."
   s.homepage                = "https://github.com/kif-framework/KIF/"
   s.license                 = 'Apache 2.0'

--- a/Sources/KIF/Classes/KIFUITestActor.m
+++ b/Sources/KIF/Classes/KIFUITestActor.m
@@ -230,8 +230,9 @@ static BOOL KIFUITestActorAnimationsEnabled = YES;
             [self waitForTimeInterval:maximumWaitingTimeInterval relativeToAnimationSpeed:YES];
         }
     } else {
+
         // Wait for the view to stabilize and give them a chance to start animations before we wait for them.
-        [self waitForTimeInterval:MAX(stabilizationTime / [UIApplication sharedApplication].animationSpeed, 0.25) relativeToAnimationSpeed:NO];
+        [self waitForTimeInterval:stabilizationTime relativeToAnimationSpeed:YES];
         maximumWaitingTimeInterval -= stabilizationTime;
 
         NSTimeInterval startTime = [NSDate timeIntervalSinceReferenceDate];


### PR DESCRIPTION
The reverted commit increases the duration of waitForAnimationToFinish and slows down KIF tests.

Also bumps the version to 3.11.1.