### PR TITLE
Fix a bug when determining whether an existing animation has completed

### DIFF
--- a/Sources/KIF/Additions/CALayer-KIFAdditions.m
+++ b/Sources/KIF/Additions/CALayer-KIFAdditions.m
@@ -60,7 +60,7 @@
                     if (!animationDidStopSent) {
                         result = YES;
                     }
-                } else if (currentTime > completionTime) {
+                } else if (currentTime < completionTime) {
                     // Otherwise, use the completion time to determine if the animation has been completed.
                     // This doesn't seem to always be exactly right however.
                     result = YES;


### PR DESCRIPTION
Fixes a bug in the logic for determining if a given layer has active animations.

When encountering an animation that has already completed (its completion time is in the past), we incorrectly determined it was _not_ completed. This would lead to `waitForAnimationsToFinish()` to continue running until it hits the animation wait timeout, which defaults to 2 seconds.