### PR TITLE
Ensure per-phase UIEvent creation in KIF tap simulation

### DIFF
--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -599,13 +599,12 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
     // Handle touches in the normal way for other views
     UITouch *touch = [[UITouch alloc] initAtPoint:point inView:self];
     [touch setPhaseAndUpdateTimestamp:UITouchPhaseBegan];
-    
-    UIEvent *event = [self eventWithTouch:touch];
+    UIEvent *beganEvent = [self eventWithTouch:touch];
+    [[UIApplication sharedApplication] kif_sendEvent:beganEvent];
 
-    [[UIApplication sharedApplication] kif_sendEvent:event];
-    
     [touch setPhaseAndUpdateTimestamp:UITouchPhaseEnded];
-    [[UIApplication sharedApplication] kif_sendEvent:event];
+    UIEvent *endedEvent = [self eventWithTouch:touch];
+    [[UIApplication sharedApplication] kif_sendEvent:endedEvent];
 
     // Dispatching the event doesn't actually update the first responder, so fake it
     if ([touch.view isDescendantOfView:self] && [self canBecomeFirstResponder]) {


### PR DESCRIPTION
## Background

* On iOS 26, KIF’s current touch injection logic in `-tapAtPoint:` sometimes fails to trigger taps on non-UIControl views (e.g. `UILabel`, `UIView`).  
* The root cause is that KIF reuses the **same `UIEvent` instance** for multiple touch phases (`Began` and `Ended`).  
* In earlier iOS versions this worked, but starting with iOS 26, it seems like UIKit appears to enforce stricter validation of `UIEvent` snapshots.  
* From my local testing of my app, if the event does not match the current `UITouch` phase, the system may ignore the injected event, resulting in taps being dropped.  

## Changes

- Update `-tapAtPoint:` to **create a new `UIEvent` for each touch phase (`.began` and `.ended`)**.   
- Ensure each event is freshly generated from the updated `UITouch` state before sending.  