### PR TITLE
Add missing headers to module.modulemap and include directory

### DIFF
--- a/KIF.podspec
+++ b/KIF.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = "KIF"
-  s.version                 = "3.12.2"
+  s.version                 = "3.12.3"
   s.summary                 = "Keep It Functional - iOS UI acceptance testing in an XCUnit harness."
   s.homepage                = "https://github.com/kif-framework/KIF/"
   s.license                 = 'Apache 2.0'

--- a/Sources/KIF/include/IOHIDEvent+KIF.h
+++ b/Sources/KIF/include/IOHIDEvent+KIF.h
@@ -1,0 +1,1 @@
+../Classes/IOHIDEvent+KIF.h

--- a/Sources/KIF/include/KIFTestActor_Private.h
+++ b/Sources/KIF/include/KIFTestActor_Private.h
@@ -1,0 +1,1 @@
+../Classes/KIFTestActor_Private.h

--- a/Sources/KIF/include/KIFTextInputTraitsOverrides.h
+++ b/Sources/KIF/include/KIFTextInputTraitsOverrides.h
@@ -1,0 +1,1 @@
+../Classes/KIFTextInputTraitsOverrides.h

--- a/Sources/KIF/include/KIFUITestActor_Private.h
+++ b/Sources/KIF/include/KIFUITestActor_Private.h
@@ -1,0 +1,1 @@
+../Classes/KIFUITestActor_Private.h

--- a/Sources/KIF/include/NSObject+KIFAdditions.h
+++ b/Sources/KIF/include/NSObject+KIFAdditions.h
@@ -1,0 +1,1 @@
+../Additions/NSObject+KIFAdditions.h

--- a/Sources/KIF/include/NSPredicate+KIFAdditions.h
+++ b/Sources/KIF/include/NSPredicate+KIFAdditions.h
@@ -1,0 +1,1 @@
+../Additions/NSPredicate+KIFAdditions.h

--- a/Sources/KIF/include/NSString+KIFAdditions.h
+++ b/Sources/KIF/include/NSString+KIFAdditions.h
@@ -1,0 +1,1 @@
+../Additions/NSString+KIFAdditions.h

--- a/Sources/KIF/include/UIAccessibilityCustomAction+KIFAdditions.h
+++ b/Sources/KIF/include/UIAccessibilityCustomAction+KIFAdditions.h
@@ -1,0 +1,1 @@
+../Additions/UIAccessibilityCustomAction+KIFAdditions.h

--- a/Sources/KIF/include/UIAutomationHelper.h
+++ b/Sources/KIF/include/UIAutomationHelper.h
@@ -1,0 +1,1 @@
+../Classes/UIAutomationHelper.h

--- a/Sources/KIF/include/UIDatePicker+KIFAdditions.h
+++ b/Sources/KIF/include/UIDatePicker+KIFAdditions.h
@@ -1,0 +1,1 @@
+../Additions/UIDatePicker+KIFAdditions.h

--- a/Sources/KIF/include/UIEvent+KIFAdditions.h
+++ b/Sources/KIF/include/UIEvent+KIFAdditions.h
@@ -1,0 +1,1 @@
+../Additions/UIEvent+KIFAdditions.h

--- a/Sources/KIF/include/UIScreen+KIFAdditions.h
+++ b/Sources/KIF/include/UIScreen+KIFAdditions.h
@@ -1,0 +1,1 @@
+../Additions/UIScreen+KIFAdditions.h

--- a/Sources/KIF/include/module.modulemap
+++ b/Sources/KIF/include/module.modulemap
@@ -28,6 +28,18 @@ module KIF {
     header "UIView-KIFAdditions.h"
     header "UIWindow-KIFAdditions.h"
     header "XCTestCase-KIFAdditions.h"
+    header "IOHIDEvent+KIF.h"
+    header "KIFTestActor_Private.h"
+    header "KIFTextInputTraitsOverrides.h"
+    header "KIFUITestActor_Private.h"
+    header "UIAutomationHelper.h"
+    header "NSObject+KIFAdditions.h"
+    header "NSPredicate+KIFAdditions.h"
+    header "NSString+KIFAdditions.h"
+    header "UIAccessibilityCustomAction+KIFAdditions.h"
+    header "UIDatePicker+KIFAdditions.h"
+    header "UIScreen+KIFAdditions.h"
+    header "UIEvent+KIFAdditions.h"
 
     export *
 }


### PR DESCRIPTION
### Summary
  - Added 12 missing header files to module.modulemap 
  - Created symbolic links for all missing headers in Sources/KIF/include/

### Why
The module.modulemap was incomplete - it only included headers that were already symlinked in the include/ directory, missing many public APIs from Classes/ and Additions/ folders. This made those classes unavailable when importing KIF as a module via @import KIF; in Swift Package Manager projects (while those were still accessible through CocoaPods)