### PR TITLE
Update all example projects to use local spm dependencies for pulling in KIF

### DIFF
--- a/Documentation/Examples/Calculator/Calculator.xcodeproj/project.pbxproj
+++ b/Documentation/Examples/Calculator/Calculator.xcodeproj/project.pbxproj
@@ -3,11 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6282C6352C9CBE210040DCDB /* KIF in Frameworks */ = {isa = PBXBuildFile; productRef = 6282C6342C9CBE210040DCDB /* KIF */; };
+		2593D75B2FDB4E54001AB786 /* KIF in Frameworks */ = {isa = PBXBuildFile; productRef = 2593D75A2FDB4E54001AB786 /* KIF */; };
 		62F81B521EBBE976009B2400 /* BasicCalculatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EB4C315F167BAE6100E31109 /* BasicCalculatorTests.m */; };
 		62F81B5D1EBBEB6B009B2400 /* BasicCalculatorRobot.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F81B5C1EBBEB6B009B2400 /* BasicCalculatorRobot.m */; };
 		62F972EB1F708273003EFFDA /* TestRobot.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F972EA1F708273003EFFDA /* TestRobot.m */; };
@@ -45,7 +45,6 @@
 		62F81B5C1EBBEB6B009B2400 /* BasicCalculatorRobot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BasicCalculatorRobot.m; sourceTree = "<group>"; };
 		62F972E91F708273003EFFDA /* TestRobot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestRobot.h; sourceTree = "<group>"; };
 		62F972EA1F708273003EFFDA /* TestRobot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestRobot.m; sourceTree = "<group>"; };
-		62FA513E2C9CBDCD00E335D6 /* KIF */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = KIF; path = ../../..; sourceTree = "<group>"; };
 		EB4C30D9167B9E3A00E31109 /* Calculator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB4C30DD167B9E3A00E31109 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		EB4C30DF167B9E3A00E31109 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -74,11 +73,11 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		62F81B421EBBE925009B2400 /* Frameworks */ = {
+		2593D7582FDB4E2E001AB786 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6282C6352C9CBE210040DCDB /* KIF in Frameworks */,
+				2593D75B2FDB4E54001AB786 /* KIF in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -117,7 +116,6 @@
 		EB4C30DC167B9E3A00E31109 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				62FA513E2C9CBDCD00E335D6 /* KIF */,
 				EB4C30DD167B9E3A00E31109 /* UIKit.framework */,
 				EB4C30DF167B9E3A00E31109 /* Foundation.framework */,
 				EB4C30E1167B9E3A00E31109 /* CoreGraphics.framework */,
@@ -189,7 +187,7 @@
 			buildConfigurationList = 62F81B4C1EBBE925009B2400 /* Build configuration list for PBXNativeTarget "Acceptance Tests" */;
 			buildPhases = (
 				62F81B411EBBE925009B2400 /* Sources */,
-				62F81B421EBBE925009B2400 /* Frameworks */,
+				2593D7582FDB4E2E001AB786 /* Frameworks */,
 				62F81B431EBBE925009B2400 /* Resources */,
 			);
 			buildRules = (
@@ -200,6 +198,7 @@
 			name = "Acceptance Tests";
 			packageProductDependencies = (
 				6282C6342C9CBE210040DCDB /* KIF */,
+				2593D75A2FDB4E54001AB786 /* KIF */,
 			);
 			productName = "Acceptance Tests";
 			productReference = 62F81B451EBBE925009B2400 /* Acceptance Tests.xctest */;
@@ -249,6 +248,9 @@
 				Base,
 			);
 			mainGroup = EB4C30CE167B9E3A00E31109;
+			packageReferences = (
+				2593D7592FDB4E54001AB786 /* XCLocalSwiftPackageReference "../../../../KIF" */,
+			);
 			productRefGroup = EB4C30DA167B9E3A00E31109 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -576,7 +578,18 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		2593D7592FDB4E54001AB786 /* XCLocalSwiftPackageReference "../../../../KIF" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../../../KIF;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		2593D75A2FDB4E54001AB786 /* KIF */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KIF;
+		};
 		6282C6342C9CBE210040DCDB /* KIF */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = KIF;

--- a/Documentation/Examples/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
+++ b/Documentation/Examples/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2593D8B22FDB5036001AB786 /* KIF in Frameworks */ = {isa = PBXBuildFile; productRef = 2593D8B12FDB5036001AB786 /* KIF */; };
 		B4310BE3260BA21400EE03AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4310BE2260BA21400EE03AF /* AppDelegate.swift */; };
 		B4310BE7260BA21400EE03AF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4310BE6260BA21400EE03AF /* ViewController.swift */; };
 		B4310BEA260BA21400EE03AF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B4310BE8260BA21400EE03AF /* Main.storyboard */; };
@@ -38,7 +39,6 @@
 		B4310BF5260BA21500EE03AF /* SPMIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SPMIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4310BF9260BA21500EE03AF /* SPMIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPMIntegrationTests.swift; sourceTree = "<group>"; };
 		B4310BFB260BA21500EE03AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B488554F260CE596008916AB /* KIF */ = {isa = PBXFileReference; lastKnownFileType = folder; name = KIF; path = ../../../..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,6 +54,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B4885551260CE5D3008916AB /* KIF in Frameworks */,
+				2593D8B22FDB5036001AB786 /* KIF in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -96,7 +97,6 @@
 		B4310BF8260BA21500EE03AF /* SPMIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
-				B488554F260CE596008916AB /* KIF */,
 				B4310BF9260BA21500EE03AF /* SPMIntegrationTests.swift */,
 				B4310BFB260BA21500EE03AF /* Info.plist */,
 			);
@@ -146,6 +146,7 @@
 			name = SPMIntegrationTests;
 			packageProductDependencies = (
 				B4885550260CE5D3008916AB /* KIF */,
+				2593D8B12FDB5036001AB786 /* KIF */,
 			);
 			productName = SPMIntegrationTests;
 			productReference = B4310BF5260BA21500EE03AF /* SPMIntegrationTests.xctest */;
@@ -178,6 +179,9 @@
 				Base,
 			);
 			mainGroup = B4310BD6260BA21400EE03AF;
+			packageReferences = (
+				2593D8B02FDB5036001AB786 /* XCLocalSwiftPackageReference "../../../../KIF" */,
+			);
 			productRefGroup = B4310BE0260BA21400EE03AF /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -480,7 +484,18 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		2593D8B02FDB5036001AB786 /* XCLocalSwiftPackageReference "../../../../KIF" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../../../KIF;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		2593D8B12FDB5036001AB786 /* KIF */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KIF;
+		};
 		B4885550260CE5D3008916AB /* KIF */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = KIF;

--- a/Documentation/Examples/Testable/Acceptance Tests/Acceptance Tests-Info.plist
+++ b/Documentation/Examples/Testable/Acceptance Tests/Acceptance Tests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.square.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/Documentation/Examples/Testable/Acceptance Tests/IntegrationTestCases.m
+++ b/Documentation/Examples/Testable/Acceptance Tests/IntegrationTestCases.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 #import "KIFUITestActor+EXAddition.h"
 
 @interface IntegrationTestCases : KIFTestCase

--- a/Documentation/Examples/Testable/Acceptance Tests/KIFUITestActor+EXAddition.h
+++ b/Documentation/Examples/Testable/Acceptance Tests/KIFUITestActor+EXAddition.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface KIFUIViewTestActor (EXAddition)
 

--- a/Documentation/Examples/Testable/Testable.xcodeproj/project.pbxproj
+++ b/Documentation/Examples/Testable/Testable.xcodeproj/project.pbxproj
@@ -3,12 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2593D8062FDB4EC0001AB786 /* KIF in Frameworks */ = {isa = PBXBuildFile; productRef = 2593D8052FDB4EC0001AB786 /* KIF */; };
 		4440B32C17F5692A00253D51 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 4440B32B17F5692A00253D51 /* Default-568h@2x.png */; };
-		6282C65B2C9CE4080040DCDB /* libKIF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6282C6562C9CE3F70040DCDB /* libKIF.a */; };
 		62F81B001EBBD073009B2400 /* IntegrationTestCases.m in Sources */ = {isa = PBXBuildFile; fileRef = EB47EFB21781DF6D006BBFAC /* IntegrationTestCases.m */; };
 		62F81B011EBBD073009B2400 /* KIFUITestActor+EXAddition.m in Sources */ = {isa = PBXBuildFile; fileRef = EB47EFB41781DF6D006BBFAC /* KIFUITestActor+EXAddition.m */; };
 		62F81B311EBBE348009B2400 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62F81B301EBBE348009B2400 /* IOKit.framework */; };
@@ -26,27 +26,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		6282C6552C9CE3F70040DCDB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6282C64E2C9CE3F70040DCDB /* KIF.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = EABD46AA1857A0C700A5F081;
-			remoteInfo = KIF;
-		};
-		6282C6572C9CE3F70040DCDB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6282C64E2C9CE3F70040DCDB /* KIF.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = EB60ECC1177F8C83005A041A;
-			remoteInfo = "TestHost";
-		};
-		6282C6592C9CE3F70040DCDB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 6282C64E2C9CE3F70040DCDB /* KIF.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = EABD46CD1857A0F300A5F081;
-			remoteInfo = "KIFTests";
-		};
 		62F81AFB1EBBD038009B2400 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AAB0739F139861C0008AF393 /* Project object */;
@@ -60,7 +39,6 @@
 		22191E0524BF79F4004CAA18 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainWindow.xib; sourceTree = "<group>"; };
 		22191E0624BF79F4004CAA18 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/RootViewController.xib; sourceTree = "<group>"; };
 		4440B32B17F5692A00253D51 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
-		6282C64E2C9CE3F70040DCDB /* KIF.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = KIF.xcodeproj; path = ../../../KIF.xcodeproj; sourceTree = "<group>"; };
 		62F81AF61EBBD038009B2400 /* Acceptance Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Acceptance Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		62F81B301EBBE348009B2400 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/IOKit.framework; sourceTree = DEVELOPER_DIR; };
 		AAB073A8139861C0008AF393 /* Testable.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Testable.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -89,8 +67,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2593D8062FDB4EC0001AB786 /* KIF in Frameworks */,
 				BCA154372331FFF700CDC69F /* WebKit.framework in Frameworks */,
-				6282C65B2C9CE4080040DCDB /* libKIF.a in Frameworks */,
 				62F81B311EBBE348009B2400 /* IOKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -109,16 +87,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		6282C64F2C9CE3F70040DCDB /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				6282C6562C9CE3F70040DCDB /* libKIF.a */,
-				6282C6582C9CE3F70040DCDB /* TestHost.app */,
-				6282C65A2C9CE3F70040DCDB /* KIFTests - XCTest.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		AAB0739D139861C0008AF393 = {
 			isa = PBXGroup;
 			children = (
@@ -142,7 +110,6 @@
 		AAB073AB139861C0008AF393 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				6282C64E2C9CE3F70040DCDB /* KIF.xcodeproj */,
 				BCA1542F2331FF8C00CDC69F /* WebKit.framework */,
 				EB9DB7431781DDBA0087B6FD /* libKIF.a */,
 				62F81B301EBBE348009B2400 /* IOKit.framework */,
@@ -242,7 +209,8 @@
 		AAB0739F139861C0008AF393 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1150;
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 2650;
 				TargetAttributes = {
 					62F81AF51EBBD038009B2400 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -260,14 +228,11 @@
 				Base,
 			);
 			mainGroup = AAB0739D139861C0008AF393;
+			packageReferences = (
+				2593D8042FDB4EC0001AB786 /* XCLocalSwiftPackageReference "../../../../KIF" */,
+			);
 			productRefGroup = AAB073A9139861C0008AF393 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 6282C64F2C9CE3F70040DCDB /* Products */;
-					ProjectRef = 6282C64E2C9CE3F70040DCDB /* KIF.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				AAB073A7139861C0008AF393 /* Testable */,
@@ -275,30 +240,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		6282C6562C9CE3F70040DCDB /* libKIF.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libKIF.a;
-			remoteRef = 6282C6552C9CE3F70040DCDB /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6282C6582C9CE3F70040DCDB /* TestHost.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = "TestHost.app";
-			remoteRef = 6282C6572C9CE3F70040DCDB /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		6282C65A2C9CE3F70040DCDB /* KIFTests - XCTest.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "KIFTests - XCTest.xctest";
-			remoteRef = 6282C6592C9CE3F70040DCDB /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		62F81AF41EBBD038009B2400 /* Resources */ = {
@@ -402,7 +343,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -418,7 +358,11 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				INFOPLIST_FILE = "Acceptance Tests/Acceptance Tests-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_CFLAGS = (
 					"-DDEPRECATE_KIF_SYSTEM=1",
@@ -427,7 +371,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.squareup.Acceptance-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRIP_INSTALLED_PRODUCT = NO;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Testable.app/Testable";
 			};
 			name = Debug;
@@ -455,7 +398,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEAD_CODE_STRIPPING = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -466,12 +408,15 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				INFOPLIST_FILE = "Acceptance Tests/Acceptance Tests-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.squareup.Acceptance-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRIP_INSTALLED_PRODUCT = NO;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Testable.app/Testable";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -493,6 +438,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -501,6 +447,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -515,6 +462,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 			};
 			name = Debug;
 		};
@@ -534,6 +482,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -541,6 +490,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -552,6 +502,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 			};
 			name = Release;
 		};
@@ -620,6 +571,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		2593D8042FDB4EC0001AB786 /* XCLocalSwiftPackageReference "../../../../KIF" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../../../KIF;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		2593D8052FDB4EC0001AB786 /* KIF */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KIF;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AAB0739F139861C0008AF393 /* Project object */;
 }

--- a/Documentation/Examples/Testable/Testable.xcodeproj/xcshareddata/xcschemes/Testable.xcscheme
+++ b/Documentation/Examples/Testable/Testable.xcodeproj/xcshareddata/xcschemes/Testable.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1150"
+   LastUpgradeVersion = "2650"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Documentation/Examples/TestableSwift/TestableSwift.xcodeproj/project.pbxproj
+++ b/Documentation/Examples/TestableSwift/TestableSwift.xcodeproj/project.pbxproj
@@ -3,12 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2593D8092FDB4F9E001AB786 /* KIF in Frameworks */ = {isa = PBXBuildFile; productRef = 2593D8082FDB4F9E001AB786 /* KIF */; };
 		5600E94A1C3BBCC800235220 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5600E9491C3BBCC700235220 /* IOKit.framework */; };
-		62582AF22C9CB00E00F800BF /* KIF in Resources */ = {isa = PBXBuildFile; fileRef = 62582AF12C9CAFEA00F800BF /* KIF */; };
 		62FA513C2C9CB1A500E335D6 /* KIF in Frameworks */ = {isa = PBXBuildFile; productRef = 62FA513B2C9CB1A500E335D6 /* KIF */; };
 		A88CD9831A019AFF0064F706 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88CD9821A019AFF0064F706 /* AppDelegate.swift */; };
 		A88CD9851A019AFF0064F706 /* MasterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88CD9841A019AFF0064F706 /* MasterViewController.swift */; };
@@ -32,7 +32,6 @@
 
 /* Begin PBXFileReference section */
 		5600E9491C3BBCC700235220 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/IOKit.framework; sourceTree = DEVELOPER_DIR; };
-		62582AF12C9CAFEA00F800BF /* KIF */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = KIF; path = ../../../..; sourceTree = "<group>"; };
 		A88CD97D1A019AFF0064F706 /* TestableSwift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestableSwift.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A88CD9811A019AFF0064F706 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A88CD9821A019AFF0064F706 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -60,6 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2593D8092FDB4F9E001AB786 /* KIF in Frameworks */,
 				5600E94A1C3BBCC800235220 /* IOKit.framework in Frameworks */,
 				62FA513C2C9CB1A500E335D6 /* KIF in Frameworks */,
 			);
@@ -118,7 +118,6 @@
 		A88CD9971A019AFF0064F706 /* TestableSwiftTests */ = {
 			isa = PBXGroup;
 			children = (
-				62582AF12C9CAFEA00F800BF /* KIF */,
 				5600E9491C3BBCC700235220 /* IOKit.framework */,
 				A88CD99A1A019AFF0064F706 /* Testable_SwiftTests.swift */,
 				A88CD9981A019AFF0064F706 /* Supporting Files */,
@@ -173,6 +172,7 @@
 			name = TestableSwiftTests;
 			packageProductDependencies = (
 				62FA513B2C9CB1A500E335D6 /* KIF */,
+				2593D8082FDB4F9E001AB786 /* KIF */,
 			);
 			productName = TestableSwiftTests;
 			productReference = A88CD9941A019AFF0064F706 /* TestableSwiftTests.xctest */;
@@ -184,8 +184,9 @@
 		A88CD9751A019AFF0064F706 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 2650;
 				TargetAttributes = {
 					A88CD97C1A019AFF0064F706 = {
 						CreatedOnToolsVersion = 6.1;
@@ -207,6 +208,9 @@
 				Base,
 			);
 			mainGroup = A88CD9741A019AFF0064F706;
+			packageReferences = (
+				2593D8072FDB4F9E001AB786 /* XCLocalSwiftPackageReference "../../../../KIF" */,
+			);
 			productRefGroup = A88CD97E1A019AFF0064F706 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -232,7 +236,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				62582AF22C9CB00E00F800BF /* KIF in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -310,6 +313,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -319,6 +323,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -338,6 +343,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -364,6 +370,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -373,6 +380,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -384,6 +392,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
@@ -517,7 +526,18 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		2593D8072FDB4F9E001AB786 /* XCLocalSwiftPackageReference "../../../../KIF" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../../../KIF;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		2593D8082FDB4F9E001AB786 /* KIF */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KIF;
+		};
 		62FA513B2C9CB1A500E335D6 /* KIF */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = KIF;

--- a/Documentation/Examples/TestableSwift/TestableSwift.xcodeproj/xcshareddata/xcschemes/TestableSwift.xcscheme
+++ b/Documentation/Examples/TestableSwift/TestableSwift.xcodeproj/xcshareddata/xcschemes/TestableSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "2650"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -41,15 +41,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "A88CD97C1A019AFF0064F706"
-            BuildableName = "TestableSwift.app"
-            BlueprintName = "TestableSwift"
-            ReferencedContainer = "container:Testable Swift.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -73,6 +64,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A88CD97C1A019AFF0064F706"
+            BuildableName = "TestableSwift.app"
+            BlueprintName = "TestableSwift"
+            ReferencedContainer = "container:TestableSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Replace project references and framework references with local SPM dependencies for pulling the local KIF framework into example projects.

Also updates the projects to more modern settings using Xcode 26.5.0