### PR TITLE
Emit demangled Swift type names in view hierarchy dumps

### DIFF
--- a/KIF.xcodeproj/project.pbxproj
+++ b/KIF.xcodeproj/project.pbxproj
@@ -7,117 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		06A507622D5274B800F77047 /* UIView+KIFPrivateAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 06A507612D5274B800F77047 /* UIView+KIFPrivateAPI.h */; };
-		0E27A9EE1B45B53D00A6DE6E /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9AD81F91AA180B900B369FD /* IOKit.framework */; };
-		2229D59525BEF47D0093296C /* KIFUITestActor-IdentifierTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D53E25BEF47D0093296C /* KIFUITestActor-IdentifierTests.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D59625BEF47D0093296C /* KIFUITestActor-IdentifierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D53F25BEF47D0093296C /* KIFUITestActor-IdentifierTests.m */; };
-		2229D59725BEF47D0093296C /* KIFTouchVisualizerViewCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D54125BEF47D0093296C /* KIFTouchVisualizerViewCoordinator.m */; };
-		2229D59825BEF47D0093296C /* KIFEventVisualizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D54225BEF47D0093296C /* KIFEventVisualizer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D59925BEF47D0093296C /* KIFTouchVisualizerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D54325BEF47D0093296C /* KIFTouchVisualizerView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D59A25BEF47D0093296C /* KIFEventVisualizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D54425BEF47D0093296C /* KIFEventVisualizer.m */; };
-		2229D59B25BEF47D0093296C /* KIFTouchVisualizerViewCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D54525BEF47D0093296C /* KIFTouchVisualizerViewCoordinator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D59C25BEF47D0093296C /* KIFTouchVisualizerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D54625BEF47D0093296C /* KIFTouchVisualizerView.m */; };
-		2229D59D25BEF47D0093296C /* UIAccessibilityElement-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D54825BEF47D0093296C /* UIAccessibilityElement-KIFAdditions.m */; };
-		2229D59E25BEF47D0093296C /* UIScreen+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D54925BEF47D0093296C /* UIScreen+KIFAdditions.m */; };
-		2229D59F25BEF47D0093296C /* NSException-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D54A25BEF47D0093296C /* NSException-KIFAdditions.m */; };
-		2229D5A025BEF47D0093296C /* NSString+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D54B25BEF47D0093296C /* NSString+KIFAdditions.m */; };
-		2229D5A125BEF47D0093296C /* UIApplication-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D54C25BEF47D0093296C /* UIApplication-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5A225BEF47D0093296C /* CGGeometry-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D54D25BEF47D0093296C /* CGGeometry-KIFAdditions.m */; };
-		2229D5A325BEF47D0093296C /* UIWindow-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D54E25BEF47D0093296C /* UIWindow-KIFAdditions.m */; };
-		2229D5A425BEF47D0093296C /* UIScrollView-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D54F25BEF47D0093296C /* UIScrollView-KIFAdditions.m */; };
-		2229D5A525BEF47D0093296C /* UIView-Debugging.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D55025BEF47D0093296C /* UIView-Debugging.m */; };
-		2229D5A625BEF47D0093296C /* UITouch-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D55125BEF47D0093296C /* UITouch-KIFAdditions.m */; };
-		2229D5A725BEF47D0093296C /* UITableView-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D55225BEF47D0093296C /* UITableView-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5A825BEF47D0093296C /* CAAnimation+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D55325BEF47D0093296C /* CAAnimation+KIFAdditions.m */; };
-		2229D5A925BEF47D0093296C /* NSFileManager-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D55425BEF47D0093296C /* NSFileManager-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5AA25BEF47D0093296C /* UIView-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D55525BEF47D0093296C /* UIView-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5AB25BEF47D0093296C /* NSError-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D55625BEF47D0093296C /* NSError-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5AC25BEF47D0093296C /* UIEvent+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D55725BEF47D0093296C /* UIEvent+KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5AD25BEF47D0093296C /* UIDatePicker+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D55825BEF47D0093296C /* UIDatePicker+KIFAdditions.m */; };
-		2229D5AE25BEF47D0093296C /* CALayer-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D55925BEF47D0093296C /* CALayer-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5AF25BEF47D0093296C /* NSBundle-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D55A25BEF47D0093296C /* NSBundle-KIFAdditions.m */; };
-		2229D5B025BEF47D0093296C /* NSPredicate+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D55B25BEF47D0093296C /* NSPredicate+KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5B125BEF47D0093296C /* XCTestCase-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D55C25BEF47D0093296C /* XCTestCase-KIFAdditions.m */; };
-		2229D5B225BEF47D0093296C /* UIScrollView-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D55D25BEF47D0093296C /* UIScrollView-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5B325BEF47D0093296C /* UIWindow-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D55E25BEF47D0093296C /* UIWindow-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5B425BEF47D0093296C /* CGGeometry-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D55F25BEF47D0093296C /* CGGeometry-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5B525BEF47D0093296C /* UIApplication-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D56025BEF47D0093296C /* UIApplication-KIFAdditions.m */; };
-		2229D5B625BEF47D0093296C /* NSString+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D56125BEF47D0093296C /* NSString+KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5B725BEF47D0093296C /* NSException-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D56225BEF47D0093296C /* NSException-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5B825BEF47D0093296C /* UIScreen+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D56325BEF47D0093296C /* UIScreen+KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5B925BEF47D0093296C /* UIAccessibilityElement-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D56425BEF47D0093296C /* UIAccessibilityElement-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5BA25BEF47D0093296C /* UIView-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D56525BEF47D0093296C /* UIView-KIFAdditions.m */; };
-		2229D5BB25BEF47D0093296C /* NSFileManager-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D56625BEF47D0093296C /* NSFileManager-KIFAdditions.m */; };
-		2229D5BC25BEF47D0093296C /* CAAnimation+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D56725BEF47D0093296C /* CAAnimation+KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5BD25BEF47D0093296C /* UITouch-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D56825BEF47D0093296C /* UITouch-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5BE25BEF47D0093296C /* UITableView-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D56925BEF47D0093296C /* UITableView-KIFAdditions.m */; };
-		2229D5BF25BEF47D0093296C /* UIView-Debugging.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D56A25BEF47D0093296C /* UIView-Debugging.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5C025BEF47D0093296C /* UIEvent+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D56B25BEF47D0093296C /* UIEvent+KIFAdditions.m */; };
-		2229D5C125BEF47D0093296C /* NSError-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D56C25BEF47D0093296C /* NSError-KIFAdditions.m */; };
-		2229D5C225BEF47D0093296C /* LoadableCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D56D25BEF47D0093296C /* LoadableCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5C325BEF47D0093296C /* XCTestCase-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D56E25BEF47D0093296C /* XCTestCase-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5C425BEF47D0093296C /* NSPredicate+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D56F25BEF47D0093296C /* NSPredicate+KIFAdditions.m */; };
-		2229D5C525BEF47D0093296C /* NSBundle-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D57025BEF47D0093296C /* NSBundle-KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5C625BEF47D0093296C /* UIDatePicker+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D57125BEF47D0093296C /* UIDatePicker+KIFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5C725BEF47D0093296C /* CALayer-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D57225BEF47D0093296C /* CALayer-KIFAdditions.m */; };
-		2229D5C825BEF47D0093296C /* IOHIDEvent+KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D57425BEF47D0093296C /* IOHIDEvent+KIF.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5CA25BEF47D0093296C /* KIFUITestActor-ConditionalTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D57625BEF47D0093296C /* KIFUITestActor-ConditionalTests.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5CB25BEF47D0093296C /* KIFUIObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D57725BEF47D0093296C /* KIFUIObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5CC25BEF47D0093296C /* KIFSystemTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D57825BEF47D0093296C /* KIFSystemTestActor.m */; };
-		2229D5CD25BEF47D0093296C /* KIFTestStepValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D57925BEF47D0093296C /* KIFTestStepValidation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5CE25BEF47D0093296C /* KIFTypist.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D57A25BEF47D0093296C /* KIFTypist.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5CF25BEF47D0093296C /* KIFAccessibilityEnabler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D57B25BEF47D0093296C /* KIFAccessibilityEnabler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5D025BEF47D0093296C /* KIFUIViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D57C25BEF47D0093296C /* KIFUIViewTestActor.m */; };
-		2229D5D125BEF47D0093296C /* UIAutomationHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D57D25BEF47D0093296C /* UIAutomationHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5D225BEF47D0093296C /* KIFTextInputTraitsOverrides.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D57E25BEF47D0093296C /* KIFTextInputTraitsOverrides.m */; };
-		2229D5D425BEF47D0093296C /* KIFUITestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D58025BEF47D0093296C /* KIFUITestActor.m */; };
-		2229D5D525BEF47D0093296C /* KIFTestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D58125BEF47D0093296C /* KIFTestActor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5D625BEF47D0093296C /* KIFTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D58225BEF47D0093296C /* KIFTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5D725BEF47D0093296C /* KIFUITestActor_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D58325BEF47D0093296C /* KIFUITestActor_Private.h */; };
-		2229D5D825BEF47D0093296C /* IOHIDEvent+KIF.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D58425BEF47D0093296C /* IOHIDEvent+KIF.m */; };
-		2229D5D925BEF47D0093296C /* KIFTestStepValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D58525BEF47D0093296C /* KIFTestStepValidation.m */; };
-		2229D5DA25BEF47D0093296C /* KIFTestActor_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D58625BEF47D0093296C /* KIFTestActor_Private.h */; };
-		2229D5DB25BEF47D0093296C /* KIFUITestActor-ConditionalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D58725BEF47D0093296C /* KIFUITestActor-ConditionalTests.m */; };
-		2229D5DC25BEF47D0093296C /* KIFUIObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D58825BEF47D0093296C /* KIFUIObject.m */; };
-		2229D5DD25BEF47D0093296C /* KIFSystemTestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D58925BEF47D0093296C /* KIFSystemTestActor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5DE25BEF47D0093296C /* KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D58A25BEF47D0093296C /* KIF.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5DF25BEF47D0093296C /* KIFTextInputTraitsOverrides.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D58B25BEF47D0093296C /* KIFTextInputTraitsOverrides.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5E025BEF47D0093296C /* UIAutomationHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D58C25BEF47D0093296C /* UIAutomationHelper.m */; };
-		2229D5E125BEF47D0093296C /* KIFUIViewTestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D58D25BEF47D0093296C /* KIFUIViewTestActor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5E225BEF47D0093296C /* KIFAccessibilityEnabler.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D58E25BEF47D0093296C /* KIFAccessibilityEnabler.m */; };
-		2229D5E325BEF47D0093296C /* KIFTypist.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D58F25BEF47D0093296C /* KIFTypist.m */; };
-		2229D5E425BEF47D0093296C /* KIFTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D59025BEF47D0093296C /* KIFTestCase.m */; };
-		2229D5E525BEF47D0093296C /* KIFTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 2229D59125BEF47D0093296C /* KIFTestActor.m */; };
-		2229D5E625BEF47D0093296C /* KIFUITestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D59225BEF47D0093296C /* KIFUITestActor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2229D5E725BEF47D0093296C /* UIDatePicker+KIFPrivateAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 2229D59425BEF47D0093296C /* UIDatePicker+KIFPrivateAPI.h */; };
+		25105B2F2FF6E28D0098BAFB /* KIF in Frameworks */ = {isa = PBXBuildFile; productRef = 25105B2E2FF6E28D0098BAFB /* KIF */; };
 		84D293AF1A2C867300C10944 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84D293AE1A2C867300C10944 /* CoreLocation.framework */; };
 		84D293B81A2C8DF700C10944 /* AddressBookUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84D293B71A2C8DF700C10944 /* AddressBookUI.framework */; };
-		85DB94721C5A5D430025F83E /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85DB94711C5A5D430025F83E /* QuartzCore.framework */; };
 		85DB94731C5A5FD50025F83E /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85DB94711C5A5D430025F83E /* QuartzCore.framework */; };
 		85DB94741C5A5FE10025F83E /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85DB94711C5A5D430025F83E /* QuartzCore.framework */; };
-		8E654FCE29DA2FE7007F7811 /* UIWindow+KIFSwizzle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E654FCC29DA2FE7007F7811 /* UIWindow+KIFSwizzle.h */; };
-		8E654FD029DA2FE7007F7811 /* UIWindow+KIFSwizzle.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E654FCD29DA2FE7007F7811 /* UIWindow+KIFSwizzle.m */; };
 		8EAA1EE229D3AF7A008F6029 /* OffscreenViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EAA1EE129D3AF7A008F6029 /* OffscreenViewController.m */; };
-		8EC2CB1F29DB3D3B001BE493 /* NSObject+KIFSwizzle.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EC2CB1D29DB3D3B001BE493 /* NSObject+KIFSwizzle.h */; };
-		8EC2CB2129DB3D3B001BE493 /* NSObject+KIFSwizzle.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EC2CB1E29DB3D3B001BE493 /* NSObject+KIFSwizzle.m */; };
-		ACA242E72C3DB47400E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = ACA242E52C3DB46A00E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.m */; };
-		ACA242E92C3DB4EA00E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = ACA242E82C3DB4B000E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		ACCF74502DAFD34C004E3F45 /* NSObject+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = ACCF744F2DAFD34C004E3F45 /* NSObject+KIFAdditions.m */; };
-		ACCF74512DAFD34C004E3F45 /* NSObject+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = ACCF744E2DAFD34C004E3F45 /* NSObject+KIFAdditions.h */; };
 		AE62FCD81A1D2667002B10DA /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = AE62FCD71A1D2667002B10DA /* index.html */; };
 		AE62FCDA1A1D26BB002B10DA /* page2.html in Resources */ = {isa = PBXBuildFile; fileRef = AE62FCD91A1D26BB002B10DA /* page2.html */; };
-		BCA1542A23312E7300CDC69F /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCA1542923312E7300CDC69F /* WebKit.framework */; };
 		BCA1542B23312E8100CDC69F /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCA1542923312E7300CDC69F /* WebKit.framework */; };
 		BCA1542C23312E8F00CDC69F /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCA1542923312E7300CDC69F /* WebKit.framework */; };
 		E9F646F81AA3BABA00C37EA3 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9AD81F91AA180B900B369FD /* IOKit.framework */; };
-		EABD468E1857A0C700A5F081 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB0726B139719AC008AF393 /* Foundation.framework */; };
-		EABD468F1857A0C700A5F081 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB072B413971AEA008AF393 /* UIKit.framework */; };
 		EABD46C31857A0F300A5F081 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB072B413971AEA008AF393 /* UIKit.framework */; };
 		EABD46C41857A0F300A5F081 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB0726B139719AC008AF393 /* Foundation.framework */; };
 		EABD46C51857A0F300A5F081 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB60ECC4177F8C83005A041A /* CoreGraphics.framework */; };
 		EABD46CF1857A15400A5F081 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EABD46AB1857A0EB00A5F081 /* XCTest.framework */; };
-		EABD46D21857A24E00A5F081 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EABD46AB1857A0EB00A5F081 /* XCTest.framework */; };
-		EABD46D61858C8ED00A5F081 /* libKIF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EABD46AA1857A0C700A5F081 /* libKIF.a */; };
 		EB60ECC2177F8C83005A041A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB072B413971AEA008AF393 /* UIKit.framework */; };
 		EB60ECC3177F8C83005A041A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB0726B139719AC008AF393 /* Foundation.framework */; };
 		EB60ECC5177F8C83005A041A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB60ECC4177F8C83005A041A /* CoreGraphics.framework */; };
@@ -140,113 +44,23 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		06A507612D5274B800F77047 /* UIView+KIFPrivateAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+KIFPrivateAPI.h"; sourceTree = "<group>"; };
 		22191DFA24BF793F004CAA18 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainStoryboard.storyboard; sourceTree = "<group>"; };
 		221FF9A2252231030058F471 /* TestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestPlan.xctestplan; sourceTree = "<group>"; };
-		2229D53E25BEF47D0093296C /* KIFUITestActor-IdentifierTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "KIFUITestActor-IdentifierTests.h"; sourceTree = "<group>"; };
-		2229D53F25BEF47D0093296C /* KIFUITestActor-IdentifierTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "KIFUITestActor-IdentifierTests.m"; sourceTree = "<group>"; };
-		2229D54125BEF47D0093296C /* KIFTouchVisualizerViewCoordinator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFTouchVisualizerViewCoordinator.m; sourceTree = "<group>"; };
-		2229D54225BEF47D0093296C /* KIFEventVisualizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFEventVisualizer.h; sourceTree = "<group>"; };
-		2229D54325BEF47D0093296C /* KIFTouchVisualizerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFTouchVisualizerView.h; sourceTree = "<group>"; };
-		2229D54425BEF47D0093296C /* KIFEventVisualizer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFEventVisualizer.m; sourceTree = "<group>"; };
-		2229D54525BEF47D0093296C /* KIFTouchVisualizerViewCoordinator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFTouchVisualizerViewCoordinator.h; sourceTree = "<group>"; };
-		2229D54625BEF47D0093296C /* KIFTouchVisualizerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFTouchVisualizerView.m; sourceTree = "<group>"; };
-		2229D54825BEF47D0093296C /* UIAccessibilityElement-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIAccessibilityElement-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D54925BEF47D0093296C /* UIScreen+KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIScreen+KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D54A25BEF47D0093296C /* NSException-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSException-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D54B25BEF47D0093296C /* NSString+KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D54C25BEF47D0093296C /* UIApplication-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIApplication-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D54D25BEF47D0093296C /* CGGeometry-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CGGeometry-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D54E25BEF47D0093296C /* UIWindow-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIWindow-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D54F25BEF47D0093296C /* UIScrollView-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIScrollView-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D55025BEF47D0093296C /* UIView-Debugging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView-Debugging.m"; sourceTree = "<group>"; };
-		2229D55125BEF47D0093296C /* UITouch-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITouch-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D55225BEF47D0093296C /* UITableView-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITableView-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D55325BEF47D0093296C /* CAAnimation+KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CAAnimation+KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D55425BEF47D0093296C /* NSFileManager-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSFileManager-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D55525BEF47D0093296C /* UIView-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D55625BEF47D0093296C /* NSError-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D55725BEF47D0093296C /* UIEvent+KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIEvent+KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D55825BEF47D0093296C /* UIDatePicker+KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIDatePicker+KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D55925BEF47D0093296C /* CALayer-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CALayer-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D55A25BEF47D0093296C /* NSBundle-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSBundle-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D55B25BEF47D0093296C /* NSPredicate+KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSPredicate+KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D55C25BEF47D0093296C /* XCTestCase-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCTestCase-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D55D25BEF47D0093296C /* UIScrollView-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIScrollView-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D55E25BEF47D0093296C /* UIWindow-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIWindow-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D55F25BEF47D0093296C /* CGGeometry-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CGGeometry-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D56025BEF47D0093296C /* UIApplication-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIApplication-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D56125BEF47D0093296C /* NSString+KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D56225BEF47D0093296C /* NSException-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSException-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D56325BEF47D0093296C /* UIScreen+KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIScreen+KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D56425BEF47D0093296C /* UIAccessibilityElement-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIAccessibilityElement-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D56525BEF47D0093296C /* UIView-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D56625BEF47D0093296C /* NSFileManager-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileManager-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D56725BEF47D0093296C /* CAAnimation+KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CAAnimation+KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D56825BEF47D0093296C /* UITouch-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITouch-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D56925BEF47D0093296C /* UITableView-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITableView-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D56A25BEF47D0093296C /* UIView-Debugging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView-Debugging.h"; sourceTree = "<group>"; };
-		2229D56B25BEF47D0093296C /* UIEvent+KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIEvent+KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D56C25BEF47D0093296C /* NSError-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D56D25BEF47D0093296C /* LoadableCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadableCategory.h; sourceTree = "<group>"; };
-		2229D56E25BEF47D0093296C /* XCTestCase-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestCase-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D56F25BEF47D0093296C /* NSPredicate+KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSPredicate+KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D57025BEF47D0093296C /* NSBundle-KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSBundle-KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D57125BEF47D0093296C /* UIDatePicker+KIFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIDatePicker+KIFAdditions.h"; sourceTree = "<group>"; };
-		2229D57225BEF47D0093296C /* CALayer-KIFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CALayer-KIFAdditions.m"; sourceTree = "<group>"; };
-		2229D57425BEF47D0093296C /* IOHIDEvent+KIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IOHIDEvent+KIF.h"; sourceTree = "<group>"; };
-		2229D57625BEF47D0093296C /* KIFUITestActor-ConditionalTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "KIFUITestActor-ConditionalTests.h"; sourceTree = "<group>"; };
-		2229D57725BEF47D0093296C /* KIFUIObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFUIObject.h; sourceTree = "<group>"; };
-		2229D57825BEF47D0093296C /* KIFSystemTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFSystemTestActor.m; sourceTree = "<group>"; };
-		2229D57925BEF47D0093296C /* KIFTestStepValidation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFTestStepValidation.h; sourceTree = "<group>"; };
-		2229D57A25BEF47D0093296C /* KIFTypist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFTypist.h; sourceTree = "<group>"; };
-		2229D57B25BEF47D0093296C /* KIFAccessibilityEnabler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFAccessibilityEnabler.h; sourceTree = "<group>"; };
-		2229D57C25BEF47D0093296C /* KIFUIViewTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFUIViewTestActor.m; sourceTree = "<group>"; };
-		2229D57D25BEF47D0093296C /* UIAutomationHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIAutomationHelper.h; sourceTree = "<group>"; };
-		2229D57E25BEF47D0093296C /* KIFTextInputTraitsOverrides.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFTextInputTraitsOverrides.m; sourceTree = "<group>"; };
-		2229D58025BEF47D0093296C /* KIFUITestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFUITestActor.m; sourceTree = "<group>"; };
-		2229D58125BEF47D0093296C /* KIFTestActor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFTestActor.h; sourceTree = "<group>"; };
-		2229D58225BEF47D0093296C /* KIFTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFTestCase.h; sourceTree = "<group>"; };
-		2229D58325BEF47D0093296C /* KIFUITestActor_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFUITestActor_Private.h; sourceTree = "<group>"; };
-		2229D58425BEF47D0093296C /* IOHIDEvent+KIF.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IOHIDEvent+KIF.m"; sourceTree = "<group>"; };
-		2229D58525BEF47D0093296C /* KIFTestStepValidation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFTestStepValidation.m; sourceTree = "<group>"; };
-		2229D58625BEF47D0093296C /* KIFTestActor_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFTestActor_Private.h; sourceTree = "<group>"; };
-		2229D58725BEF47D0093296C /* KIFUITestActor-ConditionalTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "KIFUITestActor-ConditionalTests.m"; sourceTree = "<group>"; };
-		2229D58825BEF47D0093296C /* KIFUIObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFUIObject.m; sourceTree = "<group>"; };
-		2229D58925BEF47D0093296C /* KIFSystemTestActor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFSystemTestActor.h; sourceTree = "<group>"; };
-		2229D58A25BEF47D0093296C /* KIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIF.h; sourceTree = "<group>"; };
-		2229D58B25BEF47D0093296C /* KIFTextInputTraitsOverrides.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFTextInputTraitsOverrides.h; sourceTree = "<group>"; };
-		2229D58C25BEF47D0093296C /* UIAutomationHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIAutomationHelper.m; sourceTree = "<group>"; };
-		2229D58D25BEF47D0093296C /* KIFUIViewTestActor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFUIViewTestActor.h; sourceTree = "<group>"; };
-		2229D58E25BEF47D0093296C /* KIFAccessibilityEnabler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFAccessibilityEnabler.m; sourceTree = "<group>"; };
-		2229D58F25BEF47D0093296C /* KIFTypist.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFTypist.m; sourceTree = "<group>"; };
-		2229D59025BEF47D0093296C /* KIFTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFTestCase.m; sourceTree = "<group>"; };
-		2229D59125BEF47D0093296C /* KIFTestActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIFTestActor.m; sourceTree = "<group>"; };
-		2229D59225BEF47D0093296C /* KIFUITestActor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIFUITestActor.h; sourceTree = "<group>"; };
-		2229D59425BEF47D0093296C /* UIDatePicker+KIFPrivateAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIDatePicker+KIFPrivateAPI.h"; sourceTree = "<group>"; };
 		22B1372525D6E27F00D88061 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/Library/Frameworks/IOKit.framework; sourceTree = DEVELOPER_DIR; };
+		25105B302FF6E4C30098BAFB /* KIF.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = KIF.xctestplan; sourceTree = "<group>"; };
 		255C040F2F68D9050023E400 /* KIFTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "KIFTests-Info.plist"; sourceTree = "<group>"; };
 		255C04112F68D9690023E400 /* TestHost-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TestHost-Bridging-Header.h"; sourceTree = "<group>"; };
 		84D293AE1A2C867300C10944 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		84D293B71A2C8DF700C10944 /* AddressBookUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBookUI.framework; path = System/Library/Frameworks/AddressBookUI.framework; sourceTree = SDKROOT; };
 		85DB94711C5A5D430025F83E /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
-		8E654FCC29DA2FE7007F7811 /* UIWindow+KIFSwizzle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIWindow+KIFSwizzle.h"; sourceTree = "<group>"; };
-		8E654FCD29DA2FE7007F7811 /* UIWindow+KIFSwizzle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIWindow+KIFSwizzle.m"; sourceTree = "<group>"; };
 		8EAA1EE129D3AF7A008F6029 /* OffscreenViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OffscreenViewController.m; sourceTree = "<group>"; };
-		8EC2CB1D29DB3D3B001BE493 /* NSObject+KIFSwizzle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSObject+KIFSwizzle.h"; sourceTree = "<group>"; };
-		8EC2CB1E29DB3D3B001BE493 /* NSObject+KIFSwizzle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSObject+KIFSwizzle.m"; sourceTree = "<group>"; };
 		9CC881A21AD4CAAC002CD34C /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		AAB0726B139719AC008AF393 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		AAB072B413971AEA008AF393 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
-		ACA242E52C3DB46A00E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIAccessibilityCustomAction+KIFAdditions.m"; sourceTree = "<group>"; };
-		ACA242E82C3DB4B000E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIAccessibilityCustomAction+KIFAdditions.h"; sourceTree = "<group>"; };
-		ACCF744E2DAFD34C004E3F45 /* NSObject+KIFAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSObject+KIFAdditions.h"; sourceTree = "<group>"; };
-		ACCF744F2DAFD34C004E3F45 /* NSObject+KIFAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSObject+KIFAdditions.m"; sourceTree = "<group>"; };
 		AE62FCD71A1D2667002B10DA /* index.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
 		AE62FCD91A1D26BB002B10DA /* page2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = page2.html; sourceTree = "<group>"; };
 		BCA1542923312E7300CDC69F /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		E9AD81F91AA180B900B369FD /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/IOKit.framework; sourceTree = DEVELOPER_DIR; };
-		EABD46AA1857A0C700A5F081 /* libKIF.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libKIF.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		EABD46AB1857A0EB00A5F081 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		EABD46CD1857A0F300A5F081 /* KIFTests - XCTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "KIFTests - XCTest.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB4C3138167BA3D200E31109 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -267,26 +81,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		EABD468C1857A0C700A5F081 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BCA1542A23312E7300CDC69F /* WebKit.framework in Frameworks */,
-				85DB94721C5A5D430025F83E /* QuartzCore.framework in Frameworks */,
-				EABD46D21857A24E00A5F081 /* XCTest.framework in Frameworks */,
-				EABD468E1857A0C700A5F081 /* Foundation.framework in Frameworks */,
-				EABD468F1857A0C700A5F081 /* UIKit.framework in Frameworks */,
-				0E27A9EE1B45B53D00A6DE6E /* IOKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		EABD46C01857A0F300A5F081 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				25105B2F2FF6E28D0098BAFB /* KIF in Frameworks */,
 				BCA1542C23312E8F00CDC69F /* WebKit.framework in Frameworks */,
 				85DB94741C5A5FE10025F83E /* QuartzCore.framework in Frameworks */,
-				EABD46D61858C8ED00A5F081 /* libKIF.a in Frameworks */,
 				EABD46CF1857A15400A5F081 /* XCTest.framework in Frameworks */,
 				EABD46C31857A0F300A5F081 /* UIKit.framework in Frameworks */,
 				EABD46C41857A0F300A5F081 /* Foundation.framework in Frameworks */,
@@ -312,140 +113,10 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2229D53D25BEF47D0093296C /* IdentifierTests */ = {
-			isa = PBXGroup;
-			children = (
-				2229D53E25BEF47D0093296C /* KIFUITestActor-IdentifierTests.h */,
-				2229D53F25BEF47D0093296C /* KIFUITestActor-IdentifierTests.m */,
-			);
-			name = IdentifierTests;
-			path = Sources/KIF/IdentifierTests;
-			sourceTree = "<group>";
-		};
-		2229D54025BEF47D0093296C /* Visualizer */ = {
-			isa = PBXGroup;
-			children = (
-				2229D54225BEF47D0093296C /* KIFEventVisualizer.h */,
-				2229D54425BEF47D0093296C /* KIFEventVisualizer.m */,
-				2229D54325BEF47D0093296C /* KIFTouchVisualizerView.h */,
-				2229D54625BEF47D0093296C /* KIFTouchVisualizerView.m */,
-				2229D54525BEF47D0093296C /* KIFTouchVisualizerViewCoordinator.h */,
-				2229D54125BEF47D0093296C /* KIFTouchVisualizerViewCoordinator.m */,
-			);
-			name = Visualizer;
-			path = Sources/KIF/Visualizer;
-			sourceTree = "<group>";
-		};
-		2229D54725BEF47D0093296C /* Additions */ = {
-			isa = PBXGroup;
-			children = (
-				2229D56725BEF47D0093296C /* CAAnimation+KIFAdditions.h */,
-				2229D55325BEF47D0093296C /* CAAnimation+KIFAdditions.m */,
-				2229D55925BEF47D0093296C /* CALayer-KIFAdditions.h */,
-				2229D57225BEF47D0093296C /* CALayer-KIFAdditions.m */,
-				2229D55F25BEF47D0093296C /* CGGeometry-KIFAdditions.h */,
-				2229D54D25BEF47D0093296C /* CGGeometry-KIFAdditions.m */,
-				2229D56D25BEF47D0093296C /* LoadableCategory.h */,
-				2229D57025BEF47D0093296C /* NSBundle-KIFAdditions.h */,
-				2229D55A25BEF47D0093296C /* NSBundle-KIFAdditions.m */,
-				2229D55625BEF47D0093296C /* NSError-KIFAdditions.h */,
-				2229D56C25BEF47D0093296C /* NSError-KIFAdditions.m */,
-				2229D56225BEF47D0093296C /* NSException-KIFAdditions.h */,
-				2229D54A25BEF47D0093296C /* NSException-KIFAdditions.m */,
-				2229D55425BEF47D0093296C /* NSFileManager-KIFAdditions.h */,
-				2229D56625BEF47D0093296C /* NSFileManager-KIFAdditions.m */,
-				2229D55B25BEF47D0093296C /* NSPredicate+KIFAdditions.h */,
-				2229D56F25BEF47D0093296C /* NSPredicate+KIFAdditions.m */,
-				2229D56125BEF47D0093296C /* NSString+KIFAdditions.h */,
-				2229D54B25BEF47D0093296C /* NSString+KIFAdditions.m */,
-				ACA242E82C3DB4B000E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.h */,
-				ACA242E52C3DB46A00E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.m */,
-				2229D56425BEF47D0093296C /* UIAccessibilityElement-KIFAdditions.h */,
-				2229D54825BEF47D0093296C /* UIAccessibilityElement-KIFAdditions.m */,
-				2229D54C25BEF47D0093296C /* UIApplication-KIFAdditions.h */,
-				2229D56025BEF47D0093296C /* UIApplication-KIFAdditions.m */,
-				2229D57125BEF47D0093296C /* UIDatePicker+KIFAdditions.h */,
-				2229D55825BEF47D0093296C /* UIDatePicker+KIFAdditions.m */,
-				2229D55725BEF47D0093296C /* UIEvent+KIFAdditions.h */,
-				2229D56B25BEF47D0093296C /* UIEvent+KIFAdditions.m */,
-				2229D56325BEF47D0093296C /* UIScreen+KIFAdditions.h */,
-				2229D54925BEF47D0093296C /* UIScreen+KIFAdditions.m */,
-				2229D55D25BEF47D0093296C /* UIScrollView-KIFAdditions.h */,
-				2229D54F25BEF47D0093296C /* UIScrollView-KIFAdditions.m */,
-				2229D55225BEF47D0093296C /* UITableView-KIFAdditions.h */,
-				2229D56925BEF47D0093296C /* UITableView-KIFAdditions.m */,
-				2229D56825BEF47D0093296C /* UITouch-KIFAdditions.h */,
-				2229D55125BEF47D0093296C /* UITouch-KIFAdditions.m */,
-				2229D56A25BEF47D0093296C /* UIView-Debugging.h */,
-				2229D55025BEF47D0093296C /* UIView-Debugging.m */,
-				2229D55525BEF47D0093296C /* UIView-KIFAdditions.h */,
-				2229D56525BEF47D0093296C /* UIView-KIFAdditions.m */,
-				2229D55E25BEF47D0093296C /* UIWindow-KIFAdditions.h */,
-				2229D54E25BEF47D0093296C /* UIWindow-KIFAdditions.m */,
-				2229D56E25BEF47D0093296C /* XCTestCase-KIFAdditions.h */,
-				2229D55C25BEF47D0093296C /* XCTestCase-KIFAdditions.m */,
-				8E654FCC29DA2FE7007F7811 /* UIWindow+KIFSwizzle.h */,
-				8E654FCD29DA2FE7007F7811 /* UIWindow+KIFSwizzle.m */,
-				8EC2CB1D29DB3D3B001BE493 /* NSObject+KIFSwizzle.h */,
-				8EC2CB1E29DB3D3B001BE493 /* NSObject+KIFSwizzle.m */,
-				ACCF744E2DAFD34C004E3F45 /* NSObject+KIFAdditions.h */,
-				ACCF744F2DAFD34C004E3F45 /* NSObject+KIFAdditions.m */,
-			);
-			name = Additions;
-			path = Sources/KIF/Additions;
-			sourceTree = "<group>";
-		};
-		2229D57325BEF47D0093296C /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				2229D57425BEF47D0093296C /* IOHIDEvent+KIF.h */,
-				2229D58425BEF47D0093296C /* IOHIDEvent+KIF.m */,
-				2229D58A25BEF47D0093296C /* KIF.h */,
-				2229D57B25BEF47D0093296C /* KIFAccessibilityEnabler.h */,
-				2229D58E25BEF47D0093296C /* KIFAccessibilityEnabler.m */,
-				2229D58925BEF47D0093296C /* KIFSystemTestActor.h */,
-				2229D57825BEF47D0093296C /* KIFSystemTestActor.m */,
-				2229D58625BEF47D0093296C /* KIFTestActor_Private.h */,
-				2229D58125BEF47D0093296C /* KIFTestActor.h */,
-				2229D59125BEF47D0093296C /* KIFTestActor.m */,
-				2229D58225BEF47D0093296C /* KIFTestCase.h */,
-				2229D59025BEF47D0093296C /* KIFTestCase.m */,
-				2229D57925BEF47D0093296C /* KIFTestStepValidation.h */,
-				2229D58525BEF47D0093296C /* KIFTestStepValidation.m */,
-				2229D58B25BEF47D0093296C /* KIFTextInputTraitsOverrides.h */,
-				2229D57E25BEF47D0093296C /* KIFTextInputTraitsOverrides.m */,
-				2229D57A25BEF47D0093296C /* KIFTypist.h */,
-				2229D58F25BEF47D0093296C /* KIFTypist.m */,
-				2229D57725BEF47D0093296C /* KIFUIObject.h */,
-				2229D58825BEF47D0093296C /* KIFUIObject.m */,
-				2229D58325BEF47D0093296C /* KIFUITestActor_Private.h */,
-				2229D57625BEF47D0093296C /* KIFUITestActor-ConditionalTests.h */,
-				2229D58725BEF47D0093296C /* KIFUITestActor-ConditionalTests.m */,
-				2229D59225BEF47D0093296C /* KIFUITestActor.h */,
-				2229D58025BEF47D0093296C /* KIFUITestActor.m */,
-				2229D58D25BEF47D0093296C /* KIFUIViewTestActor.h */,
-				2229D57C25BEF47D0093296C /* KIFUIViewTestActor.m */,
-				2229D57D25BEF47D0093296C /* UIAutomationHelper.h */,
-				2229D58C25BEF47D0093296C /* UIAutomationHelper.m */,
-			);
-			name = Classes;
-			path = Sources/KIF/Classes;
-			sourceTree = "<group>";
-		};
-		2229D59325BEF47D0093296C /* ApplePrivateAPIs */ = {
-			isa = PBXGroup;
-			children = (
-				06A507612D5274B800F77047 /* UIView+KIFPrivateAPI.h */,
-				2229D59425BEF47D0093296C /* UIDatePicker+KIFPrivateAPI.h */,
-			);
-			name = ApplePrivateAPIs;
-			path = Sources/KIF/ApplePrivateAPIs;
-			sourceTree = "<group>";
-		};
 		AAB0725D139719AC008AF393 = {
 			isa = PBXGroup;
 			children = (
-				EB60ECBC177F8C51005A041A /* KIF */,
+				25105B302FF6E4C30098BAFB /* KIF.xctestplan */,
 				EB60ECEF177F8DB3005A041A /* Tests */,
 				EB60ECC6177F8C83005A041A /* TestHost */,
 				AAB0726A139719AC008AF393 /* Frameworks */,
@@ -457,7 +128,6 @@
 			isa = PBXGroup;
 			children = (
 				EB60ECC1177F8C83005A041A /* TestHost.app */,
-				EABD46AA1857A0C700A5F081 /* libKIF.a */,
 				EABD46CD1857A0F300A5F081 /* KIFTests - XCTest.xctest */,
 			);
 			name = Products;
@@ -480,18 +150,6 @@
 				EB60ECC4177F8C83005A041A /* CoreGraphics.framework */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		EB60ECBC177F8C51005A041A /* KIF */ = {
-			isa = PBXGroup;
-			children = (
-				2229D54725BEF47D0093296C /* Additions */,
-				2229D59325BEF47D0093296C /* ApplePrivateAPIs */,
-				2229D57325BEF47D0093296C /* Classes */,
-				2229D53D25BEF47D0093296C /* IdentifierTests */,
-				2229D54025BEF47D0093296C /* Visualizer */,
-			);
-			name = KIF;
 			sourceTree = "<group>";
 		};
 		EB60ECC6177F8C83005A041A /* TestHost */ = {
@@ -534,64 +192,6 @@
 		};
 /* End PBXGroup section */
 
-/* Begin PBXHeadersBuildPhase section */
-		EABD46901857A0C700A5F081 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2229D5E125BEF47D0093296C /* KIFUIViewTestActor.h in Headers */,
-				2229D5AC25BEF47D0093296C /* UIEvent+KIFAdditions.h in Headers */,
-				2229D5B325BEF47D0093296C /* UIWindow-KIFAdditions.h in Headers */,
-				2229D5DD25BEF47D0093296C /* KIFSystemTestActor.h in Headers */,
-				2229D5CB25BEF47D0093296C /* KIFUIObject.h in Headers */,
-				2229D5DF25BEF47D0093296C /* KIFTextInputTraitsOverrides.h in Headers */,
-				2229D5E725BEF47D0093296C /* UIDatePicker+KIFPrivateAPI.h in Headers */,
-				2229D5CA25BEF47D0093296C /* KIFUITestActor-ConditionalTests.h in Headers */,
-				2229D59825BEF47D0093296C /* KIFEventVisualizer.h in Headers */,
-				2229D5B225BEF47D0093296C /* UIScrollView-KIFAdditions.h in Headers */,
-				2229D5BF25BEF47D0093296C /* UIView-Debugging.h in Headers */,
-				2229D5D725BEF47D0093296C /* KIFUITestActor_Private.h in Headers */,
-				2229D5D125BEF47D0093296C /* UIAutomationHelper.h in Headers */,
-				2229D5AE25BEF47D0093296C /* CALayer-KIFAdditions.h in Headers */,
-				2229D5DE25BEF47D0093296C /* KIF.h in Headers */,
-				2229D5CE25BEF47D0093296C /* KIFTypist.h in Headers */,
-				2229D5A725BEF47D0093296C /* UITableView-KIFAdditions.h in Headers */,
-				8EC2CB1F29DB3D3B001BE493 /* NSObject+KIFSwizzle.h in Headers */,
-				2229D5AB25BEF47D0093296C /* NSError-KIFAdditions.h in Headers */,
-				2229D5B825BEF47D0093296C /* UIScreen+KIFAdditions.h in Headers */,
-				ACCF74512DAFD34C004E3F45 /* NSObject+KIFAdditions.h in Headers */,
-				2229D5AA25BEF47D0093296C /* UIView-KIFAdditions.h in Headers */,
-				ACA242E92C3DB4EA00E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.h in Headers */,
-				2229D5CD25BEF47D0093296C /* KIFTestStepValidation.h in Headers */,
-				2229D5C225BEF47D0093296C /* LoadableCategory.h in Headers */,
-				2229D5D625BEF47D0093296C /* KIFTestCase.h in Headers */,
-				2229D5C825BEF47D0093296C /* IOHIDEvent+KIF.h in Headers */,
-				06A507622D5274B800F77047 /* UIView+KIFPrivateAPI.h in Headers */,
-				2229D5B725BEF47D0093296C /* NSException-KIFAdditions.h in Headers */,
-				2229D5C325BEF47D0093296C /* XCTestCase-KIFAdditions.h in Headers */,
-				2229D5B425BEF47D0093296C /* CGGeometry-KIFAdditions.h in Headers */,
-				2229D5E625BEF47D0093296C /* KIFUITestActor.h in Headers */,
-				2229D5B625BEF47D0093296C /* NSString+KIFAdditions.h in Headers */,
-				2229D5BC25BEF47D0093296C /* CAAnimation+KIFAdditions.h in Headers */,
-				2229D59525BEF47D0093296C /* KIFUITestActor-IdentifierTests.h in Headers */,
-				8E654FCE29DA2FE7007F7811 /* UIWindow+KIFSwizzle.h in Headers */,
-				2229D59925BEF47D0093296C /* KIFTouchVisualizerView.h in Headers */,
-				2229D5C525BEF47D0093296C /* NSBundle-KIFAdditions.h in Headers */,
-				2229D59B25BEF47D0093296C /* KIFTouchVisualizerViewCoordinator.h in Headers */,
-				2229D5DA25BEF47D0093296C /* KIFTestActor_Private.h in Headers */,
-				2229D5A125BEF47D0093296C /* UIApplication-KIFAdditions.h in Headers */,
-				2229D5C625BEF47D0093296C /* UIDatePicker+KIFAdditions.h in Headers */,
-				2229D5B925BEF47D0093296C /* UIAccessibilityElement-KIFAdditions.h in Headers */,
-				2229D5CF25BEF47D0093296C /* KIFAccessibilityEnabler.h in Headers */,
-				2229D5B025BEF47D0093296C /* NSPredicate+KIFAdditions.h in Headers */,
-				2229D5BD25BEF47D0093296C /* UITouch-KIFAdditions.h in Headers */,
-				2229D5A925BEF47D0093296C /* NSFileManager-KIFAdditions.h in Headers */,
-				2229D5D525BEF47D0093296C /* KIFTestActor.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
 /* Begin PBXLegacyTarget section */
 		A88930091685088F00FC7C63 /* KIF Documentation */ = {
 			isa = PBXLegacyTarget;
@@ -610,23 +210,6 @@
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
-		EABD46791857A0C700A5F081 /* KIF */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = EABD46A61857A0C700A5F081 /* Build configuration list for PBXNativeTarget "KIF" */;
-			buildPhases = (
-				EABD467A1857A0C700A5F081 /* Sources */,
-				EABD468C1857A0C700A5F081 /* Frameworks */,
-				EABD46901857A0C700A5F081 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = KIF;
-			productName = KIFTestCase;
-			productReference = EABD46AA1857A0C700A5F081 /* libKIF.a */;
-			productType = "com.apple.product-type.library.static";
-		};
 		EABD46AD1857A0F300A5F081 /* KIFTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EABD46C91857A0F300A5F081 /* Build configuration list for PBXNativeTarget "KIFTests" */;
@@ -691,11 +274,13 @@
 				Base,
 			);
 			mainGroup = AAB0725D139719AC008AF393;
+			packageReferences = (
+				25105B2D2FF6E28D0098BAFB /* XCLocalSwiftPackageReference "../KIF" */,
+			);
 			productRefGroup = AAB07269139719AC008AF393 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				EABD46791857A0C700A5F081 /* KIF */,
 				A88930091685088F00FC7C63 /* KIF Documentation */,
 				EB60ECC0177F8C83005A041A /* TestHost */,
 				EABD46AD1857A0F300A5F081 /* KIFTests */,
@@ -728,55 +313,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		EABD467A1857A0C700A5F081 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2229D5E225BEF47D0093296C /* KIFAccessibilityEnabler.m in Sources */,
-				2229D59D25BEF47D0093296C /* UIAccessibilityElement-KIFAdditions.m in Sources */,
-				2229D5D225BEF47D0093296C /* KIFTextInputTraitsOverrides.m in Sources */,
-				2229D5BB25BEF47D0093296C /* NSFileManager-KIFAdditions.m in Sources */,
-				2229D5DB25BEF47D0093296C /* KIFUITestActor-ConditionalTests.m in Sources */,
-				2229D59725BEF47D0093296C /* KIFTouchVisualizerViewCoordinator.m in Sources */,
-				2229D5B125BEF47D0093296C /* XCTestCase-KIFAdditions.m in Sources */,
-				2229D5A225BEF47D0093296C /* CGGeometry-KIFAdditions.m in Sources */,
-				8E654FD029DA2FE7007F7811 /* UIWindow+KIFSwizzle.m in Sources */,
-				2229D5BE25BEF47D0093296C /* UITableView-KIFAdditions.m in Sources */,
-				2229D5AF25BEF47D0093296C /* NSBundle-KIFAdditions.m in Sources */,
-				2229D59C25BEF47D0093296C /* KIFTouchVisualizerView.m in Sources */,
-				2229D5D825BEF47D0093296C /* IOHIDEvent+KIF.m in Sources */,
-				2229D5DC25BEF47D0093296C /* KIFUIObject.m in Sources */,
-				2229D5BA25BEF47D0093296C /* UIView-KIFAdditions.m in Sources */,
-				2229D5D425BEF47D0093296C /* KIFUITestActor.m in Sources */,
-				2229D59625BEF47D0093296C /* KIFUITestActor-IdentifierTests.m in Sources */,
-				2229D5A425BEF47D0093296C /* UIScrollView-KIFAdditions.m in Sources */,
-				2229D5C425BEF47D0093296C /* NSPredicate+KIFAdditions.m in Sources */,
-				2229D59E25BEF47D0093296C /* UIScreen+KIFAdditions.m in Sources */,
-				2229D5A825BEF47D0093296C /* CAAnimation+KIFAdditions.m in Sources */,
-				2229D5E525BEF47D0093296C /* KIFTestActor.m in Sources */,
-				2229D5A325BEF47D0093296C /* UIWindow-KIFAdditions.m in Sources */,
-				2229D5E325BEF47D0093296C /* KIFTypist.m in Sources */,
-				2229D5E425BEF47D0093296C /* KIFTestCase.m in Sources */,
-				2229D5C725BEF47D0093296C /* CALayer-KIFAdditions.m in Sources */,
-				2229D5D025BEF47D0093296C /* KIFUIViewTestActor.m in Sources */,
-				2229D5AD25BEF47D0093296C /* UIDatePicker+KIFAdditions.m in Sources */,
-				2229D59A25BEF47D0093296C /* KIFEventVisualizer.m in Sources */,
-				ACCF74502DAFD34C004E3F45 /* NSObject+KIFAdditions.m in Sources */,
-				2229D5E025BEF47D0093296C /* UIAutomationHelper.m in Sources */,
-				2229D5A025BEF47D0093296C /* NSString+KIFAdditions.m in Sources */,
-				2229D59F25BEF47D0093296C /* NSException-KIFAdditions.m in Sources */,
-				2229D5A625BEF47D0093296C /* UITouch-KIFAdditions.m in Sources */,
-				2229D5CC25BEF47D0093296C /* KIFSystemTestActor.m in Sources */,
-				2229D5D925BEF47D0093296C /* KIFTestStepValidation.m in Sources */,
-				2229D5A525BEF47D0093296C /* UIView-Debugging.m in Sources */,
-				2229D5C125BEF47D0093296C /* NSError-KIFAdditions.m in Sources */,
-				ACA242E72C3DB47400E6F1B6 /* UIAccessibilityCustomAction+KIFAdditions.m in Sources */,
-				8EC2CB2129DB3D3B001BE493 /* NSObject+KIFSwizzle.m in Sources */,
-				2229D5B525BEF47D0093296C /* UIApplication-KIFAdditions.m in Sources */,
-				2229D5C025BEF47D0093296C /* UIEvent+KIFAdditions.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		EABD46B01857A0F300A5F081 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -972,59 +508,6 @@
 			};
 			name = Release;
 		};
-		EABD46A71857A0C700A5F081 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				DSTROOT = /tmp/KIF.dst;
-				ENABLE_BITCODE = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
-				GCC_PREFIX_HEADER = "";
-				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = KIF;
-			};
-			name = Debug;
-		};
-		EABD46A81857A0C700A5F081 /* Coverage */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				DSTROOT = /tmp/KIF.dst;
-				ENABLE_BITCODE = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
-				GCC_PREFIX_HEADER = "";
-				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = KIF;
-			};
-			name = Coverage;
-		};
-		EABD46A91857A0C700A5F081 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				DSTROOT = /tmp/KIF.dst;
-				ENABLE_BITCODE = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
-				GCC_PREFIX_HEADER = "";
-				HEADER_SEARCH_PATHS = "$(inherited)";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = KIF;
-			};
-			name = Release;
-		};
 		EABD46CA1857A0F300A5F081 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1032,6 +515,7 @@
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -1069,6 +553,7 @@
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -1106,6 +591,7 @@
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -1338,16 +824,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		EABD46A61857A0C700A5F081 /* Build configuration list for PBXNativeTarget "KIF" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				EABD46A71857A0C700A5F081 /* Debug */,
-				EABD46A81857A0C700A5F081 /* Coverage */,
-				EABD46A91857A0C700A5F081 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		EABD46C91857A0F300A5F081 /* Build configuration list for PBXNativeTarget "KIFTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1369,6 +845,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		25105B2D2FF6E28D0098BAFB /* XCLocalSwiftPackageReference "../KIF" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../KIF;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		25105B2E2FF6E28D0098BAFB /* KIF */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KIF;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AAB0725F139719AC008AF393 /* Project object */;
 }

--- a/KIF.xcodeproj/xcshareddata/xcschemes/KIF.xcscheme
+++ b/KIF.xcodeproj/xcshareddata/xcschemes/KIF.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
-   version = "1.3">
+   LastUpgradeVersion = "2650"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -14,10 +15,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EABD46791857A0C700A5F081"
-               BuildableName = "libKIF.a"
+               BlueprintIdentifier = "KIF"
+               BuildableName = "KIF"
                BlueprintName = "KIF"
-               ReferencedContainer = "container:KIF.xcodeproj">
+               ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -27,24 +28,21 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EABD46791857A0C700A5F081"
-            BuildableName = "libKIF.a"
-            BlueprintName = "KIF"
-            ReferencedContainer = "container:KIF.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:KIF.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EABD46AD1857A0F300A5F081"
-               BuildableName = "KIFTests - XCTest.xctest"
+               BlueprintIdentifier = "KIFTests"
+               BuildableName = "KIFTests"
                BlueprintName = "KIFTests"
-               ReferencedContainer = "container:KIF.xcodeproj">
+               ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
       </Testables>
@@ -59,27 +57,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EABD46791857A0C700A5F081"
-            BuildableName = "libKIF.a"
-            BlueprintName = "KIF"
-            ReferencedContainer = "container:KIF.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "KIF_PRINTVIEWTREEONFAILURE"
-            value = "YES"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "VISUALIZE_TOUCHES"
-            value = "YES"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -90,10 +67,10 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EABD46791857A0C700A5F081"
-            BuildableName = "libKIF.a"
+            BlueprintIdentifier = "KIF"
+            BuildableName = "KIF"
             BlueprintName = "KIF"
-            ReferencedContainer = "container:KIF.xcodeproj">
+            ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>
    </ProfileAction>

--- a/KIF.xcodeproj/xcshareddata/xcschemes/KIFTests.xcscheme
+++ b/KIF.xcodeproj/xcshareddata/xcschemes/KIFTests.xcscheme
@@ -1,33 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
-   version = "1.3">
+   LastUpgradeVersion = "2650"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A88930091685088F00FC7C63"
-               BuildableName = "KIF Documentation"
-               BlueprintName = "KIF Documentation"
-               ReferencedContainer = "container:KIF.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EABD46AD1857A0F300A5F081"
+               BuildableName = "KIFTests - XCTest.xctest"
+               BlueprintName = "KIFTests"
+               ReferencedContainer = "container:KIF.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -39,16 +35,18 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
-      <MacroExpansion>
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "A88930091685088F00FC7C63"
-            BuildableName = "KIF Documentation"
-            BlueprintName = "KIF Documentation"
+            BlueprintIdentifier = "EB60ECC0177F8C83005A041A"
+            BuildableName = "TestHost.app"
+            BlueprintName = "TestHost"
             ReferencedContainer = "container:KIF.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -56,6 +54,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EB60ECC0177F8C83005A041A"
+            BuildableName = "TestHost.app"
+            BlueprintName = "TestHost"
+            ReferencedContainer = "container:KIF.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/KIF.xctestplan
+++ b/KIF.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "28683086-9317-4D0B-9456-520884DD03F4",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "performanceAntipatternCheckerEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:KIF.xcodeproj",
+        "identifier" : "EABD46AD1857A0F300A5F081",
+        "name" : "KIFTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     targets: [
         .target(
             name: "KIF",
-            dependencies: [],
+            dependencies: ["KIFSwift"],
             publicHeadersPath: "include",
             cSettings: [
                 .headerSearchPath("ApplePrivateAPIs/"),
@@ -27,6 +27,10 @@ let package = Package(
                 .headerSearchPath("IdentifierTests/"),
             ],
             linkerSettings: [.linkedFramework("IOKit"), .linkedFramework("XCTest")]
+        ),
+        .target(
+            name: "KIFSwift",
+            dependencies: [],
         ),
         .testTarget(
             name: "KIFTests",

--- a/Sources/KIF/Additions/UIView-Debugging.m
+++ b/Sources/KIF/Additions/UIView-Debugging.m
@@ -9,6 +9,7 @@
 #import "KIFEventVisualizer.h"
 #import "KIFTouchVisualizerView.h"
 #import <Foundation/Foundation.h>
+@import KIFSwift;
 
 @implementation UIView (Debugging)
 
@@ -94,7 +95,7 @@
 }
 
 - (void)_KIF_appendClassName:(NSMutableString *)result {
-    [result appendString:NSStringFromClass([self class])];
+    [result appendString:[NSObject _kif_typeNameOfObject:self qualified:YES]];
 }
 
 - (void)_KIF_appendAccessibilityInfo:(NSMutableString *)result {

--- a/Sources/KIFSwift/NSObject+KIF.swift
+++ b/Sources/KIFSwift/NSObject+KIF.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension NSObject {
+    /// Return a demangled type name for a given object.
+    /// If `qualified` is `true`, Swift types will produce a qualified type name
+    @objc(_kif_typeNameOfObject:qualified:)
+    public static func _kif_typeName(object: Any, qualified: Bool) -> String {
+        let meta = type(of: object)
+        if qualified {
+            return String(reflecting: meta)    
+        } else {
+            return String(describing: meta)
+        }
+    }
+}

--- a/Tests/KIFTests/AccessibilityIdentifierPullToRefreshTests.m
+++ b/Tests/KIFTests/AccessibilityIdentifierPullToRefreshTests.m
@@ -6,11 +6,7 @@
 //
 //
 
-#import <KIF/KIFTestCase.h>
-#import <KIF/KIFUITestActor-IdentifierTests.h>
-#import <KIF/KIFUIViewTestActor.h>
-
-#import <KIF/KIFTestStepValidation.h>
+@import KIF;
 
 @interface AccessibilityIdentifierPullToRefreshTests : KIFTestCase
 @end

--- a/Tests/KIFTests/AccessibilityIdentifierTests.m
+++ b/Tests/KIFTests/AccessibilityIdentifierTests.m
@@ -6,9 +6,7 @@
 //
 //
 
-#import <KIF/KIFTestCase.h>
-#import <KIF/KIFUITestActor-IdentifierTests.h>
-#import <KIF/KIFTestStepValidation.h>
+@import KIF;
 
 @interface AccessibilityIdentifierTests : KIFTestCase
 @end

--- a/Tests/KIFTests/Additions/UIScreen+KIFAdditionsTests.m
+++ b/Tests/KIFTests/Additions/UIScreen+KIFAdditionsTests.m
@@ -7,7 +7,7 @@
 //
 
 #import <XCTest/XCTest.h>
-#import "UIScreen+KIFAdditions.h"
+@import KIF;
 
 @interface CustomBoundsUIScreen : UIScreen
 

--- a/Tests/KIFTests/AutocorrectTests.m
+++ b/Tests/KIFTests/AutocorrectTests.m
@@ -5,9 +5,8 @@
 //  Created by Harley Cooper on 2/7/18.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
-#import "KIFTextInputTraitsOverrides.h"
 
 @interface AutocorrectTests : KIFTestCase
 @end

--- a/Tests/KIFTests/BackgroundTests.m
+++ b/Tests/KIFTests/BackgroundTests.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface BackgroundTests : KIFTestCase
 

--- a/Tests/KIFTests/CascadingFailureTests.m
+++ b/Tests/KIFTests/CascadingFailureTests.m
@@ -6,8 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
-#import "KIFTestStepValidation.h"
+@import KIF;
 
 @interface KIFSystemTestActor (CascadingFailureTests)
 - (void)failA;

--- a/Tests/KIFTests/CollectionViewTests.m
+++ b/Tests/KIFTests/CollectionViewTests.m
@@ -6,8 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
-#import "KIFTestStepValidation.h"
+@import KIF;
 
 @interface CollectionViewTests : KIFTestCase
 @end

--- a/Tests/KIFTests/CompositionTests.m
+++ b/Tests/KIFTests/CompositionTests.m
@@ -6,9 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
-#import "UIApplication-KIFAdditions.h"
-#import "UIAccessibilityElement-KIFAdditions.h"
+@import KIF;
 
 @interface KIFUITestActor (Composition)
 

--- a/Tests/KIFTests/CustomPickerTests.m
+++ b/Tests/KIFTests/CustomPickerTests.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface CustomPickerTests : KIFTestCase
 @end

--- a/Tests/KIFTests/ExistTests.m
+++ b/Tests/KIFTests/ExistTests.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface ExistTests : KIFTestCase
 @end

--- a/Tests/KIFTests/GestureTests.m
+++ b/Tests/KIFTests/GestureTests.m
@@ -6,10 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
-#import <KIF/KIFTestStepValidation.h>
-#import <KIF/KIFUITestActor-IdentifierTests.h>
-#import <KIF/UIView-KIFAdditions.h>
+@import KIF;
 
 #define kPanMeAccessibilityString               @"Pan Me"
 #define kVelocityValueLabelAccessibilityString  @"velocityValueLabel"

--- a/Tests/KIFTests/KIFUIViewTestActor/AccessibilityActivationTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/AccessibilityActivationTests_ViewTestActor.m
@@ -5,7 +5,7 @@
 //  Created by Alex Odawa on 09/07/2024.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 #import <UIKit/UIAccessibility.h>
 
 @interface AccessibilityActivateTests_ViewTestActor : KIFTestCase

--- a/Tests/KIFTests/KIFUIViewTestActor/AccessibilityIdentifierTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/AccessibilityIdentifierTests_ViewTestActor.m
@@ -6,8 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
-#import <KIF/KIFTestStepValidation.h>
+@import KIF;
 
 @interface AccessibilityIdentifierTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/AutocorrectTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/AutocorrectTests_ViewTestActor.m
@@ -5,9 +5,8 @@
 //  Created by Harley Cooper on 2/7/18.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
-#import "KIFTextInputTraitsOverrides.h"
 
 @interface AutocorrectTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/CollectionViewTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/CollectionViewTests_ViewTestActor.m
@@ -6,8 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
-#import "KIFTestStepValidation.h"
+@import KIF;
 
 @interface CollectionViewTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/CompositionTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/CompositionTests_ViewTestActor.m
@@ -6,9 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
-#import "UIApplication-KIFAdditions.h"
-#import "UIAccessibilityElement-KIFAdditions.h"
+@import KIF;
 
 @interface KIFUIViewTestActor (Composition)
 

--- a/Tests/KIFTests/KIFUIViewTestActor/CustomActionTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/CustomActionTests_ViewTestActor.m
@@ -5,7 +5,7 @@
 //  Created by Alex Odawa on 09/07/2024.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface CustomActionTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/CustomPickerTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/CustomPickerTests_ViewTestActor.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface CustomPickerTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/ExistTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/ExistTests_ViewTestActor.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface ExistTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/GestureTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/GestureTests_ViewTestActor.m
@@ -7,8 +7,7 @@
 //
 
 
-#import <KIF/KIF.h>
-#import <KIF/KIFTestStepValidation.h>
+@import KIF;
 @implementation KIFUIViewTestActor (gesturetests)
 
 - (KIFUIViewTestActor *)swipeMe

--- a/Tests/KIFTests/KIFUIViewTestActor/LandscapeTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/LandscapeTests_ViewTestActor.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface LandscapeTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/LongPressTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/LongPressTests_ViewTestActor.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface LongPressTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/ModalViewTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/ModalViewTests_ViewTestActor.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface ModalViewTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/MultiFingerTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/MultiFingerTests_ViewTestActor.m
@@ -7,9 +7,7 @@
 //
 
 
-#import <KIF/KIF.h>
-#import "KIFTestStepValidation.h"
-#import <KIF/UIApplication-KIFAdditions.h>
+@import KIF;
 
 @interface MultiFingerTests_ViewTestActor : KIFTestCase
 @property (nonatomic, readwrite) BOOL twoFingerPanSuccess;

--- a/Tests/KIFTests/KIFUIViewTestActor/OffscreenTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/OffscreenTests_ViewTestActor.m
@@ -5,8 +5,7 @@
 //  Created by Steve Sun on 2023-03-31.
 //
 
-#import <KIF/KIF.h>
-#import "KIFUITestActor.h"
+@import KIF;
 
 @interface OffscreenTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/PickerTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/PickerTests_ViewTestActor.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @implementation KIFUIViewTestActor (pickertests)
 

--- a/Tests/KIFTests/KIFUIViewTestActor/PullToRefreshTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/PullToRefreshTests_ViewTestActor.m
@@ -7,8 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "KIFTestCase.h"
-#import "KIFUIViewTestActor.h"
+@import KIF;
 
 @interface PullToRefreshTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/ScrollViewTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/ScrollViewTests_ViewTestActor.m
@@ -6,8 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
-#import "KIFTestStepValidation.h"
+@import KIF;
 
 @interface ScrollViewTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/SearchFieldTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/SearchFieldTests_ViewTestActor.m
@@ -7,8 +7,7 @@
 //
 
 
-#import <KIF/KIF.h>
-#import <KIF/UIApplication-KIFAdditions.h>
+@import KIF;
 
 @interface SearchFieldTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/SpecificControlTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/SpecificControlTests_ViewTestActor.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface SpecificControlTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/SystemAlertTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/SystemAlertTests_ViewTestActor.m
@@ -7,8 +7,7 @@
 //
 
 
-#import <KIF/KIF.h>
-#import "KIFUITestActor.h"
+@import KIF;
 
 @interface SystemAlertTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/TableViewTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/TableViewTests_ViewTestActor.m
@@ -7,9 +7,7 @@
 //
 
 
-#import <KIF/KIF.h>
-#import "KIFTestStepValidation.h"
-#import "UIApplication-KIFAdditions.h"
+@import KIF;
 
 @interface TableViewTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/TappingTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/TappingTests_ViewTestActor.m
@@ -7,7 +7,7 @@
 //
 
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @implementation KIFUIViewTestActor (tappingtests)
 

--- a/Tests/KIFTests/KIFUIViewTestActor/TypingTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/TypingTests_ViewTestActor.m
@@ -6,8 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
-#import "KIFTestStepValidation.h"
+@import KIF;
 
 @interface TypingTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/WaitForAbscenceTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/WaitForAbscenceTests_ViewTestActor.m
@@ -7,7 +7,7 @@
 //
 
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface WaitForAbscenceTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/WaitForAnimationTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/WaitForAnimationTests_ViewTestActor.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface WaitForAnimationTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/WaitForTappableViewTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/WaitForTappableViewTests_ViewTestActor.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface WaitForTappableViewTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/WaitForViewTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/WaitForViewTests_ViewTestActor.m
@@ -7,7 +7,7 @@
 //
 
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface WaitForViewTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/KIFUIViewTestActor/WebViewTests_ViewTestActor.m
+++ b/Tests/KIFTests/KIFUIViewTestActor/WebViewTests_ViewTestActor.m
@@ -6,10 +6,7 @@
 //
 //
 
-#import <KIF/KIFTestCase.h>
-#import <KIF/KIFUIViewTestActor.h>
-#import <KIF/KIFUITestActor-IdentifierTests.h>
-#import <KIF/KIFTestStepValidation.h>
+@import KIF;
 
 @interface WebViewTests_ViewTestActor : KIFTestCase
 @end

--- a/Tests/KIFTests/LandscapeTests.m
+++ b/Tests/KIFTests/LandscapeTests.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface LandscapeTests : KIFTestCase
 @end

--- a/Tests/KIFTests/LongPressTests.m
+++ b/Tests/KIFTests/LongPressTests.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface LongPressTests : KIFTestCase
 @end

--- a/Tests/KIFTests/ModalViewTests.m
+++ b/Tests/KIFTests/ModalViewTests.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface ModalViewTests : KIFTestCase
 @end

--- a/Tests/KIFTests/OffscreenTests.m
+++ b/Tests/KIFTests/OffscreenTests.m
@@ -5,8 +5,7 @@
 //  Created by Steve Sun on 2023-03-28.
 //
 
-#import <KIF/KIF.h>
-#import "KIFTestStepValidation.h"
+@import KIF;
 
 @interface OffscreenTests : KIFTestCase
 @end

--- a/Tests/KIFTests/PickerTests.m
+++ b/Tests/KIFTests/PickerTests.m
@@ -1,4 +1,4 @@
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface PickerTests : KIFTestCase
 @end

--- a/Tests/KIFTests/PullToRefreshTests.m
+++ b/Tests/KIFTests/PullToRefreshTests.m
@@ -6,10 +6,7 @@
 //
 //
 
-#import <KIF/KIFTestCase.h>
-#import <KIF/KIFUITestActor-IdentifierTests.h>
-#import <KIF/KIFUIViewTestActor.h>
-#import <KIF/KIFTestStepValidation.h>
+@import KIF;
 
 @interface PullToRefreshTests : KIFTestCase
 @end

--- a/Tests/KIFTests/ScrollViewTests.m
+++ b/Tests/KIFTests/ScrollViewTests.m
@@ -6,8 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
-#import "KIFTestStepValidation.h"
+@import KIF;
 
 @interface ScrollViewTests : KIFTestCase
 @end

--- a/Tests/KIFTests/SearchFieldTests.m
+++ b/Tests/KIFTests/SearchFieldTests.m
@@ -6,8 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
-#import <KIF/UIApplication-KIFAdditions.h>
+@import KIF;
 
 @interface SearchFieldTests : KIFTestCase
 @end

--- a/Tests/KIFTests/SpecificControlTests.m
+++ b/Tests/KIFTests/SpecificControlTests.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface SpecificControlTests : KIFTestCase
 @end

--- a/Tests/KIFTests/SwiftUI Tests/SwiftUITappingTests.m
+++ b/Tests/KIFTests/SwiftUI Tests/SwiftUITappingTests.m
@@ -5,7 +5,7 @@
 //  Created by Bartłomiej Włodarczak on 03/02/2025.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface SwiftUITappingTests : KIFTestCase
 @end

--- a/Tests/KIFTests/SwiftUI Tests/SwiftUITypingTests.m
+++ b/Tests/KIFTests/SwiftUI Tests/SwiftUITypingTests.m
@@ -5,8 +5,7 @@
 //  Created by Bartłomiej Włodarczak on 10/02/2025.
 //
 
-#import <KIF/KIF.h>
-#import "KIFTestStepValidation.h"
+@import KIF;
 
 @interface SwiftUITypingTests : KIFTestCase
 @end

--- a/Tests/KIFTests/SystemAlertTests.m
+++ b/Tests/KIFTests/SystemAlertTests.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface SystemAlertTests : KIFTestCase
 

--- a/Tests/KIFTests/SystemTests.m
+++ b/Tests/KIFTests/SystemTests.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 #define KIFAssertEqual XCTAssertEqual
 #define KIFAssertEqualObjects XCTAssertEqualObjects

--- a/Tests/KIFTests/TableViewTests.m
+++ b/Tests/KIFTests/TableViewTests.m
@@ -6,10 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
-#import <KIF/KIFUITestActor-IdentifierTests.h>
-#import "KIFTestStepValidation.h"
-#import "UIApplication-KIFAdditions.h"
+@import KIF;
 
 @interface TableViewTests : KIFTestCase
 @end

--- a/Tests/KIFTests/TappingTests.m
+++ b/Tests/KIFTests/TappingTests.m
@@ -6,8 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
-#import <KIF/KIFUITestActor-IdentifierTests.h>
+@import KIF;
 
 @interface TappingTests : KIFTestCase
 @end

--- a/Tests/KIFTests/TypingTests.m
+++ b/Tests/KIFTests/TypingTests.m
@@ -6,8 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
-#import "KIFTestStepValidation.h"
+@import KIF;
 
 @interface TypingTests : KIFTestCase
 @end

--- a/Tests/KIFTests/UIApplicationKIFAdditionsTests.m
+++ b/Tests/KIFTests/UIApplicationKIFAdditionsTests.m
@@ -6,8 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
-#import "UIApplication-KIFAdditions.h"
+@import KIF;
 
 @interface UIApplication ()
 - (NSString *)imageNameForFile:(NSString *)filename lineNumber:(NSUInteger)lineNumber description:(NSString *)description;

--- a/Tests/KIFTests/WaitForAbscenceTests.m
+++ b/Tests/KIFTests/WaitForAbscenceTests.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface WaitForAbscenceTests : KIFTestCase
 @end

--- a/Tests/KIFTests/WaitForAnimationTests.m
+++ b/Tests/KIFTests/WaitForAnimationTests.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface WaitForAnimationTests : KIFTestCase
 

--- a/Tests/KIFTests/WaitForTappableViewTests.m
+++ b/Tests/KIFTests/WaitForTappableViewTests.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface WaitForTappableViewTests : KIFTestCase
 @end

--- a/Tests/KIFTests/WaitForViewTests.m
+++ b/Tests/KIFTests/WaitForViewTests.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Brian Nickel. All rights reserved.
 //
 
-#import <KIF/KIF.h>
+@import KIF;
 
 @interface WaitForViewTests : KIFTestCase
 @end

--- a/Tests/KIFTests/WebViewTests.m
+++ b/Tests/KIFTests/WebViewTests.m
@@ -6,9 +6,7 @@
 //
 //
 
-#import <KIF/KIFTestCase.h>
-#import <KIF/KIFUITestActor-IdentifierTests.h>
-#import <KIF/KIFTestStepValidation.h>
+@import KIF;
 
 @interface WebViewTests : KIFTestCase
 @end


### PR DESCRIPTION
Emit demangled Swift type names in view hierarchy dumps.

## Examples

* `_TtCO8MarketUI16MarketNavigation4View` -> `MarketUI.MarketNavigation.View`
* `_TtGC16MarketWorkflowUI26MarketScreenViewControllerV19InvoicesDetails_App34InvoicesDetailsAccountLoadedScreen_` -> `MarketWorkflowUI.MarketScreenViewController<InvoicesDetails_App.InvoicesDetailsAccountLoadedScreen>`

