### PR TITLE
Reveal in-bounds elements covered by floating overlays before failing tappability

### DIFF
--- a/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -280,10 +280,12 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
 // uncover it and the caller should fail with the original error).
 + (BOOL)KIF_revealPossiblyCoveredAccessibilityElement:(UIAccessibilityElement *)element view:(UIView *)view;
 {
+    // The view itself is a candidate: a scroll view acting as the accessibility
+    // container resolves as the element's containing view.
     UIScrollView *scrollView = nil;
-    for (UIView *superview = view.superview; superview; superview = superview.superview) {
-        if ([superview isKindOfClass:[UIScrollView class]]) {
-            scrollView = (UIScrollView *)superview;
+    for (UIView *candidate = view; candidate; candidate = candidate.superview) {
+        if ([candidate isKindOfClass:[UIScrollView class]]) {
+            scrollView = (UIScrollView *)candidate;
             break;
         }
     }

--- a/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIAccessibilityElement-KIFAdditions.m
@@ -256,13 +256,61 @@ MAKE_CATEGORIES_LOADABLE(UIAccessibilityElement_KIFAdditions)
     }
     
     if (mustBeTappable && !view.isProbablyTappable) {
+        // The scroll pass above only scrolls when the element lies outside its scroll view's
+        // visible rect. An element inside the visible rect can still fail hit-testing when a
+        // floating overlay (e.g. a tab bar or toolbar) covers it. Center the element in its
+        // scroll ancestor's viewport, which moves it clear of edge-anchored overlays, and
+        // resolve once more with scrolling disabled.
+        if (!scrollDisabled && [self KIF_revealPossiblyCoveredAccessibilityElement:element view:view]) {
+            return [self viewContainingAccessibilityElement:element tappable:mustBeTappable error:error disableScroll:YES];
+        }
         if (error) {
             *error = [NSError KIFErrorWithFormat:@"Accessibility element %@ for view %@ with label \"%@\" is not tappable. It may be blocked by other views.", element, view, element.accessibilityLabel];
         }
         return nil;
     }
-    
+
     return view;
+}
+
+// Attempts to uncover an element that resolved to a view but failed the tappability check by
+// centering it vertically in its nearest scroll ancestor's inset-adjusted viewport.
+// Returns YES if the scroll view was scrolled, NO if there is no scroll ancestor or the
+// element is already as centered as the content allows (in which case scrolling cannot
+// uncover it and the caller should fail with the original error).
++ (BOOL)KIF_revealPossiblyCoveredAccessibilityElement:(UIAccessibilityElement *)element view:(UIView *)view;
+{
+    UIScrollView *scrollView = nil;
+    for (UIView *superview = view.superview; superview; superview = superview.superview) {
+        if ([superview isKindOfClass:[UIScrollView class]]) {
+            scrollView = (UIScrollView *)superview;
+            break;
+        }
+    }
+    if (!scrollView) {
+        return NO;
+    }
+
+    CGRect elementFrame = [view.window convertRect:element.accessibilityFrame toView:scrollView];
+    UIEdgeInsets contentInset = scrollView.adjustedContentInset;
+    CGFloat visibleHeight = CGRectGetHeight(scrollView.bounds) - contentInset.top - contentInset.bottom;
+    if (visibleHeight <= 0) {
+        return NO;
+    }
+
+    CGFloat minOffsetY = -contentInset.top;
+    CGFloat maxOffsetY = MAX(minOffsetY, scrollView.contentSize.height + contentInset.bottom - CGRectGetHeight(scrollView.bounds));
+    CGFloat targetOffsetY = CGRectGetMidY(elementFrame) - contentInset.top - visibleHeight / 2;
+    targetOffsetY = MIN(MAX(targetOffsetY, minOffsetY), maxOffsetY);
+    if (fabs(targetOffsetY - scrollView.contentOffset.y) < 1) {
+        return NO;
+    }
+
+    BOOL animationEnabled = [KIFUITestActor testActorAnimationsEnabled];
+    [scrollView setContentOffset:CGPointMake(scrollView.contentOffset.x, targetOffsetY) animated:animationEnabled];
+    CFTimeInterval delay = animationEnabled ? 0.3 : 0.05;
+    KIFRunLoopRunInModeRelativeToAnimationSpeed(kCFRunLoopDefaultMode, delay, false);
+    return YES;
 }
 
 + (NSError *)errorForFailingPredicate:(NSPredicate*)failingPredicate disableScroll:(BOOL) scrollDisabled;


### PR DESCRIPTION
### Problem

A tap target can sit fully inside its scroll view's visible rect and still be un-tappable because a floating overlay (tab bar, toolbar) hovers over it. `+viewContainingAccessibilityElement:tappable:error:disableScroll:` never recovers from this:

1. The scroll pass only scrolls when the element is **outside** the visible rect (`CGRectContainsRect(visibleRect, elementFrame)`), so an in-bounds element is left exactly where it is.
2. The hit test then resolves to the overlay instead of the element, and the method fails with `is not tappable. It may be blocked by other views.`

Any list whose last rows extend under a floating bar hits this. In our suite this had already been worked around the only way possible: robot code that detects the failed hit test, walks up to the scroll ancestor, and sets `contentOffset` by hand.

### Change

When the tappability check fails and scrolling is allowed, center the element vertically in its nearest scroll ancestor's `adjustedContentInset`-adjusted viewport, then resolve once more with `disableScroll:YES`. Overlays that cause this failure are anchored to the viewport's edges, so centering moves the element out from under them.

### Safety

- The new path runs **only where the method currently returns an error** — no passing interaction changes behavior. The existing scroll pass, table-cell handling, and visible-rect fast path are untouched.
- Genuinely blocked elements still fail with the same error: if there is no scroll ancestor, the viewport has no height, or the element is already as centered as the content allows, scrolling can't uncover it and the method returns the original failure.
- One re-resolution, no loops; callers' outer wait loops retry as they do today.
- The scroll honors `testActorAnimationsEnabled` and uses the same settle delays (`KIFRunLoopRunInModeRelativeToAnimationSpeed`, 0.3s/0.05s) as the existing scroll pass.

### Testing

Validated against a production suite of several hundred KIF integration tests. Rows covered by a floating tab bar on phone-size devices now pass with their hand-rolled scroll workarounds deleted, and no previously-passing test changed behavior. (The same logic ran there first as a swizzle wrapping this method; this PR contributes it natively.)


