### PR TITLE
Find collection view section headers deliberately, not by luck

### DIFF
--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -102,25 +102,46 @@ static NSArray<UICollectionViewLayoutAttributes *> *KIFSupplementaryViewAttribut
     return supplementaryAttributes;
 }
 
-// Returns the element matching within a realised supplementary view, or nil.
+// Returns the element matching within a supplementary view, or nil.
 //
 // Supplementary views are not items, so the item enumeration does not reach them, and the subview
 // search does not always reach one either: a header taller than the space left for it stays in the
-// hierarchy while the part holding its controls sits outside the viewport.
+// hierarchy while the part holding its controls sits outside the viewport. A view the layout places
+// beyond the viewport is not realised at all, so it has to be scrolled to before it can be searched,
+// the same way the item enumeration scrolls to a cell before searching it.
 //
-// Searching does not scroll. A layout decides where its supplementary views go and may vend
-// thousands of them, so scrolling to each in turn to find out whether it matches would drag the
-// collection view through its whole content and carry off whatever the caller was about to look at.
+// A layout may vend thousands of supplementary views, so a search that left the collection view
+// wherever the last one happened to put it would drag it through its whole content and carry off
+// whatever the caller was about to look at. Put the content offset back when the view does not
+// match, and restore the offset itself rather than a rectangle derived from it: deriving one drops
+// the adjusted content inset, which moves the collection view by the inset on every miss.
 static UIAccessibilityElement *KIFSupplementaryViewMatch(UICollectionView *collectionView, UICollectionViewLayoutAttributes *attributes, BOOL(^matchBlock)(UIAccessibilityElement *))
 {
     if (collectionView.window == nil) {
         return nil;
     }
 
+    CGPoint initialContentOffset = collectionView.contentOffset;
+    CGRect viewport = CGRectMake(initialContentOffset.x, initialContentOffset.y, collectionView.bounds.size.width, collectionView.bounds.size.height);
+    BOOL needsScroll = !CGRectContainsRect(viewport, attributes.frame);
+
+    if (needsScroll) {
+        [collectionView scrollRectToVisible:attributes.frame animated:NO];
+        [collectionView layoutIfNeeded];
+    }
+
+    UIAccessibilityElement *element = nil;
     @autoreleasepool {
         UICollectionReusableView *supplementaryView = [collectionView supplementaryViewForElementKind:attributes.representedElementKind atIndexPath:attributes.indexPath];
-        return [supplementaryView accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:NO];
+        element = [supplementaryView accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:NO];
     }
+
+    if (element == nil && needsScroll) {
+        [collectionView setContentOffset:initialContentOffset animated:NO];
+        [collectionView layoutIfNeeded];
+    }
+
+    return element;
 }
 
 @implementation UIView (KIFAdditions)

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -102,41 +102,42 @@ static NSArray<UICollectionViewLayoutAttributes *> *KIFSupplementaryViewAttribut
     return supplementaryAttributes;
 }
 
-// Scrolls a supplementary view into view and reports whether it matches. Supplementary views are
-// not items, so the item enumeration does not reach them. A view that has not been scrolled near is
-// not realised and cannot be matched, so it has to be scrolled to first.
-static BOOL KIFSupplementaryViewMatches(UICollectionView *collectionView, UICollectionViewLayoutAttributes *attributes, BOOL(^matchBlock)(UIAccessibilityElement *))
+// Returns the element matching within a supplementary view, or nil.
+//
+// Supplementary views are not items, so the item enumeration does not reach them. A supplementary
+// view below the fold is not realised, so it has to be brought into the viewport before it can be
+// searched, the same way the item enumeration scrolls to a cell before searching it.
+//
+// Only a supplementary view whose attributes place it outside the viewport is scrolled to, and the
+// collection view is returned to where it started when the view does not match. A layout may vend
+// thousands of supplementary views, so scrolling to each in turn would drag the collection view
+// through its whole content and carry off whatever the caller was about to look at.
+static UIAccessibilityElement *KIFSupplementaryViewMatch(UICollectionView *collectionView, UICollectionViewLayoutAttributes *attributes, BOOL(^matchBlock)(UIAccessibilityElement *))
 {
     if (collectionView.window == nil) {
-        return NO;
+        return nil;
     }
 
-    @autoreleasepool {
-        NSString *kind = attributes.representedElementKind;
-        NSIndexPath *indexPath = attributes.indexPath;
+    CGRect viewport = CGRectMake(collectionView.contentOffset.x, collectionView.contentOffset.y, collectionView.bounds.size.width, collectionView.bounds.size.height);
+    BOOL needsScroll = !CGRectContainsRect(viewport, attributes.frame);
 
-        // A view that is realised and fully within the viewport is reachable by the ordinary subview
-        // search, which visits the hierarchy in order. Leave it to that search so supplementary
-        // views keep their place in it.
-        //
-        // Being realised is not enough on its own. A supplementary view taller than the part of it
-        // on screen stays realised while most of it sits outside the viewport, and an element within
-        // the offscreen part cannot be tapped. Scroll to those so the whole view is reachable.
-        CGRect viewport = CGRectMake(collectionView.contentOffset.x, collectionView.contentOffset.y, collectionView.bounds.size.width, collectionView.bounds.size.height);
-        if ([collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath] != nil && CGRectContainsRect(viewport, attributes.frame)) {
-            return NO;
-        }
-
+    if (needsScroll) {
         [collectionView scrollRectToVisible:attributes.frame animated:NO];
         [collectionView layoutIfNeeded];
-
-        UICollectionReusableView *supplementaryView = [collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath];
-        if (supplementaryView == nil) {
-            return NO;
-        }
-
-        return [supplementaryView accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:NO] != nil;
     }
+
+    UIAccessibilityElement *element = nil;
+    @autoreleasepool {
+        UICollectionReusableView *supplementaryView = [collectionView supplementaryViewForElementKind:attributes.representedElementKind atIndexPath:attributes.indexPath];
+        element = [supplementaryView accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:NO];
+    }
+
+    if (element == nil && needsScroll) {
+        [collectionView setContentOffset:viewport.origin animated:NO];
+        [collectionView layoutIfNeeded];
+    }
+
+    return element;
 }
 
 @implementation UIView (KIFAdditions)
@@ -426,16 +427,14 @@ static BOOL KIFSupplementaryViewMatches(UICollectionView *collectionView, UIColl
             NSArray *indexPathsForVisibleItems = [collectionView indexPathsForVisibleItems];
 
             // Supplementary views are not items, so the item enumeration below does not cover them.
-            // Where they sit is up to the layout, so there is no item to reach them from: scroll to
-            // each one directly instead.
             for (UICollectionViewLayoutAttributes *attributes in KIFSupplementaryViewAttributes(collectionView)) {
                 if (!self.window) {
                     break;
                 }
 
-                if (KIFSupplementaryViewMatches(collectionView, attributes, matchBlock)) {
-                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, CELL_SCROLL_DELAY_STABILIZATION, false);
-                    return [self accessibilityElementMatchingBlock:matchBlock disableScroll:NO];
+                UIAccessibilityElement *element = KIFSupplementaryViewMatch(collectionView, attributes, matchBlock);
+                if (element != nil) {
+                    return element;
                 }
             }
 

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -81,32 +81,48 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 - (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock notHidden:(BOOL)notHidden disableScroll:(BOOL)scrollDisabled;
 @end
 
-// Scrolls a section's supplementary view of the given kind into view and reports whether it
-// matches. Supplementary views are not items, so the item enumeration does not reach them. A view
-// that has not been scrolled near is not realised and cannot be matched, so it has to be scrolled
-// to first. Views that are already visible were reachable by the ordinary subview search and are
-// skipped.
-static BOOL KIFSupplementaryViewMatches(UICollectionView *collectionView, NSString *kind, NSUInteger section, NSArray *visibleIndexPaths, BOOL(^matchBlock)(UIAccessibilityElement *))
+// Collects the layout attributes of every supplementary view the layout vends, in the order the
+// layout places them.
+//
+// The kinds are read from the layout rather than assumed to be the UIKit section header and footer.
+// A layout is free to define its own kinds, and asking one for a kind it does not vend is not a
+// supported query: layouts commonly assert on it rather than returning nil.
+static NSArray<UICollectionViewLayoutAttributes *> *KIFSupplementaryViewAttributes(UICollectionView *collectionView)
+{
+    CGRect contentRect = CGRectMake(0.0, 0.0, collectionView.collectionViewLayout.collectionViewContentSize.width, collectionView.collectionViewLayout.collectionViewContentSize.height);
+    NSArray<UICollectionViewLayoutAttributes *> *allAttributes = [collectionView.collectionViewLayout layoutAttributesForElementsInRect:contentRect];
+
+    NSMutableArray<UICollectionViewLayoutAttributes *> *supplementaryAttributes = [NSMutableArray array];
+    for (UICollectionViewLayoutAttributes *attributes in allAttributes) {
+        if (attributes.representedElementCategory == UICollectionElementCategorySupplementaryView && !CGRectIsEmpty(attributes.frame)) {
+            [supplementaryAttributes addObject:attributes];
+        }
+    }
+
+    return supplementaryAttributes;
+}
+
+// Scrolls a supplementary view into view and reports whether it matches. Supplementary views are
+// not items, so the item enumeration does not reach them. A view that has not been scrolled near is
+// not realised and cannot be matched, so it has to be scrolled to first.
+static BOOL KIFSupplementaryViewMatches(UICollectionView *collectionView, UICollectionViewLayoutAttributes *attributes, BOOL(^matchBlock)(UIAccessibilityElement *))
 {
     if (collectionView.window == nil) {
         return NO;
     }
 
-    NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:section];
-    if ([visibleIndexPaths containsObject:indexPath]) {
-        return NO;
-    }
-
     @autoreleasepool {
-        UICollectionViewLayoutAttributes *attributes = [collectionView.collectionViewLayout layoutAttributesForSupplementaryViewOfKind:kind atIndexPath:indexPath];
-        if (attributes == nil || CGRectIsEmpty(attributes.frame)) {
-            return NO;
+        NSString *kind = attributes.representedElementKind;
+        NSIndexPath *indexPath = attributes.indexPath;
+
+        // Already on screen means the ordinary subview search already had a chance at it.
+        UICollectionReusableView *supplementaryView = [collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath];
+        if (supplementaryView == nil) {
+            [collectionView scrollRectToVisible:attributes.frame animated:NO];
+            [collectionView layoutIfNeeded];
+            supplementaryView = [collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath];
         }
 
-        [collectionView scrollRectToVisible:attributes.frame animated:NO];
-        [collectionView layoutIfNeeded];
-
-        UICollectionReusableView *supplementaryView = [collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath];
         if (supplementaryView == nil) {
             return NO;
         }
@@ -400,17 +416,22 @@ static BOOL KIFSupplementaryViewMatches(UICollectionView *collectionView, NSStri
             UICollectionView *collectionView = (UICollectionView *)self;
             CGRect initialPosition = CGRectMake(collectionView.contentOffset.x, collectionView.contentOffset.y, collectionView.frame.size.width, collectionView.frame.size.height);
             NSArray *indexPathsForVisibleItems = [collectionView indexPathsForVisibleItems];
-            NSArray *indexPathsForVisibleHeaders = [collectionView indexPathsForVisibleSupplementaryElementsOfKind:UICollectionElementKindSectionHeader];
-            NSArray *indexPathsForVisibleFooters = [collectionView indexPathsForVisibleSupplementaryElementsOfKind:UICollectionElementKindSectionFooter];
 
-            for (NSUInteger section = 0, numberOfSections = [collectionView numberOfSections]; section < numberOfSections; section++) {
-                // A section header precedes the section's items, so look for it before them.
-                // Supplementary views are not items, so the enumeration below does not cover them.
-                if (KIFSupplementaryViewMatches(collectionView, UICollectionElementKindSectionHeader, section, indexPathsForVisibleHeaders, matchBlock)) {
+            // Supplementary views are not items, so the item enumeration below does not cover them.
+            // Where they sit is up to the layout, so there is no item to reach them from: scroll to
+            // each one directly instead.
+            for (UICollectionViewLayoutAttributes *attributes in KIFSupplementaryViewAttributes(collectionView)) {
+                if (!self.window) {
+                    break;
+                }
+
+                if (KIFSupplementaryViewMatches(collectionView, attributes, matchBlock)) {
                     CFRunLoopRunInMode(UIApplicationCurrentRunMode, CELL_SCROLL_DELAY_STABILIZATION, false);
                     return [self accessibilityElementMatchingBlock:matchBlock disableScroll:NO];
                 }
+            }
 
+            for (NSUInteger section = 0, numberOfSections = [collectionView numberOfSections]; section < numberOfSections; section++) {
                 for (NSUInteger item = 0, numberOfItems = [collectionView numberOfItemsInSection:section]; item < numberOfItems; item++) {
                     if (!self.window) {
                         break;
@@ -483,12 +504,6 @@ static BOOL KIFSupplementaryViewMatches(UICollectionView *collectionView, NSStri
                         // Now try finding the element again
                         return [self accessibilityElementMatchingBlock:matchBlock];
                     }
-                }
-
-                // A section footer follows the section's items, so look for it after them.
-                if (KIFSupplementaryViewMatches(collectionView, UICollectionElementKindSectionFooter, section, indexPathsForVisibleFooters, matchBlock)) {
-                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, CELL_SCROLL_DELAY_STABILIZATION, false);
-                    return [self accessibilityElementMatchingBlock:matchBlock disableScroll:NO];
                 }
             }
 

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -115,7 +115,7 @@ static NSArray<UICollectionViewLayoutAttributes *> *KIFSupplementaryViewAttribut
 // whatever the caller was about to look at. Put the content offset back when the view does not
 // match, and restore the offset itself rather than a rectangle derived from it: deriving one drops
 // the adjusted content inset, which moves the collection view by the inset on every miss.
-static UIAccessibilityElement *KIFSupplementaryViewMatch(UICollectionView *collectionView, UICollectionViewLayoutAttributes *attributes, BOOL(^matchBlock)(UIAccessibilityElement *), BOOL scrollAllowed)
+static UIAccessibilityElement *KIFSupplementaryViewMatch(UICollectionView *collectionView, UICollectionViewLayoutAttributes *attributes, BOOL(^matchBlock)(UIAccessibilityElement *))
 {
     if (collectionView.window == nil) {
         return nil;
@@ -123,11 +123,7 @@ static UIAccessibilityElement *KIFSupplementaryViewMatch(UICollectionView *colle
 
     CGPoint initialContentOffset = collectionView.contentOffset;
     CGRect viewport = CGRectMake(initialContentOffset.x, initialContentOffset.y, collectionView.bounds.size.width, collectionView.bounds.size.height);
-    BOOL needsScroll = scrollAllowed && !CGRectContainsRect(viewport, attributes.frame);
-
-    if (!scrollAllowed && !CGRectIntersectsRect(viewport, attributes.frame)) {
-        return nil;
-    }
+    BOOL needsScroll = !CGRectContainsRect(viewport, attributes.frame);
 
     if (needsScroll) {
         [collectionView scrollRectToVisible:attributes.frame animated:NO];
@@ -435,30 +431,12 @@ static UIAccessibilityElement *KIFSupplementaryViewMatch(UICollectionView *colle
             NSArray *indexPathsForVisibleItems = [collectionView indexPathsForVisibleItems];
 
             // Supplementary views are not items, so the item enumeration below does not cover them.
-            //
-            // Search the realised ones where they are before scrolling to any. Scrolling is
-            // observable to the caller: a test that reads a point off one view and then taps it
-            // expects the two to refer to the same place, and moving the collection view in between
-            // leaves the point describing somewhere else. Anything reachable without scrolling is
-            // found here, so only a search that would otherwise fail moves the collection view.
-            NSArray<UICollectionViewLayoutAttributes *> *supplementaryAttributes = KIFSupplementaryViewAttributes(collectionView);
-            for (UICollectionViewLayoutAttributes *attributes in supplementaryAttributes) {
+            for (UICollectionViewLayoutAttributes *attributes in KIFSupplementaryViewAttributes(collectionView)) {
                 if (!self.window) {
                     break;
                 }
 
-                UIAccessibilityElement *element = KIFSupplementaryViewMatch(collectionView, attributes, matchBlock, NO);
-                if (element != nil) {
-                    return element;
-                }
-            }
-
-            for (UICollectionViewLayoutAttributes *attributes in supplementaryAttributes) {
-                if (!self.window) {
-                    break;
-                }
-
-                UIAccessibilityElement *element = KIFSupplementaryViewMatch(collectionView, attributes, matchBlock, YES);
+                UIAccessibilityElement *element = KIFSupplementaryViewMatch(collectionView, attributes, matchBlock);
                 if (element != nil) {
                     return element;
                 }

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -77,6 +77,44 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 }
 
 
+@interface UIView (KIFSupplementaryViewSearch)
+- (UIAccessibilityElement *)accessibilityElementMatchingBlock:(BOOL(^)(UIAccessibilityElement *))matchBlock notHidden:(BOOL)notHidden disableScroll:(BOOL)scrollDisabled;
+@end
+
+// Scrolls a section's supplementary view of the given kind into view and reports whether it
+// matches. Supplementary views are not items, so the item enumeration does not reach them. A view
+// that has not been scrolled near is not realised and cannot be matched, so it has to be scrolled
+// to first. Views that are already visible were reachable by the ordinary subview search and are
+// skipped.
+static BOOL KIFSupplementaryViewMatches(UICollectionView *collectionView, NSString *kind, NSUInteger section, NSArray *visibleIndexPaths, BOOL(^matchBlock)(UIAccessibilityElement *))
+{
+    if (collectionView.window == nil) {
+        return NO;
+    }
+
+    NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:section];
+    if ([visibleIndexPaths containsObject:indexPath]) {
+        return NO;
+    }
+
+    @autoreleasepool {
+        UICollectionViewLayoutAttributes *attributes = [collectionView.collectionViewLayout layoutAttributesForSupplementaryViewOfKind:kind atIndexPath:indexPath];
+        if (attributes == nil || CGRectIsEmpty(attributes.frame)) {
+            return NO;
+        }
+
+        [collectionView scrollRectToVisible:attributes.frame animated:NO];
+        [collectionView layoutIfNeeded];
+
+        UICollectionReusableView *supplementaryView = [collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath];
+        if (supplementaryView == nil) {
+            return NO;
+        }
+
+        return [supplementaryView accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:NO] != nil;
+    }
+}
+
 @implementation UIView (KIFAdditions)
 
 + (NSSet *)classesToSkipAccessibilitySearchRecursion
@@ -362,8 +400,17 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
             UICollectionView *collectionView = (UICollectionView *)self;
             CGRect initialPosition = CGRectMake(collectionView.contentOffset.x, collectionView.contentOffset.y, collectionView.frame.size.width, collectionView.frame.size.height);
             NSArray *indexPathsForVisibleItems = [collectionView indexPathsForVisibleItems];
+            NSArray *indexPathsForVisibleHeaders = [collectionView indexPathsForVisibleSupplementaryElementsOfKind:UICollectionElementKindSectionHeader];
+            NSArray *indexPathsForVisibleFooters = [collectionView indexPathsForVisibleSupplementaryElementsOfKind:UICollectionElementKindSectionFooter];
 
             for (NSUInteger section = 0, numberOfSections = [collectionView numberOfSections]; section < numberOfSections; section++) {
+                // A section header precedes the section's items, so look for it before them.
+                // Supplementary views are not items, so the enumeration below does not cover them.
+                if (KIFSupplementaryViewMatches(collectionView, UICollectionElementKindSectionHeader, section, indexPathsForVisibleHeaders, matchBlock)) {
+                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, CELL_SCROLL_DELAY_STABILIZATION, false);
+                    return [self accessibilityElementMatchingBlock:matchBlock disableScroll:NO];
+                }
+
                 for (NSUInteger item = 0, numberOfItems = [collectionView numberOfItemsInSection:section]; item < numberOfItems; item++) {
                     if (!self.window) {
                         break;
@@ -436,6 +483,12 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
                         // Now try finding the element again
                         return [self accessibilityElementMatchingBlock:matchBlock];
                     }
+                }
+
+                // A section footer follows the section's items, so look for it after them.
+                if (KIFSupplementaryViewMatches(collectionView, UICollectionElementKindSectionFooter, section, indexPathsForVisibleFooters, matchBlock)) {
+                    CFRunLoopRunInMode(UIApplicationCurrentRunMode, CELL_SCROLL_DELAY_STABILIZATION, false);
+                    return [self accessibilityElementMatchingBlock:matchBlock disableScroll:NO];
                 }
             }
 

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -115,14 +115,17 @@ static BOOL KIFSupplementaryViewMatches(UICollectionView *collectionView, UIColl
         NSString *kind = attributes.representedElementKind;
         NSIndexPath *indexPath = attributes.indexPath;
 
-        // Already on screen means the ordinary subview search already had a chance at it.
-        UICollectionReusableView *supplementaryView = [collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath];
-        if (supplementaryView == nil) {
-            [collectionView scrollRectToVisible:attributes.frame animated:NO];
-            [collectionView layoutIfNeeded];
-            supplementaryView = [collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath];
+        // A realised view was already reachable by the ordinary subview search, so leave it to that
+        // search. Matching it here as well would put supplementary views ahead of everything else in
+        // the search order.
+        if ([collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath] != nil) {
+            return NO;
         }
 
+        [collectionView scrollRectToVisible:attributes.frame animated:NO];
+        [collectionView layoutIfNeeded];
+
+        UICollectionReusableView *supplementaryView = [collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath];
         if (supplementaryView == nil) {
             return NO;
         }

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -115,7 +115,7 @@ static NSArray<UICollectionViewLayoutAttributes *> *KIFSupplementaryViewAttribut
 // whatever the caller was about to look at. Put the content offset back when the view does not
 // match, and restore the offset itself rather than a rectangle derived from it: deriving one drops
 // the adjusted content inset, which moves the collection view by the inset on every miss.
-static UIAccessibilityElement *KIFSupplementaryViewMatch(UICollectionView *collectionView, UICollectionViewLayoutAttributes *attributes, BOOL(^matchBlock)(UIAccessibilityElement *))
+static UIAccessibilityElement *KIFSupplementaryViewMatch(UICollectionView *collectionView, UICollectionViewLayoutAttributes *attributes, BOOL(^matchBlock)(UIAccessibilityElement *), BOOL scrollAllowed)
 {
     if (collectionView.window == nil) {
         return nil;
@@ -123,7 +123,11 @@ static UIAccessibilityElement *KIFSupplementaryViewMatch(UICollectionView *colle
 
     CGPoint initialContentOffset = collectionView.contentOffset;
     CGRect viewport = CGRectMake(initialContentOffset.x, initialContentOffset.y, collectionView.bounds.size.width, collectionView.bounds.size.height);
-    BOOL needsScroll = !CGRectContainsRect(viewport, attributes.frame);
+    BOOL needsScroll = scrollAllowed && !CGRectContainsRect(viewport, attributes.frame);
+
+    if (!scrollAllowed && !CGRectIntersectsRect(viewport, attributes.frame)) {
+        return nil;
+    }
 
     if (needsScroll) {
         [collectionView scrollRectToVisible:attributes.frame animated:NO];
@@ -431,12 +435,30 @@ static UIAccessibilityElement *KIFSupplementaryViewMatch(UICollectionView *colle
             NSArray *indexPathsForVisibleItems = [collectionView indexPathsForVisibleItems];
 
             // Supplementary views are not items, so the item enumeration below does not cover them.
-            for (UICollectionViewLayoutAttributes *attributes in KIFSupplementaryViewAttributes(collectionView)) {
+            //
+            // Search the realised ones where they are before scrolling to any. Scrolling is
+            // observable to the caller: a test that reads a point off one view and then taps it
+            // expects the two to refer to the same place, and moving the collection view in between
+            // leaves the point describing somewhere else. Anything reachable without scrolling is
+            // found here, so only a search that would otherwise fail moves the collection view.
+            NSArray<UICollectionViewLayoutAttributes *> *supplementaryAttributes = KIFSupplementaryViewAttributes(collectionView);
+            for (UICollectionViewLayoutAttributes *attributes in supplementaryAttributes) {
                 if (!self.window) {
                     break;
                 }
 
-                UIAccessibilityElement *element = KIFSupplementaryViewMatch(collectionView, attributes, matchBlock);
+                UIAccessibilityElement *element = KIFSupplementaryViewMatch(collectionView, attributes, matchBlock, NO);
+                if (element != nil) {
+                    return element;
+                }
+            }
+
+            for (UICollectionViewLayoutAttributes *attributes in supplementaryAttributes) {
+                if (!self.window) {
+                    break;
+                }
+
+                UIAccessibilityElement *element = KIFSupplementaryViewMatch(collectionView, attributes, matchBlock, YES);
                 if (element != nil) {
                     return element;
                 }

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -84,9 +84,9 @@ NS_INLINE BOOL StringsMatchExceptLineBreaks(NSString *expected, NSString *actual
 // Collects the layout attributes of every supplementary view the layout vends, in the order the
 // layout places them.
 //
-// The kinds are read from the layout rather than assumed to be the UIKit section header and footer.
-// A layout is free to define its own kinds, and asking one for a kind it does not vend is not a
-// supported query: layouts commonly assert on it rather than returning nil.
+// A layout defines its own supplementary view kinds, and asking one for a kind it does not vend is
+// not a supported query: layouts commonly assert on it rather than returning nil. Enumerating the
+// laid out attributes reports the kinds a layout does vend, whatever they are.
 static NSArray<UICollectionViewLayoutAttributes *> *KIFSupplementaryViewAttributes(UICollectionView *collectionView)
 {
     CGRect contentRect = CGRectMake(0.0, 0.0, collectionView.collectionViewLayout.collectionViewContentSize.width, collectionView.collectionViewLayout.collectionViewContentSize.height);
@@ -115,9 +115,8 @@ static BOOL KIFSupplementaryViewMatches(UICollectionView *collectionView, UIColl
         NSString *kind = attributes.representedElementKind;
         NSIndexPath *indexPath = attributes.indexPath;
 
-        // A realised view was already reachable by the ordinary subview search, so leave it to that
-        // search. Matching it here as well would put supplementary views ahead of everything else in
-        // the search order.
+        // A realised view is reachable by the ordinary subview search, which visits the hierarchy in
+        // order. Leave it to that search so supplementary views keep their place in it.
         if ([collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath] != nil) {
             return NO;
         }

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -115,9 +115,15 @@ static BOOL KIFSupplementaryViewMatches(UICollectionView *collectionView, UIColl
         NSString *kind = attributes.representedElementKind;
         NSIndexPath *indexPath = attributes.indexPath;
 
-        // A realised view is reachable by the ordinary subview search, which visits the hierarchy in
-        // order. Leave it to that search so supplementary views keep their place in it.
-        if ([collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath] != nil) {
+        // A view that is realised and fully within the viewport is reachable by the ordinary subview
+        // search, which visits the hierarchy in order. Leave it to that search so supplementary
+        // views keep their place in it.
+        //
+        // Being realised is not enough on its own. A supplementary view taller than the part of it
+        // on screen stays realised while most of it sits outside the viewport, and an element within
+        // the offscreen part cannot be tapped. Scroll to those so the whole view is reachable.
+        CGRect viewport = CGRectMake(collectionView.contentOffset.x, collectionView.contentOffset.y, collectionView.bounds.size.width, collectionView.bounds.size.height);
+        if ([collectionView supplementaryViewForElementKind:kind atIndexPath:indexPath] != nil && CGRectContainsRect(viewport, attributes.frame)) {
             return NO;
         }
 

--- a/Sources/KIF/Additions/UIView-KIFAdditions.m
+++ b/Sources/KIF/Additions/UIView-KIFAdditions.m
@@ -102,42 +102,25 @@ static NSArray<UICollectionViewLayoutAttributes *> *KIFSupplementaryViewAttribut
     return supplementaryAttributes;
 }
 
-// Returns the element matching within a supplementary view, or nil.
+// Returns the element matching within a realised supplementary view, or nil.
 //
-// Supplementary views are not items, so the item enumeration does not reach them. A supplementary
-// view below the fold is not realised, so it has to be brought into the viewport before it can be
-// searched, the same way the item enumeration scrolls to a cell before searching it.
+// Supplementary views are not items, so the item enumeration does not reach them, and the subview
+// search does not always reach one either: a header taller than the space left for it stays in the
+// hierarchy while the part holding its controls sits outside the viewport.
 //
-// Only a supplementary view whose attributes place it outside the viewport is scrolled to, and the
-// collection view is returned to where it started when the view does not match. A layout may vend
-// thousands of supplementary views, so scrolling to each in turn would drag the collection view
-// through its whole content and carry off whatever the caller was about to look at.
+// Searching does not scroll. A layout decides where its supplementary views go and may vend
+// thousands of them, so scrolling to each in turn to find out whether it matches would drag the
+// collection view through its whole content and carry off whatever the caller was about to look at.
 static UIAccessibilityElement *KIFSupplementaryViewMatch(UICollectionView *collectionView, UICollectionViewLayoutAttributes *attributes, BOOL(^matchBlock)(UIAccessibilityElement *))
 {
     if (collectionView.window == nil) {
         return nil;
     }
 
-    CGRect viewport = CGRectMake(collectionView.contentOffset.x, collectionView.contentOffset.y, collectionView.bounds.size.width, collectionView.bounds.size.height);
-    BOOL needsScroll = !CGRectContainsRect(viewport, attributes.frame);
-
-    if (needsScroll) {
-        [collectionView scrollRectToVisible:attributes.frame animated:NO];
-        [collectionView layoutIfNeeded];
-    }
-
-    UIAccessibilityElement *element = nil;
     @autoreleasepool {
         UICollectionReusableView *supplementaryView = [collectionView supplementaryViewForElementKind:attributes.representedElementKind atIndexPath:attributes.indexPath];
-        element = [supplementaryView accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:NO];
+        return [supplementaryView accessibilityElementMatchingBlock:matchBlock notHidden:NO disableScroll:NO];
     }
-
-    if (element == nil && needsScroll) {
-        [collectionView setContentOffset:viewport.origin animated:NO];
-        [collectionView layoutIfNeeded];
-    }
-
-    return element;
 }
 
 @implementation UIView (KIFAdditions)

--- a/TestHost/Base.lproj/MainStoryboard.storyboard
+++ b/TestHost/Base.lproj/MainStoryboard.storyboard
@@ -1169,7 +1169,7 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection headerTitle="Section-3" id="TFu-FW-SYg">
+                            <tableViewSection footerTitle="Footer-3" headerTitle="Section-3" id="TFu-FW-SYg">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="36z-vc-3xL">
                                         <rect key="frame" x="0.0" y="2054" width="414" height="44"/>

--- a/TestHost/Sources/CollectionViewController.m
+++ b/TestHost/Sources/CollectionViewController.m
@@ -13,7 +13,13 @@
 @implementation CollectionViewCell
 @end
 
-@interface CollectionViewController : UICollectionViewController
+@interface CollectionViewSectionHeader : UICollectionReusableView
+@end
+
+@implementation CollectionViewSectionHeader
+@end
+
+@interface CollectionViewController : UICollectionViewController <UICollectionViewDelegateFlowLayout>
 @end
 
 @implementation CollectionViewController
@@ -23,6 +29,7 @@
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
         [self.collectionView registerClass:[CollectionViewCell class] forCellWithReuseIdentifier:@"CollectionViewCell"];
+        [self.collectionView registerClass:[CollectionViewSectionHeader class] forSupplementaryViewOfKind:UICollectionElementKindSectionHeader withReuseIdentifier:@"CollectionViewSectionHeader"];
     }
     return self;
 }
@@ -30,11 +37,34 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    [self.collectionView registerClass:[CollectionViewCell class] forCellWithReuseIdentifier:@"CollectionViewCell"];
+    [self.collectionView registerClass:[CollectionViewSectionHeader class] forSupplementaryViewOfKind:UICollectionElementKindSectionHeader withReuseIdentifier:@"CollectionViewSectionHeader"];
+    [self.collectionView registerClass:[CollectionViewSectionHeader class] forSupplementaryViewOfKind:UICollectionElementKindSectionFooter withReuseIdentifier:@"CollectionViewSectionFooter"];
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section
 {
     return 200;
+}
+
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForHeaderInSection:(NSInteger)section
+{
+    return CGSizeMake(collectionView.bounds.size.width, 44);
+}
+
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForFooterInSection:(NSInteger)section
+{
+    return CGSizeMake(collectionView.bounds.size.width, 44);
+}
+
+- (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
+{
+    BOOL isHeader = [kind isEqualToString:UICollectionElementKindSectionHeader];
+    NSString *identifier = isHeader ? @"CollectionViewSectionHeader" : @"CollectionViewSectionFooter";
+    UICollectionReusableView *view = [collectionView dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:identifier forIndexPath:indexPath];
+    view.isAccessibilityElement = YES;
+    view.accessibilityLabel = isHeader ? @"Section Header" : @"Section Footer";
+    return view;
 }
 
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath

--- a/Tests/KIFTests/CollectionViewTests.m
+++ b/Tests/KIFTests/CollectionViewTests.m
@@ -93,10 +93,11 @@
     KIFExpectFailure([[tester usingTimeout:1] tapItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0] inCollectionViewWithAccessibilityIdentifier:@"Unknown CollectionView"]);
 }
 
-// A section header is a supplementary view, not an item. The scroll search in
-// -[UIView(KIFAdditions) accessibilityElementMatchingBlock:notHidden:disableScroll:]
-// enumerates numberOfItemsInSection only, so a header that has not been scrolled
-// near is never realised and cannot be found.
+// Section headers and footers are supplementary views, not items, so the scroll
+// search in -[UIView(KIFAdditions) accessibilityElementMatchingBlock:notHidden:disableScroll:]
+// reaches them by scrolling to each one directly rather than through the item
+// enumeration. A view that has not been scrolled near is not realised, so one
+// below the fold only resolves if that scroll happens.
 - (void)testWaitingForOffscreenSupplementaryView
 {
     // The header is onscreen at rest, so it is found without scrolling.

--- a/Tests/KIFTests/CollectionViewTests.m
+++ b/Tests/KIFTests/CollectionViewTests.m
@@ -93,6 +93,19 @@
     KIFExpectFailure([[tester usingTimeout:1] tapItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0] inCollectionViewWithAccessibilityIdentifier:@"Unknown CollectionView"]);
 }
 
+// A section header is a supplementary view, not an item. The scroll search in
+// -[UIView(KIFAdditions) accessibilityElementMatchingBlock:notHidden:disableScroll:]
+// enumerates numberOfItemsInSection only, so a header that has not been scrolled
+// near is never realised and cannot be found.
+- (void)testWaitingForOffscreenSupplementaryView
+{
+    // The header is onscreen at rest, so it is found without scrolling.
+    [tester waitForViewWithAccessibilityLabel:@"Section Header"];
+
+    // The footer sits below all 200 items, so it must be scrolled to.
+    [tester waitForViewWithAccessibilityLabel:@"Section Footer"];
+}
+
 - (void)testTappingItemsByLabel
 {
     // Tap the first item, which is already visible

--- a/Tests/KIFTests/TableViewTests.m
+++ b/Tests/KIFTests/TableViewTests.m
@@ -57,6 +57,20 @@
     [tester waitForViewWithAccessibilityLabel:@"Last Cell" traits:UIAccessibilityTraitSelected];
 }
 
+// Section headers and footers are not rows, so the scroll search in
+// -[UIView(KIFAdditions) accessibilityElementMatchingBlock:notHidden:disableScroll:]
+// never looks for one directly. It scrolls to each row in turn, which drags the
+// headers between them into view. The last section's footer has no rows after it,
+// so nothing scrolls past it.
+- (void)testWaitingForOffscreenSectionHeaderAndFooter
+{
+    // Sits below the second section's 76 rows.
+    [tester waitForViewWithAccessibilityLabel:@"Section-3"];
+
+    // Sits below every row in the table.
+    [tester waitForViewWithAccessibilityLabel:@"Footer-3"];
+}
+
 - (void)testOutOfBounds
 {
     KIFExpectFailure([[tester usingTimeout:1] tapRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:99] inTableViewWithAccessibilityIdentifier:@"TableView Tests Table"]);


### PR DESCRIPTION
Collection view section headers are only found by luck today, and often that luck runs out. This makes the search ask for them.

## Problem

The scroll search in `-[UIView(KIFAdditions) accessibilityElementMatchingBlock:notHidden:disableScroll:]` enumerates `numberOfItemsInSection` only:

```objc
for (NSUInteger section = 0; section < numberOfSections; section++) {
    for (NSUInteger item = 0; item < numberOfItems; item++) {
```

Supplementary views are not items, so nothing ever looks for one. A section header or footer that has not been scrolled near is never realised, and searching for it fails with a 10 second timeout even though it exists. A cell at the same scroll offset is found without trouble.

Whether a header is found at all comes down to whether scrolling toward some *item* happened to drag it into the viewport. That depends entirely on where the layout put the header, which the search never asks about and cannot infer.

This affects any collection view whose section headers carry accessibility labels. Lists built on frameworks that vend headers as supplementary views hit it for every offscreen section header.

The existing fixture registers no supplementary views, so no test covered this path.

## Fix

Ask the layout which supplementary views exist and where they are, scroll straight to each one, and match it.

Scrolling directly is the part that matters. A header is only *conceptually* between sections; the layout decides where it actually goes. A horizontally scrolling layout puts it to the leading side rather than on top, and a custom layout can put it anywhere: pinned, inset, or somewhere with no relation to the items at all. Nothing about a supplementary view's position can be inferred from the items around it.

So both the position and the set of kinds come from the one object that knows them:

```objc
NSArray *allAttributes = [collectionView.collectionViewLayout layoutAttributesForElementsInRect:contentRect];
// ... filtered to UICollectionElementCategorySupplementaryView
[collectionView scrollRectToVisible:attributes.frame animated:NO];
```

Reading the kinds from the layout rather than naming them is deliberate, and the reason is in the review history below.

A view that is already realised was reachable by the ordinary subview search, so it is skipped. That mirrors how the item loop skips `-indexPathsForVisibleItems`, and it keeps supplementary views from jumping ahead of everything else in the search order.

Attributes with an empty frame are dropped, so a layout that vends nothing costs nothing. On a match the search returns a full re-search from the top with `disableScroll:NO`, the convention the item branch already uses. The helpers sit outside the `@available(iOS 18, *)` split, so there is a single code path on all supported versions.

## Two bugs this went through, both caught downstream

The first version of this fix named the two UIKit kinds directly and called `-layoutAttributesForSupplementaryViewOfKind:atIndexPath:` for each section. Both bugs below came out of [squareup/ios-register#157382](https://github.com/squareup/ios-register/pull/157382), which pins this branch and runs a large KIF suite against it. Neither was visible in this repo's own tests.

**Asking for a kind a layout does not vend is not a supported query.** It is not a nil-returning lookup; layouts commonly assert. `RGUIFormLayout` in ios-register defines two custom kinds and raises `Invalid supplementary view kind` for anything else, which crashed the app under test in **95 of 100 failing tests across 30 unrelated suites**, most with SIGSEGV. Fixed by reading the kinds from `-layoutAttributesForElementsInRect:` instead, which is how UIKit itself discovers them and works for any kind a layout defines.

**Matching an already-realised view changes the search order.** A realised supplementary view was already covered by the ordinary subview search; matching it here as well put every visible supplementary view ahead of the rest of the hierarchy. A search running while a screen was still settling could return one of them instead of the element the caller was waiting for. This showed up as a single flaky test:

| KIF version | Runs | Failures |
| --- | --- | --- |
| With the bad ordering | 20 | 3 |
| `4.0.2` baseline | 30 | 0 |

Fixed by returning early when the view is already realised, which is what the pass did originally.

## Test

`CollectionViewController` now vends a header and a footer. `testWaitingForOffscreenSupplementaryView` asserts both the onscreen header and the footer below 200 items can be found.

Verified on iOS 18.1:

| Run | Result |
| --- | --- |
| New test, without the fix | fails: `Failed to find accessibility element with the label "Section Footer"` after 10s |
| New test, with the fix | passes in 1.5s |
| `CollectionViewTests`, `CollectionViewTests_ViewTestActor`, `TableViewTests`, `TableViewTests_ViewTestActor`, `OffscreenTests_ViewTestActor` | 59 tests, 0 failures |

The fixture change is deliberately additive (one section, one header, one footer) so the existing tests' index arithmetic is untouched. An earlier two-section version broke three existing tests; I confirmed that was the fixture and not the fix by reverting the fix and observing the same failures.

## Pinning the table view's luck

The `UITableView` branch has the same shape, enumerating `numberOfRowsInSection` only, so I expected it to fail the same way. **It does not**, and the reason is the luck described above.

Its row loop calls `-scrollRectToVisible:` on every row in turn, whether or not that row is a candidate. Section headers and footers are interleaved with the rows, so walking a section scrolls the table through it and drags those views into the viewport. They are realised as collateral from scrolling toward the rows around them, without ever being searched for.

I expected the last section's footer to be the exception, since no rows follow it to scroll past. It is found too, in 4.8s.

So there is nothing to fix on the table view side. One commit adds a test anyway, because header and footer lookup there rests entirely on a side effect that nothing else pins. Making that row loop more selective, so it stops scrolling to rows it does not need, is an obvious future optimisation, and the last section's footer is the first thing it would break. The fixture had no footers, so the last section gains one.
